### PR TITLE
Fix S3 manifest lookup (missing ext)

### DIFF
--- a/src/main/java/edu/ucla/library/iiif/fester/verticles/S3BucketVerticle.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/verticles/S3BucketVerticle.java
@@ -80,9 +80,12 @@ public class S3BucketVerticle extends AbstractFesterVerticle {
     }
 
     private void get(final String aID, final Message<JsonObject> aMessage) {
-        LOGGER.debug(MessageCodes.MFS_133, aID);
+        // If our ID doesn't have a .json extension, add one for the lookup
+        final String id = !aID.endsWith(Constants.JSON_EXT) ? aID + Constants.JSON_EXT : aID;
 
-        myS3Client.get(myS3Bucket, aID, get -> {
+        LOGGER.debug(MessageCodes.MFS_133, id, myS3Bucket);
+
+        myS3Client.get(myS3Bucket, id, get -> {
             if (get.statusCode() == HTTP.OK) {
                 get.bodyHandler(body -> {
                     aMessage.reply(new JsonObject(body.getString(0, body.length())));

--- a/src/main/resources/fester_messages.xml
+++ b/src/main/resources/fester_messages.xml
@@ -119,5 +119,5 @@
   <entry key="MFS-130">Reset collection manifest key to: {}</entry>
   <entry key="MFS-131">Failed to upload all the work manifests: {}</entry>
   <entry key="MFS-132">Replacing '{}' with '{}' in collection document</entry>
-  <entry key="MFS-133">Getting {} from Fester's S3 bucket</entry>
+  <entry key="MFS-133">Getting '{}' from Fester's S3 bucket: {}</entry>
 </properties>


### PR DESCRIPTION
Oops, our manifests are stored in the S3 bucket with a ".json" extension but the batch handler's S3 GET was forgetting to add that to the ID being retrieved.