### PR TITLE
Add CSV response to PostCsv endpoint

### DIFF
--- a/src/main/java/edu/ucla/library/iiif/fester/handlers/AbstractManifestHandler.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/handlers/AbstractManifestHandler.java
@@ -26,11 +26,11 @@ abstract class AbstractManifestHandler implements Handler<RoutingContext> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AbstractManifestHandler.class, Constants.MESSAGES);
 
+    protected final Vertx myVertx;
+
     protected S3Client myS3Client;
 
     protected String myS3Bucket;
-
-    private final Vertx myVertx;
 
     /**
      * An abstract handler that initializes an S3 client.


### PR DESCRIPTION
This is an incremental step towards returning a CSV which includes the URLs for the created manifests. Taking this small step lets our upload script get CSVs and handle them like it should.