### PR TITLE
[IIIF-618] Fix timeout issue on image w/h lookup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 target/
 file-uploads/
+output/
 pom.xml.tag
 pom.xml.releaseBackup
 pom.xml.versionsBackup

--- a/src/main/java/edu/ucla/library/iiif/fester/ImageInfoLookup.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/ImageInfoLookup.java
@@ -67,7 +67,7 @@ public class ImageInfoLookup {
                     // Get the info.json contents
                     jsonObject = new JsonObject(result.toString());
 
-                    // Find our image's width and height or use zero if they're missing in the manifest
+                    // Find our image's width and height or use one if they're missing in the manifest
                     myHeight = jsonObject.getInteger("height", 1);
                     myWidth = jsonObject.getInteger("width", 1);
                 }

--- a/src/main/resources/fester_messages.xml
+++ b/src/main/resources/fester_messages.xml
@@ -85,6 +85,7 @@
   <entry key="MFS-069">Manifesting a CSV file of pages: {}</entry>
   <entry key="MFS-070">Unable to retrieve '{}' from the IIIF image server</entry>
   <entry key="MFS-071">Unexpected response code from the IIIF image server: {} [{}]</entry>
+  <entry key="MFS-072">Looking up image width and height from: {}</entry>
 
   <entry key="MFS-100">Stopping the {} verticle [id: {}]</entry>
   <entry key="MFS-101">Getting message consumer for: {}</entry>

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -7,9 +7,13 @@
     </encoder>
   </appender>
 
-  <appender name="FILE" class="ch.qos.logback.core.FileAppender">
-    <file>target/monitorstore-${byDay}.log</file>
-    <append>false</append>
+  <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <file>/var/log/fester/fester-${byDay}.log</file>
+      <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+        <fileNamePattern>/var/log/fester/fester.%d{yyyy-MM-dd}.log</fileNamePattern>
+        <maxHistory>30</maxHistory>
+        <totalSizeCap>2GB</totalSizeCap>
+    </rollingPolicy>
     <encoder>
       <pattern>[%level] %logger{45}:%X{line} | %msg%n</pattern>
     </encoder>


### PR DESCRIPTION
* Fix the production log location (doesn't affect log location when running in test mode)
* Increase the read timeout when looking for w/h from info.json in Cantaloupe
* Ignore the output directory festerize creates if it's run from the project's root directory
* Make the fallback w/h if image can't be found 1 (a workaround for issue with presentation library)