### PR TITLE
Fix display of OpenAPI specs

### DIFF
--- a/src/main/java/edu/ucla/library/iiif/fester/verticles/MainVerticle.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/verticles/MainVerticle.java
@@ -82,6 +82,7 @@ public class MainVerticle extends AbstractVerticle {
                         try {
                             final int port = config.getInteger(Config.HTTP_PORT, DEFAULT_PORT);
                             final PostCsvHandler postHandler = new PostCsvHandler(vertx, config);
+                            final StaticHandler staticHandler = StaticHandler.create().setWebRoot("webroot");
 
                             factory.addHandlerByOperationId(Op.POST_COLLECTION, postHandler);
 
@@ -89,7 +90,7 @@ public class MainVerticle extends AbstractVerticle {
                             router = factory.getRouter();
 
                             // Serve Fester documentation
-                            router.get("/docs/fester/*").handler(StaticHandler.create().setWebRoot("webroot"));
+                            router.get("/docs/fester*").handler(staticHandler.setIndexPage("index.html"));
 
                             // If an incoming request doesn't match one of our spec operations, it's treated as a 404;
                             // catch these generic 404s with the handler below and return more specific response codes


### PR DESCRIPTION
Fix the display of the OpenAPI docs by changing the path matching pattern and setting a default index page.