### PR TITLE
[IIIF-600] Change collection doc's label source

### DIFF
--- a/src/main/java/edu/ucla/library/iiif/fester/CSV.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/CSV.java
@@ -7,11 +7,6 @@ package edu.ucla.library.iiif.fester;
 public final class CSV {
 
     /**
-     * The name of a project. We make the assumption of one project per CSV.
-     */
-    public static final String PROJECT_NAME = "Project Name";
-
-    /**
      * The ARK identifier for a row.
      */
     public static final String ITEM_ARK = "Item ARK";

--- a/src/main/java/edu/ucla/library/iiif/fester/CsvHeaders.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/CsvHeaders.java
@@ -12,8 +12,6 @@ public class CsvHeaders {
 
     private int myTitleIndex;
 
-    private int myProjectNameIndex;
-
     private int myObjectTypeIndex;
 
     private int myFileNameIndex;
@@ -31,9 +29,6 @@ public class CsvHeaders {
             switch (aRow[index]) {
                 case CSV.TITLE:
                     setTitleIndex(index);
-                    break;
-                case CSV.PROJECT_NAME:
-                    setProjectNameIndex(index);
                     break;
                 case CSV.ITEM_ARK:
                     setItemArkIndex(index);
@@ -60,8 +55,6 @@ public class CsvHeaders {
             throw new CsvParsingException(MessageCodes.MFS_113);
         } else if (!hasParentArkIndex()) {
             throw new CsvParsingException(MessageCodes.MFS_114);
-        } else if (!hasProjectNameIndex()) {
-            throw new CsvParsingException(MessageCodes.MFS_105);
         } else if (!hasObjectTypeIndex()) {
             throw new CsvParsingException(MessageCodes.MFS_115);
         } else if (!hasTitleIndex()) {
@@ -155,34 +148,6 @@ public class CsvHeaders {
      */
     public boolean hasTitleIndex() {
         return myTitleIndex != -1;
-    }
-
-    /**
-     * Gets the Project Name index position.
-     *
-     * @return The index position of the Project Name
-     */
-    public int getProjectNameIndex() {
-        return myProjectNameIndex;
-    }
-
-    /**
-     * Sets the Project Name index position.
-     *
-     * @param aProjectNameIndex The index position of the Project Name
-     */
-    public CsvHeaders setProjectNameIndex(final int aProjectNameIndex) {
-        myProjectNameIndex = aProjectNameIndex;
-        return this;
-    }
-
-    /**
-     * Checks whether there is an Project Name index position
-     *
-     * @return True if there is a Project name index position; else, false
-     */
-    public boolean hasProjectNameIndex() {
-        return myProjectNameIndex != -1;
     }
 
     /**

--- a/src/main/java/edu/ucla/library/iiif/fester/verticles/ManifestVerticle.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/verticles/ManifestVerticle.java
@@ -608,7 +608,7 @@ public class ManifestVerticle extends AbstractFesterVerticle {
         final String id = StringUtils.trimToNull(aRow[aHeaders.getItemArkIndex()]);
 
         if (id != null) {
-            final String label = StringUtils.trimToNull(aRow[aHeaders.getProjectNameIndex()]);
+            final String label = StringUtils.trimToNull(aRow[aHeaders.getTitleIndex()]);
 
             if (label != null) {
                 return new Collection(IDUtils.encode(myHost, Constants.COLLECTIONS_PATH, id), label);


### PR DESCRIPTION
We used Project Name for the collection doc label, but after trying to run our first real Sinai CSV and talking with Dawn, we're going to change to using Title for the collection doc label value. This also reduces the number of column headers we care about in the CSV. I'm creating a separate ticket for documenting those (in the script, openapi, etc.)