### PR TITLE
[IIIF-580] Handle page-only CSV inputs

### DIFF
--- a/src/main/java/edu/ucla/library/iiif/fester/CsvMetadata.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/CsvMetadata.java
@@ -1,0 +1,61 @@
+
+package edu.ucla.library.iiif.fester;
+
+import java.util.List;
+import java.util.Map;
+
+import info.freelibrary.iiif.presentation.Collection;
+
+/**
+ * Processed metadata from a supplied CSV file.
+ */
+public class CsvMetadata {
+
+    private final Map<String, List<Collection.Manifest>> myWorksMap;
+
+    private final List<String[]> myWorksList;
+
+    private final Map<String, List<String[]>> myPagesMap;
+
+    /**
+     * Creates a CSV metadata object.
+     *
+     * @param aWorksMap A map of metadata for works stored in a collection document
+     * @param aWorksList A list of works metadata
+     * @param aPagesMap A map of pages metadata
+     */
+    public CsvMetadata(final Map<String, List<Collection.Manifest>> aWorksMap, final List<String[]> aWorksList,
+            final Map<String, List<String[]>> aPagesMap) {
+        myWorksMap = aWorksMap;
+        myWorksList = aWorksList;
+        myPagesMap = aPagesMap;
+    }
+
+    /**
+     * Gets the metadata for the works stored in a collection document.
+     *
+     * @return The metadata for the works stored in a collection document
+     */
+    public Map<String, List<Collection.Manifest>> getWorksMap() {
+        return myWorksMap;
+    }
+
+    /**
+     * Gets the metadata for the works manifests.
+     *
+     * @return The metadata for the works manifests
+     */
+    public List<String[]> getWorksList() {
+        return myWorksList;
+    }
+
+    /**
+     * Gets the metadata for the manifest pages.
+     *
+     * @return The metadata for the manifest pages
+     */
+    public Map<String, List<String[]>> getPagesMap() {
+        return myPagesMap;
+    }
+
+}

--- a/src/main/java/edu/ucla/library/iiif/fester/verticles/S3BucketVerticle.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/verticles/S3BucketVerticle.java
@@ -88,7 +88,7 @@ public class S3BucketVerticle extends AbstractFesterVerticle {
                     aMessage.reply(new JsonObject(body.getString(0, body.length())));
                 });
             } else {
-                aMessage.fail(0, get.statusMessage());
+                aMessage.fail(CodeUtils.getInt(MessageCodes.MFS_052), get.statusMessage());
             }
         });
     }

--- a/src/main/resources/fester_messages.xml
+++ b/src/main/resources/fester_messages.xml
@@ -82,6 +82,7 @@
   <entry key="MFS-066">Failed to close Vert.x test instance</entry>
   <entry key="MFS-067">Test server for {} started...</entry>
   <entry key="MFS-068">Manifesting a CSV file of works: {}</entry>
+  <entry key="MFS-069">Manifesting a CSV file of pages: {}</entry>
 
   <entry key="MFS-100">Stopping the {} verticle [id: {}]</entry>
   <entry key="MFS-101">Getting message consumer for: {}</entry>

--- a/src/test/java/edu/ucla/library/iiif/fester/verticles/FakeS3BucketVerticle.java
+++ b/src/test/java/edu/ucla/library/iiif/fester/verticles/FakeS3BucketVerticle.java
@@ -17,6 +17,7 @@ import info.freelibrary.util.StringUtils;
 import edu.ucla.library.iiif.fester.Constants;
 import edu.ucla.library.iiif.fester.MessageCodes;
 import edu.ucla.library.iiif.fester.Op;
+import edu.ucla.library.iiif.fester.utils.CodeUtils;
 import edu.ucla.library.iiif.fester.utils.IDUtils;
 import io.vertx.core.Promise;
 import io.vertx.core.eventbus.Message;
@@ -73,10 +74,10 @@ public class FakeS3BucketVerticle extends AbstractFesterVerticle {
 
                 aMessage.reply(manifest);
             } else {
-                aMessage.fail(0, id + " not found");
+                aMessage.fail(CodeUtils.getInt(MessageCodes.MFS_052), id + " not found");
             }
         } catch (final IOException details) {
-            aMessage.fail(0, details.getMessage());
+            aMessage.fail(CodeUtils.getInt(MessageCodes.MFS_052), details.getMessage());
         }
     }
 

--- a/src/test/java/edu/ucla/library/iiif/fester/verticles/FakeS3BucketVerticle.java
+++ b/src/test/java/edu/ucla/library/iiif/fester/verticles/FakeS3BucketVerticle.java
@@ -30,7 +30,8 @@ public class FakeS3BucketVerticle extends AbstractFesterVerticle {
     private static final Logger LOGGER = LoggerFactory.getLogger(FakeS3BucketVerticle.class, Constants.MESSAGES);
 
     private static final Map<String, File> JSON_FILES = Map.of("ark%3A%2F21198%2Fzz0009gsq9", new File(
-            "src/test/resources/json/ark%3A%2F21198%2Fzz0009gsq9.json"));
+            "src/test/resources/json/ark%3A%2F21198%2Fzz0009gsq9.json"), "ark%3A%2F21198%2Fzz0009gv8j", new File(
+                    "src/test/resources/json/ark%3A%2F21198%2Fzz0009gv8j.json"));
 
     private File myTmpDir;
 

--- a/src/test/java/edu/ucla/library/iiif/fester/verticles/ManifestVerticleTest.java
+++ b/src/test/java/edu/ucla/library/iiif/fester/verticles/ManifestVerticleTest.java
@@ -35,11 +35,15 @@ public class ManifestVerticleTest {
 
     private static final String IMAGE_HOST = "https://iiif.library.ucla.edu/iiif/2";
 
+    private static final String WORKS_CSV = "src/test/resources/csv/{}/batch1/{}1.csv";
+
     private static final String CSV_FILE_PATH = "src/test/resources/csv/{}.csv";
 
     private static final String HATHAWAY = "hathaway";
 
     private static final String POSTCARDS = "capostcards";
+
+    private static final String WORKS = "works";
 
     private Vertx myVertx;
 
@@ -153,6 +157,31 @@ public class ManifestVerticleTest {
         message.put(Constants.FESTER_HOST, MANIFEST_HOST);
 
         LOGGER.debug(MessageCodes.MFS_120, hathawayWorks, ManifestVerticle.class.getName());
+
+        myVertx.eventBus().request(ManifestVerticle.class.getName(), message, request -> {
+            if (request.succeeded()) {
+                asyncTask.complete();
+            } else {
+                aContext.fail(request.cause());
+            }
+        });
+    }
+
+    /**
+     * Test against a CSV that just has pages.
+     *
+     * @param aContext A testing context
+     */
+    @Test
+    public final void testPagesManifest(final TestContext aContext) {
+        final String filePath = StringUtils.format(WORKS_CSV, HATHAWAY, HATHAWAY);
+        final JsonObject message = new JsonObject();
+        final Async asyncTask = aContext.async();
+
+        message.put(Constants.CSV_FILE_NAME, myRunID).put(Constants.CSV_FILE_PATH, filePath);
+        message.put(Constants.FESTER_HOST, MANIFEST_HOST);
+
+        LOGGER.debug(MessageCodes.MFS_120, WORKS, ManifestVerticle.class.getName());
 
         myVertx.eventBus().request(ManifestVerticle.class.getName(), message, request -> {
             if (request.succeeded()) {

--- a/src/test/resources/json/ark%3A%2F21198%2Fzz0009gv8j.json
+++ b/src/test/resources/json/ark%3A%2F21198%2Fzz0009gv8j.json
@@ -1,0 +1,6 @@
+{
+  "@context" : "http://iiif.io/api/presentation/2/context.json",
+  "label" : "Hathaway 1",
+  "@id" : "https://iiif.library.ucla.edu/ark%3A%2F21198%2Fzz0009gv8j/manifest",
+  "@type" : "sc:Manifest"
+}


### PR DESCRIPTION
* Refactor to reduce nesting levels in ManifestVerticle
* Add a CsvMetadata class to reduce the number of variables passed around in ManifestVerticle
* Add handling for page-only CSV inputs to the manifest generation batch process
* Get rid of the zero in `aMessage.fail(0, message);` so there is a specific fail int code, even if it's just a generic one used for passing through a throwable's message

Fixes #IIIF-593 too