### PR TITLE
[IIIF-532] Use correct repo name for fester on dockerhub

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ jobs:
       deploy:
         - provider: script
           script:
-            - FESTER_TAG=latest .travis/trigger.sh uclalibrary/docker-fester
+            - FESTER_TAG=latest .travis/trigger.sh uclalibrary/fester
           on:
             branch: master
       if: (NOT type IN (pull_request)) AND (branch = master)
@@ -36,7 +36,7 @@ jobs:
       deploy:
         - provider: script
           script:
-            - FESTER_TAG=$TRAVIS_TAG .travis/trigger.sh uclalibrary/docker-fester
+            - FESTER_TAG=$TRAVIS_TAG .travis/trigger.sh uclalibrary/fester
           on:
             tags: true
       if: (NOT type IN (pull_request)) AND (branch =~ /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*)?(\+[0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*)?$/)


### PR DESCRIPTION
Correct typo for dockerhub repo name for fester (uclalibrary/fester not uclalibrary/docker-fester)