### PR TITLE
[IIIF-618] Add log warning and one more default value workaround

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
     <aws.sdk.version>1.11.478</aws.sdk.version>
     <commons.lang.version>3.9</commons.lang.version>
     <freelib.utils.version>0.8.10</freelib.utils.version>
-    <jiiify.presentation.version>0.1.2</jiiify.presentation.version>
+    <jiiify.presentation.version>0.1.3</jiiify.presentation.version>
 
     <!-- Build plug-in versions -->
     <shade.plugin.version>2.4.3</shade.plugin.version>

--- a/src/main/java/edu/ucla/library/iiif/fester/ImageInfoLookup.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/ImageInfoLookup.java
@@ -68,10 +68,10 @@ public class ImageInfoLookup {
                     jsonObject = new JsonObject(result.toString());
 
                     // Find our image's width and height or use one if they're missing in the manifest
-                    myHeight = jsonObject.getInteger("height", 1);
-                    myWidth = jsonObject.getInteger("width", 1);
+                    myHeight = jsonObject.getInteger("height", 0);
+                    myWidth = jsonObject.getInteger("width", 0);
 
-                    if (myHeight == 1 || myWidth == 1) {
+                    if (myHeight == 0 || myWidth == 0) {
                         LOGGER.warn(MessageCodes.MFS_073, aURL);
                     }
                 }

--- a/src/main/java/edu/ucla/library/iiif/fester/ImageInfoLookup.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/ImageInfoLookup.java
@@ -70,6 +70,10 @@ public class ImageInfoLookup {
                     // Find our image's width and height or use one if they're missing in the manifest
                     myHeight = jsonObject.getInteger("height", 1);
                     myWidth = jsonObject.getInteger("width", 1);
+
+                    if (myHeight == 1 || myWidth == 1) {
+                        LOGGER.warn(MessageCodes.MFS_073, aURL);
+                    }
                 }
             } else if (responseCode == 404) {
                 final String id = IDUtils.decode(URI.create(aURL));

--- a/src/main/java/edu/ucla/library/iiif/fester/ImageInfoLookup.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/ImageInfoLookup.java
@@ -67,7 +67,7 @@ public class ImageInfoLookup {
                     // Get the info.json contents
                     jsonObject = new JsonObject(result.toString());
 
-                    // Find our image's width and height or use one if they're missing in the manifest
+                    // Find our image's width and height or use zero if they're missing in the manifest
                     myHeight = jsonObject.getInteger("height", 0);
                     myWidth = jsonObject.getInteger("width", 0);
 

--- a/src/main/java/edu/ucla/library/iiif/fester/verticles/ManifestVerticle.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/verticles/ManifestVerticle.java
@@ -507,7 +507,7 @@ public class ManifestVerticle extends AbstractFesterVerticle {
                     // If we've not processed any, check to sequence to find one
                     final List<Canvas> canvases = aSequence.getCanvases();
 
-                    // If there is one use that; else, just use ones for the w/h values
+                    // If there is one use that; else, just use zeros for the w/h values
                     if (canvases.size() != 0) {
                         final Canvas altLastCanvas = canvases.get(canvases.size() - 1);
 

--- a/src/main/java/edu/ucla/library/iiif/fester/verticles/ManifestVerticle.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/verticles/ManifestVerticle.java
@@ -507,15 +507,17 @@ public class ManifestVerticle extends AbstractFesterVerticle {
                     // If we've not processed any, check to sequence to find one
                     final List<Canvas> canvases = aSequence.getCanvases();
 
-                    // If there is one use that; else, just use zeros for the w/h values
+                    // If there is one use that; else, just use ones for the w/h values
                     if (canvases.size() != 0) {
                         final Canvas altLastCanvas = canvases.get(canvases.size() - 1);
 
                         width = altLastCanvas.getWidth();
                         height = altLastCanvas.getHeight();
                     } else {
-                        width = 0;
-                        height = 0;
+                        LOGGER.warn(MessageCodes.MFS_073, pageURI);
+
+                        width = 1;
+                        height = 1;
                     }
                 }
 

--- a/src/main/java/edu/ucla/library/iiif/fester/verticles/ManifestVerticle.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/verticles/ManifestVerticle.java
@@ -516,8 +516,8 @@ public class ManifestVerticle extends AbstractFesterVerticle {
                     } else {
                         LOGGER.warn(MessageCodes.MFS_073, pageURI);
 
-                        width = 1;
-                        height = 1;
+                        width = 0;
+                        height = 0;
                     }
                 }
 

--- a/src/main/resources/fester_messages.xml
+++ b/src/main/resources/fester_messages.xml
@@ -86,7 +86,7 @@
   <entry key="MFS-070">Unable to retrieve '{}' from the IIIF image server</entry>
   <entry key="MFS-071">Unexpected response code from the IIIF image server: {} [{}]</entry>
   <entry key="MFS-072">Looking up image width and height from: {}</entry>
-  <entry key="MFS-073">Setting image w/h to a questionable default value: 1 [item: {}]</entry>
+  <entry key="MFS-073">Could not find an image width or height for the canvas; missing values have been set to zero [item: {}]</entry>
 
   <entry key="MFS-100">Stopping the {} verticle [id: {}]</entry>
   <entry key="MFS-101">Getting message consumer for: {}</entry>

--- a/src/main/resources/fester_messages.xml
+++ b/src/main/resources/fester_messages.xml
@@ -86,6 +86,7 @@
   <entry key="MFS-070">Unable to retrieve '{}' from the IIIF image server</entry>
   <entry key="MFS-071">Unexpected response code from the IIIF image server: {} [{}]</entry>
   <entry key="MFS-072">Looking up image width and height from: {}</entry>
+  <entry key="MFS-073">Setting image w/h to a questionable default value: 1 [item: {}]</entry>
 
   <entry key="MFS-100">Stopping the {} verticle [id: {}]</entry>
   <entry key="MFS-101">Getting message consumer for: {}</entry>


### PR DESCRIPTION
* Log a warning when we set the w/h to a default value; this isn't an error but we shouldn't blindly do it
* Add the w/h "set to 1 instead of 0" workaround to one other place that's another on-error fallback