### PR TITLE
[IIIF-591] Support using a different IIIF host for manifest creation

### DIFF
--- a/src/main/java/edu/ucla/library/iiif/fester/Constants.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/Constants.java
@@ -77,6 +77,11 @@ public final class Constants {
     public static final String CSV_FILE_NAME = "csv-file-name";
 
     /**
+     * The name of the IIIF host parameter.
+     */
+    public static final String IIIF_HOST = "iiif-host";
+
+    /**
      * The path at which we can find the collection manifests.
      */
     public static final String COLLECTIONS_PATH = "/collections";

--- a/src/main/java/edu/ucla/library/iiif/fester/ImageInfo.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/ImageInfo.java
@@ -17,6 +17,8 @@ import io.vertx.core.json.JsonObject;
  */
 public class ImageInfo {
 
+    public static final String FAKE_IIIF_SERVER = "https://test.example.com/iiif";
+
     private final int myWidth;
 
     private final int myHeight;
@@ -28,7 +30,7 @@ public class ImageInfo {
      */
     public ImageInfo(final String aURL) throws MalformedURLException, IOException {
         // If our images are using an unspecified host, we're running in test mode
-        if (aURL.contains(Constants.UNSPECIFIED_HOST)) {
+        if (aURL.contains(Constants.UNSPECIFIED_HOST) || aURL.startsWith(FAKE_IIIF_SERVER)) {
             myHeight = 1000;
             myWidth = 1000;
         } else {

--- a/src/main/java/edu/ucla/library/iiif/fester/handlers/PostCsvHandler.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/handlers/PostCsvHandler.java
@@ -78,10 +78,15 @@ public class PostCsvHandler extends AbstractManifestHandler {
             final JsonObject message = new JsonObject();
             final HttpServerRequest request = aContext.request();
             final String protocol = request.connection().isSsl() ? "https://" : "http://";
+            final String iiifHost = StringUtils.trimToNull(request.getFormAttribute(Constants.IIIF_HOST));
 
             // Store the information that the manifest generator will need
             message.put(Constants.CSV_FILE_NAME, fileName).put(Constants.CSV_FILE_PATH, filePath);
             message.put(Constants.FESTER_HOST, protocol + request.host());
+
+            if (iiifHost != null) {
+                message.put(Constants.IIIF_HOST, iiifHost);
+            }
 
             // Send a message to the manifest generator
             sendMessage(ManifestVerticle.class.getName(), message, Integer.MAX_VALUE, send -> {

--- a/src/main/resources/fester.yaml
+++ b/src/main/resources/fester.yaml
@@ -59,6 +59,8 @@ paths:
             schema:
               type: object
               properties:
+                iiif-host:
+                  type: string
                 csv-file:
                   type: string
                   format: binary


### PR DESCRIPTION
Currently, Fester creates manifests using the IIIF server its been configured with. We want it to be able to generate manifests that will point to a different IIIF server (e.g., Sinai) too though. This PR adds the ability to pass a `iiif-host` parameter to the PostCsv endpoint so that CSVs supplied with that different IIIF host will produce manifests whose manifest links point to Fester and whose IIIF links point to the different IIIF server.