### PR TITLE
[IIIF-507] Borrow the S3BucketVerticle from Bucketeer, adjust for Fester

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
     <netty.epoll.version>4.1.37.Final</netty.epoll.version>
     <vertx.plugin.version>1.0.18</vertx.plugin.version>
     <codacy.plugin.version>1.0.2</codacy.plugin.version>
-    <vertx.super.s3.version>1.1.0</vertx.super.s3.version>
+    <vertx.super.s3.version>1.2.1</vertx.super.s3.version>
     <jcip.annotations.version>1.0-1</jcip.annotations.version>
     <maven.failsafe.plugin.version>2.18.1</maven.failsafe.plugin.version>
 

--- a/src/main/java/edu/ucla/library/iiif/fester/Config.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/Config.java
@@ -20,6 +20,9 @@ public final class Config {
 
     public static final String S3_BUCKET = "fester.s3.bucket";
 
+    // Configuration options for the S3 upload verticle(s)
+    public static final String S3_MAX_REQUESTS = "s3.max.requests";
+
     /**
      * Private constructor for the Constants class.
      */

--- a/src/main/java/edu/ucla/library/iiif/fester/Constants.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/Constants.java
@@ -57,6 +57,11 @@ public final class Constants {
     public static final String SLASH = "/";
 
     /**
+     * Just a empty string, useful
+     */
+    public static final String EMPTY = "";
+
+    /**
      * The file extension for JSON files
      */
     public static final String JSON_EXT = ".json";
@@ -85,6 +90,26 @@ public final class Constants {
      * The path that distinguishes a work manifest at which work manifests.
      */
     public static final String MANIFEST = "manifest";
+
+    /**
+     * The record of completed S3 uploads.
+     */
+    public static final String RESULTS_MAP = "s3-uploads";
+
+    /**
+     * A name for wait counters.
+     */
+    public static final String WAIT_COUNT = "wait-count";
+
+    /**
+     * A name for the S3 request counter.
+     */
+    public static final String S3_REQUEST_COUNT = "s3-request-count";
+
+    /**
+     * Manifest content, stored as a JSON object
+     */
+    public static final String MANIFEST_CONTENT = "manifest-content";
 
     /**
      * Private constructor for Constants class.

--- a/src/main/java/edu/ucla/library/iiif/fester/Op.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/Op.java
@@ -17,6 +17,8 @@ public final class Op {
 
     public static final String SUCCESS = "success";
 
+    public static final String RETRY = "retry";
+
     public static final String FAILURE = "failure";
 
     private Op() {

--- a/src/main/java/edu/ucla/library/iiif/fester/verticles/MainVerticle.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/verticles/MainVerticle.java
@@ -123,6 +123,7 @@ public class MainVerticle extends AbstractVerticle {
 
         // Start up any necessary Fester verticles
         futures.add(deployVerticle(ManifestVerticle.class.getName(), options, Future.future()));
+        futures.add(deployVerticle(S3BucketVerticle.class.getName(), options, Future.future()));
 
         // Confirm all our verticles were successfully deployed
         CompositeFuture.all(futures).setHandler(handler -> {

--- a/src/main/java/edu/ucla/library/iiif/fester/verticles/S3BucketVerticle.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/verticles/S3BucketVerticle.java
@@ -1,0 +1,293 @@
+
+package edu.ucla.library.iiif.fester.verticles;
+
+import static edu.ucla.library.iiif.fester.Constants.EMPTY;
+
+import com.amazonaws.regions.RegionUtils;
+
+import info.freelibrary.util.Logger;
+import info.freelibrary.util.LoggerFactory;
+import info.freelibrary.vertx.s3.S3Client;
+import info.freelibrary.vertx.s3.UserMetadata;
+
+import edu.ucla.library.iiif.fester.Config;
+import edu.ucla.library.iiif.fester.Constants;
+import edu.ucla.library.iiif.fester.HTTP;
+import edu.ucla.library.iiif.fester.MessageCodes;
+import edu.ucla.library.iiif.fester.Op;
+import edu.ucla.library.iiif.fester.utils.CodeUtils;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Promise;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.eventbus.Message;
+import io.vertx.core.http.ConnectionPoolTooBusyException;
+import io.vertx.core.http.HttpClientOptions;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.shareddata.Counter;
+
+/**
+ * Stores submitted manifests to an S3 bucket.
+ */
+public class S3BucketVerticle extends AbstractFesterVerticle {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(S3BucketVerticle.class, Constants.MESSAGES);
+
+    private static final int DEFAULT_S3_MAX_REQUESTS = 10;
+
+    private static final long MAX_RETRIES = 10;
+
+    private S3Client myS3Client;
+
+    /**
+     * Starts the S3 Bucket Verticle.
+     */
+    @Override
+    public void start(final Future<Void> aFuture) {
+        getJsonConsumer().handler(message -> {
+            final JsonObject messageBody = message.body();
+
+            // retrieve our parameters from the message we have been sent on the bus
+            // param: manifest-content:jsonObject - holds the content of the Manifest object
+            // param: manifestID:String - the identifier we will use when storing the Manifest in S3
+            final String manifestID = messageBody.getString(Constants.MANIFEST_ID);
+            final JsonObject jsonObject = messageBody.getJsonObject(Constants.MANIFEST_CONTENT);
+
+            // grab the Fester configuration
+            final JsonObject config = config();
+            final int s3MaxRequests = config.getInteger(Config.S3_MAX_REQUESTS, DEFAULT_S3_MAX_REQUESTS);
+
+            // Initialize the S3BucketVerticle by getting our s3 configs and setting up the S3 client
+            if (myS3Client == null) {
+                final String s3AccessKey = config.getString(Config.S3_ACCESS_KEY);
+                final String s3SecretKey = config.getString(Config.S3_SECRET_KEY);
+                final String s3Bucket = config.getString(Config.S3_BUCKET);
+                final String s3RegionName = config.getString(Config.S3_REGION);
+                final String s3Region = RegionUtils.getRegion(s3RegionName).getServiceEndpoint("s3");
+
+                final HttpClientOptions options = new HttpClientOptions();
+
+                // Set the S3 client options
+                options.setDefaultHost(s3Region);
+
+                myS3Client = new S3Client(getVertx(), s3AccessKey, s3SecretKey, options);
+
+                // Trace is only for developer use; don't turn on when running on a server
+                LOGGER.trace(MessageCodes.MFS_046, s3AccessKey, s3SecretKey); // AWS S3 access / secret keys: {} / {}
+
+                LOGGER.debug(MessageCodes.MFS_047, s3RegionName); // S3 Client configured for region: {}
+            }
+
+            // handle S3 upload requests
+
+            getVertx().sharedData().getLocalCounter(Constants.S3_REQUEST_COUNT, getCounter -> {
+                if (getCounter.succeeded()) {
+                    getCounter.result().incrementAndGet(increment -> {
+                        if (increment.succeeded()) {
+                            // Check that we haven't reached our maximum number of S3 uploads
+                            if (increment.result() <= s3MaxRequests) {
+                                upload(message, config);
+                            } else {
+                                // If we have reached our maximum request count, re-queue the request
+                                sendReply(message, 0, Op.RETRY);
+                            }
+                        } else {
+                            message.fail(CodeUtils.getInt(MessageCodes.MFS_048), EMPTY);
+                        }
+                    });
+                } else {
+                    message.fail(CodeUtils.getInt(MessageCodes.MFS_049), EMPTY);
+                }
+            });
+
+        });
+
+        aFuture.complete();
+    }
+
+    /**
+     * Upload the provided MANIFEST_CONTENT to a file in S3.
+     *
+     * @param aMessage The message containing the S3 upload request
+     * @param aConfig The verticle's configuration
+     */
+    @SuppressWarnings("Indentation") // Checkstyle's indentation check doesn't work with multiple lambdas
+    private void upload(final Message<JsonObject> aMessage, final JsonObject aConfig) {
+        final JsonObject storageRequest = aMessage.body();
+
+        // If an S3 bucket isn't being supplied to us, use the one in our application configuration
+        if (!storageRequest.containsKey(Config.S3_BUCKET)) {
+            storageRequest.mergeIn(aConfig);
+        }
+
+        final String s3Bucket = storageRequest.getString(Config.S3_BUCKET);
+        final String manifestID = storageRequest.getString(Constants.MANIFEST_ID);
+        final String manifestIDwithExt = manifestID + Constants.JSON_EXT;
+
+        LOGGER.debug(MessageCodes.MFS_050, manifestID, s3Bucket);
+
+        // If we have MANIFEST_CONTENT, try to upload it to S3
+        if (storageRequest.containsKey(Constants.MANIFEST_CONTENT)) {
+            LOGGER.debug(MessageCodes.MFS_051, manifestID, s3Bucket);
+
+            // convert MANIFEST_CONTENT to a buffer
+            final Buffer manifestContent = storageRequest.getJsonObject(Constants.MANIFEST_CONTENT).toBuffer();
+
+            // This is pretty rudimentary, we will likely want to add more metadata, but we'll start with an ID
+            final UserMetadata metadata = new UserMetadata(Constants.MANIFEST_ID, manifestID);
+
+            // If our connection pool is full, drop back and try resubmitting the request
+            try {
+                myS3Client.put(s3Bucket, manifestIDwithExt, manifestContent, metadata, response -> {
+                    final int statusCode = response.statusCode();
+
+                    response.exceptionHandler(exception -> {
+                        final String details = exception.getMessage();
+
+                        LOGGER.error(exception, details);
+
+                        sendReply(aMessage, CodeUtils.getInt(MessageCodes.MFS_052), details);
+                    });
+
+                    // If we get a successful upload response code, send a reply to indicate so
+                    if (statusCode == HTTP.OK) {
+                        LOGGER.info(MessageCodes.MFS_053, manifestID);
+
+                        // Send the success result and decrement the S3 request counter
+                        sendReply(aMessage, 0, Op.SUCCESS);
+                    } else {
+                        LOGGER.error(MessageCodes.MFS_054, statusCode, response.statusMessage());
+
+                        // Log the detailed reason we failed so we can track down the issue
+                        response.bodyHandler(body -> {
+                            LOGGER.error(MessageCodes.MFS_052, body.getString(0, body.length()));
+                        });
+
+                        // If there is some internal S3 server error, let's try again
+                        if (statusCode == HTTP.INTERNAL_SERVER_ERROR) {
+                            sendReply(aMessage, 0, Op.RETRY);
+                        } else {
+                            final String errorMessage = statusCode + " - " + response.statusMessage();
+
+                            LOGGER.warn(MessageCodes.MFS_055, errorMessage);
+                            retryUpload(manifestID, aMessage);
+                        }
+                    }
+
+                }, exception -> {
+                    LOGGER.warn(MessageCodes.MFS_055, exception.getMessage());
+                    retryUpload(manifestID, aMessage);
+                });
+            } catch (final ConnectionPoolTooBusyException details) {
+                LOGGER.debug(MessageCodes.MFS_056, manifestID);
+                sendReply(aMessage, 0, Op.RETRY);
+            }
+
+        } else {
+            // log an error, because we ought to be provided MANIFEST_CONTENT, AND we ought to continue
+            // regardless
+            LOGGER.warn(MessageCodes.MFS_055, manifestID);
+            sendReply(aMessage, CodeUtils.getInt(MessageCodes.MFS_055), manifestID);
+        }
+
+    }
+
+    /**
+     * A more tentative retry attempt. We count the number of times we've retried and give up after a certain point.
+     *
+     * @param aManifestID A Manifest ID to retry
+     * @param aMessage A message to respond to with the retry request (or exception if we've failed)
+     */
+    private void retryUpload(final String aManifestID, final Message<JsonObject> aMessage) {
+        shouldRetry(aManifestID, retryCheck -> {
+            if (retryCheck.succeeded()) {
+                if (retryCheck.result()) {
+                    sendReply(aMessage, 0, Op.RETRY);
+                } else {
+                    sendReply(aMessage, CodeUtils.getInt(MessageCodes.MFS_058), EMPTY);
+                }
+            } else {
+                final Throwable retryException = retryCheck.cause();
+                final String details = retryException.getMessage();
+
+                LOGGER.error(retryException, MessageCodes.MFS_059, details);
+
+                // If we have an exception, don't retry... just log the issue
+                sendReply(aMessage, CodeUtils.getInt(MessageCodes.MFS_059), details);
+            }
+        });
+    }
+
+    /**
+     * A check to see whether an errored request should be retried.
+     *
+     * @param aManifestID A Manifest ID
+     * @param aHandler A retry handler
+     */
+    private void shouldRetry(final String aManifestID, final Handler<AsyncResult<Boolean>> aHandler) {
+        final Promise<Boolean> promise = Promise.promise();
+
+        promise.future().setHandler(aHandler);
+
+        vertx.sharedData().getLocalCounter(aManifestID, getCounter -> {
+            if (getCounter.succeeded()) {
+                final Counter counter = getCounter.result();
+
+                counter.addAndGet(1L, get -> {
+                    if (get.succeeded()) {
+                        if (get.result() == MAX_RETRIES) {
+                            promise.complete(Boolean.FALSE);
+
+                            // Reset the counter in case we ever need to process this item again
+                            counter.compareAndSet(MAX_RETRIES, 0L, reset -> {
+                                if (reset.failed()) {
+                                    LOGGER.error(MessageCodes.MFS_060, aManifestID);
+                                }
+                            });
+                        } else {
+                            promise.complete(Boolean.TRUE);
+                        }
+                    } else {
+                        promise.fail(get.cause());
+                    }
+                });
+            } else {
+                promise.fail(getCounter.cause());
+            }
+        });
+    }
+
+    /**
+     * Sends a message reply in the case that the S3 upload succeeded (or failed after the counter had been
+     * incremented).
+     *
+     * @param aMessage A message requesting an S3 upload
+     * @param aDetails The result of the S3 upload
+     */
+    private void sendReply(final Message<JsonObject> aMessage, final int aCode, final String aDetails) {
+        getVertx().sharedData().getLocalCounter(Constants.S3_REQUEST_COUNT, getCounter -> {
+            if (getCounter.succeeded()) {
+                getCounter.result().decrementAndGet(decrement -> {
+                    if (decrement.failed()) {
+                        LOGGER.error(MessageCodes.MFS_062);
+                    }
+
+                    if (aCode == 0) {
+                        aMessage.reply(aDetails);
+                    } else {
+                        aMessage.fail(aCode, aDetails);
+                    }
+                });
+            } else {
+                LOGGER.error(MessageCodes.MFS_063);
+
+                if (aCode == 0) {
+                    aMessage.reply(aDetails);
+                } else {
+                    aMessage.fail(aCode, aDetails);
+                }
+            }
+        });
+    }
+}

--- a/src/main/resources/fester_messages.xml
+++ b/src/main/resources/fester_messages.xml
@@ -55,6 +55,33 @@
   <entry key="MFS-039">Unexpected POST response: [{}] {}</entry>
   <entry key="MFS-040">Configuration file not found</entry>
   <entry key="MFS-041">Starting the Fester service on port: {}</entry>
+
+  <entry key="MFS-044">Configuring S3 uploader: {} instance(s) and {} thread(s) per instance</entry>
+  <entry key="MFS-045">{} starting in thread: {}</entry>
+  <entry key="MFS-046">AWS S3 access / secret keys: {} / {}</entry>
+  <entry key="MFS-047">S3 Client configured for region: {}</entry>
+  <entry key="MFS-048">Failed to increment S3 upload counter</entry>
+  <entry key="MFS-049">Failed to get S3 upload counter</entry>
+  <entry key="MFS-050">Preparing to send '{}' to S3 bucket: {}</entry>
+  <entry key="MFS-051">Sending '{}' to S3 bucket: {}</entry>
+  <entry key="MFS-052">{}</entry>
+  <entry key="MFS-053">Image file '{}' successfully uploaded to S3</entry>
+  <entry key="MFS-054">S3 bucket upload failed: {} -&gt; {}</entry>
+  <entry key="MFS-055">Error triggering S3 upload retry: {}</entry>
+  <entry key="MFS-056">S3 connection pool is full; re-queuing the request: {}</entry>
+  <entry key="MFS-057">Failed to read file: {}</entry>
+  <entry key="MFS-058">Stopped retrying S3 upload; maximum number of retries allowed reached: {}</entry>
+  <entry key="MFS-059">Failed to get S3 upload counter</entry>
+  <entry key="MFS-060">Failed to reset S3 upload retry counter for: {}</entry>
+  <entry key="MFS-061">Failed to close the image file after trying to upload it to S3: {}</entry>
+  <entry key="MFS-062">Failed to decrement the S3 request counter</entry>
+  <entry key="MFS-063">Couldn't retrieve the S3 request counter</entry>
+  <entry key="MFS-064">Error: Missing MANIFEST_CONTENT from S3 upload request for: {}</entry>
+  <entry key="MFS-065">Skipping test because we don't have a valid S3 configuration</entry>
+  <entry key="MFS-066">Failed to close Vert.x test instance</entry>
+  <entry key="MFS-067">Test server for {} started...</entry>
+  
+
   <entry key="MFS-100">Stopping the {} verticle [id: {}]</entry>
   <entry key="MFS-101">Getting message consumer for: {}</entry>
   <entry key="MFS-102">Sending message to {}: {}</entry>
@@ -63,7 +90,7 @@
   <entry key="MFS-105">Uploaded CSV's &quot;Project Name&quot; header could not be found</entry>
   <entry key="MFS-106">Uploaded CSV doesn't have an &quot;Item ARK&quot; to use as a collection ID</entry>
   <entry key="MFS-107">Work row in the CSV is missing its &quot;Parent ARK&quot; value</entry>
-  <entry key="MFS-108">Work row is missing an &qout;Item ARK&quot; or &quot;Title&quot; value</entry>
+  <entry key="MFS-108">Work row is missing an &quot;Item ARK&quot; or &quot;Title&quot; value</entry>
   <entry key="MFS-109">The supplied string isn't a MessageCode: {}</entry>
   <entry key="MFS-110">Starting the {} verticle [id: {}]</entry>
   <entry key="MFS-111">Uploaded CSV's &quot;Title&quot; header could not be found</entry>

--- a/src/test/java/edu/ucla/library/iiif/fester/verticles/S3BucketVerticleTest.java
+++ b/src/test/java/edu/ucla/library/iiif/fester/verticles/S3BucketVerticleTest.java
@@ -1,0 +1,189 @@
+
+package edu.ucla.library.iiif.fester.verticles;
+
+import static edu.ucla.library.iiif.fester.Constants.MESSAGES;
+import static org.junit.Assume.assumeTrue;
+
+import java.util.UUID;
+
+import org.junit.After;
+import org.junit.AssumptionViolatedException;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3Client;
+
+import info.freelibrary.util.Logger;
+import info.freelibrary.util.LoggerFactory;
+
+import edu.ucla.library.iiif.fester.Config;
+import edu.ucla.library.iiif.fester.Constants;
+import edu.ucla.library.iiif.fester.MessageCodes;
+import io.vertx.config.ConfigRetriever;
+import io.vertx.core.DeploymentOptions;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.RunTestOnContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+
+@RunWith(VertxUnitRunner.class)
+public class S3BucketVerticleTest extends AbstractFesterVerticle {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(S3BucketVerticleTest.class, MESSAGES);
+
+    private static final String MANIFEST_PATH = "src/test/resources/testManifest.json";
+
+    private static final String VERTICLE_NAME = S3BucketVerticle.class.getName();
+
+    private static final String DEFAULT_ACCESS_KEY = "YOUR_ACCESS_KEY";
+
+    private static String s3Bucket = "unconfigured";
+
+    private static AWSCredentials myAWSCredentials;
+
+    @Rule
+    public RunTestOnContext myRunTestOnContextRule = new RunTestOnContext();
+
+    private String myManifestKey;
+
+    /** We can't, as of yet, execute these tests without a non-default S3 configuration */
+    private boolean isExecutable;
+
+    private AmazonS3 myAmazonS3;
+
+    /**
+     * Set up the testing environment.
+     *
+     * @param aContext A test context
+     * @throws Exception If there is trouble starting Vert.x or configuring the tests
+     */
+    @SuppressWarnings("deprecation")
+    @Before
+    public void setUp(final TestContext aContext) throws Exception {
+        final Vertx vertx = myRunTestOnContextRule.vertx();
+        final ConfigRetriever configRetriever = ConfigRetriever.create(vertx);
+        final DeploymentOptions options = new DeploymentOptions();
+        final Async asyncTask = aContext.async();
+
+        configRetriever.getConfig(getConfig -> {
+            if (getConfig.succeeded()) {
+                final JsonObject config = getConfig.result();
+
+                myManifestKey = UUID.randomUUID().toString() + Constants.JSON_EXT;
+
+                // We need to determine if we'll be able to run the S3 integration tests so we can skip if needed
+                if (config.containsKey(Config.S3_ACCESS_KEY) && !config.getString(Config.S3_ACCESS_KEY,
+                        DEFAULT_ACCESS_KEY).equalsIgnoreCase(DEFAULT_ACCESS_KEY)) {
+                    isExecutable = true;
+                }
+
+                vertx.deployVerticle(VERTICLE_NAME, options.setConfig(config), deployment -> {
+                    if (deployment.failed()) {
+                        final Throwable details = deployment.cause();
+                        final String message = details.getMessage();
+
+                        LOGGER.error(details, message);
+                        aContext.fail(message);
+                    }
+
+                    if (myAmazonS3 == null) {
+                        final String s3AccessKey = config.getString(Config.S3_ACCESS_KEY);
+                        final String s3SecretKey = config.getString(Config.S3_SECRET_KEY);
+
+                        // get myAWSCredentials ready
+                        myAWSCredentials = new BasicAWSCredentials(s3AccessKey, s3SecretKey);
+
+                        // instantiate the myAmazonS3 client
+                        myAmazonS3 = new AmazonS3Client(myAWSCredentials);
+                    }
+
+                    s3Bucket = config.getString(Config.S3_BUCKET);
+                    LOGGER.debug(MessageCodes.MFS_067, getClass().getName());
+                    asyncTask.complete();
+                });
+            } else {
+                aContext.fail(getConfig.cause());
+                asyncTask.complete();
+            }
+        });
+    }
+
+    /**
+     * Tear down the testing environment.
+     *
+     * @param aContext A test context
+     * @throws Exception If there is trouble closing down the Vert.x instance
+     */
+    @After
+    public void tearDown(final TestContext aContext) throws Exception {
+        final Async async = aContext.async();
+
+        myRunTestOnContextRule.vertx().close(result -> {
+            if (!result.succeeded()) {
+                final String message = LOGGER.getMessage(MessageCodes.MFS_066);
+
+                LOGGER.error(message);
+                aContext.fail(message);
+            }
+
+            // clean up our test files
+            myAmazonS3.deleteObject(s3Bucket, myManifestKey);
+
+            async.complete();
+        });
+    }
+
+    /**
+     * Tests being able to store to S3. This requires an actual S3 configuration. The test will be skipped if no such
+     * configuration exists.
+     *
+     * @param aContext A test context
+     */
+    @Test
+    public final void testS3Storage(final TestContext aContext) {
+        try {
+            // Skip this test if we don't have a valid S3 configuration
+            assumeTrue(LOGGER.getMessage(MessageCodes.MFS_065), isExecutable);
+        } catch (final AssumptionViolatedException details) {
+            LOGGER.warn(details.getMessage());
+            throw details;
+        }
+
+        final Vertx vertx = myRunTestOnContextRule.vertx();
+        final JsonObject message = new JsonObject();
+        final Async asyncTask = aContext.async();
+
+        // load up our test Manifest.json file, and convert it to a JsonObject to hand to our S3 Verticle
+        final JsonObject testManifestContent = vertx.fileSystem().readFileBlocking(MANIFEST_PATH).toJsonObject();
+
+        // send the parameters the Fester S3 Verticle wants, those would be
+        // param: manifestID:String - the identifier we will use when storing the Manifest in S3
+        // param: manifest-content:jsonObject - holds the content of the Manifest object
+
+        message.put(Constants.MANIFEST_ID, myManifestKey);
+
+        message.put(Constants.MANIFEST_CONTENT, testManifestContent);
+
+        vertx.eventBus().request(VERTICLE_NAME, message, send -> {
+            if (send.failed()) {
+                final Throwable details = send.cause();
+
+                if (details != null) {
+                    LOGGER.error(details, details.getMessage());
+                }
+
+                aContext.fail();
+            }
+
+            asyncTask.complete();
+        });
+    }
+
+}


### PR DESCRIPTION
- Remove the ResultsMap and other image-related things from the
Bucketeer S3BucketVerticle
- Refactor the message requirements for the S3BucketVerticle to work
with a JSON object
- Refactor the test for the S3BucketVerticle to send a manifest instead
of an image
- Bump the version of Vert-X we're using