### PR TITLE
 [IIIF-616] Delete uploaded CSV files after PostCsvHandler sends a response

### DIFF
--- a/src/main/java/edu/ucla/library/iiif/fester/verticles/MainVerticle.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/verticles/MainVerticle.java
@@ -33,6 +33,7 @@ import io.vertx.core.http.HttpServer;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.api.contract.openapi3.OpenAPI3RouterFactory;
+import io.vertx.ext.web.handler.BodyHandler;
 import io.vertx.ext.web.handler.StaticHandler;
 
 /**
@@ -84,7 +85,9 @@ public class MainVerticle extends AbstractVerticle {
                             final PostCsvHandler postCsvHandler = new PostCsvHandler(vertx, config);
                             final StaticHandler staticHandler = StaticHandler.create().setWebRoot("webroot");
 
-                            factory.addHandlerByOperationId(Op.POST_CSV, postCsvHandler);
+                            // Make sure uploaded files get deleted
+                            factory.addHandlerByOperationId(Op.POST_CSV, postCsvHandler)
+                                    .setBodyHandler(BodyHandler.create().setDeleteUploadedFilesOnEnd(true));
 
                             // After that, we can get a router that's been configured by our OpenAPI spec
                             router = factory.getRouter();

--- a/src/main/resources/fester_messages.xml
+++ b/src/main/resources/fester_messages.xml
@@ -126,4 +126,6 @@
   <entry key="MFS-131">Failed to upload all the work manifests: {}</entry>
   <entry key="MFS-132">Replacing '{}' with '{}' in collection document</entry>
   <entry key="MFS-133">Getting '{}' from Fester's S3 bucket: {}</entry>
+  <entry key="MFS-134">Uploaded CSV file '{}' still exists on disk {} ms after the handler sent the response</entry>
+  <entry key="MFS-135">Regular expression '{}' does not match '{}'</entry>
 </properties>

--- a/src/test/java/edu/ucla/library/iiif/fester/handlers/DeleteManifestHandlerTest.java
+++ b/src/test/java/edu/ucla/library/iiif/fester/handlers/DeleteManifestHandlerTest.java
@@ -4,8 +4,6 @@ package edu.ucla.library.iiif.fester.handlers;
 import java.io.IOException;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-
 import info.freelibrary.util.Logger;
 import info.freelibrary.util.LoggerFactory;
 import info.freelibrary.util.StringUtils;
@@ -16,9 +14,7 @@ import edu.ucla.library.iiif.fester.HTTP;
 import edu.ucla.library.iiif.fester.MessageCodes;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
-import io.vertx.ext.unit.junit.VertxUnitRunner;
 
-@RunWith(VertxUnitRunner.class)
 public class DeleteManifestHandlerTest extends AbstractManifestHandlerTest {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DeleteManifestHandlerTest.class, Constants.MESSAGES);

--- a/src/test/java/edu/ucla/library/iiif/fester/handlers/GetManifestHandlerTest.java
+++ b/src/test/java/edu/ucla/library/iiif/fester/handlers/GetManifestHandlerTest.java
@@ -5,8 +5,6 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-
 import info.freelibrary.util.Logger;
 import info.freelibrary.util.LoggerFactory;
 import info.freelibrary.util.StringUtils;
@@ -18,9 +16,7 @@ import edu.ucla.library.iiif.fester.MessageCodes;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
-import io.vertx.ext.unit.junit.VertxUnitRunner;
 
-@RunWith(VertxUnitRunner.class)
 public class GetManifestHandlerTest extends AbstractManifestHandlerTest {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(GetManifestHandlerTest.class, Constants.MESSAGES);

--- a/src/test/java/edu/ucla/library/iiif/fester/handlers/PutManifestHandlerTest.java
+++ b/src/test/java/edu/ucla/library/iiif/fester/handlers/PutManifestHandlerTest.java
@@ -6,8 +6,6 @@ import java.io.IOException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-
 import com.amazonaws.SdkClientException;
 
 import info.freelibrary.util.Logger;
@@ -22,9 +20,7 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.RequestOptions;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
-import io.vertx.ext.unit.junit.VertxUnitRunner;
 
-@RunWith(VertxUnitRunner.class)
 public class PutManifestHandlerTest extends AbstractManifestHandlerTest {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(PutManifestHandlerTest.class, Constants.MESSAGES);


### PR DESCRIPTION
- Set a custom BodyHandler on PostCsvHandler that ensures uploaded files are eventually deleted from disk
- Remove some redundant annotations on the handler test classes

(PostCsvHandlerTest has even more repeated code now, so it should be refactored at some point.)