### PR TITLE
[IIIF-632] Update freelib dependency versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,8 @@
     <slf4j.ext.version>1.7.26</slf4j.ext.version>
     <aws.sdk.version>1.11.478</aws.sdk.version>
     <commons.lang.version>3.9</commons.lang.version>
-    <freelib.utils.version>0.8.10</freelib.utils.version>
+    <freelib.utils.version>1.0.2</freelib.utils.version>
+    <freelib.maven.version>0.0.3</freelib.maven.version>
     <jiiify.presentation.version>0.2.0</jiiify.presentation.version>
 
     <!-- Build plug-in versions -->
@@ -209,8 +210,8 @@
       ]]>-->
       <plugin>
         <groupId>info.freelibrary</groupId>
-        <artifactId>freelib-utils</artifactId>
-        <version>${freelib.utils.version}</version>
+        <artifactId>freelib-maven-plugins</artifactId>
+        <version>${freelib.maven.version}</version>
         <executions>
           <execution>
             <phase>process-resources</phase>
@@ -411,6 +412,7 @@
             <fester.http.port>${http.port}</fester.http.port>
             <vertx-config-path>${project.basedir}/target/test-classes/test-config.properties</vertx-config-path>
           </systemPropertyVariables>
+          <argLine>${jacoco.agent.arg}</argLine>
         </configuration>
         <executions>
           <execution>
@@ -420,12 +422,6 @@
             </goals>
           </execution>
         </executions>
-      </plugin>
-
-      <!-- Jacoco does code coverage for the test suite -->
-      <plugin>
-        <groupId>org.jacoco</groupId>
-        <artifactId>jacoco-maven-plugin</artifactId>
       </plugin>
 
       <!-- The Vert.x plug-in enables running the application from within Maven for development -->
@@ -780,6 +776,6 @@
   <parent>
     <artifactId>freelib-parent</artifactId>
     <groupId>info.freelibrary</groupId>
-    <version>3.6.4</version>
+    <version>3.8.2</version>
   </parent>
 </project>

--- a/src/main/resources/checkstyle.xml
+++ b/src/main/resources/checkstyle.xml
@@ -6,6 +6,9 @@
 <!-- Checkstyle-Configuration: FreeLibrary Description: Checkstyle configuration for the FreeLibrary projects -->
 <module name="Checker">
   <property name="severity" value="warning" />
+  <module name="LineLength">
+    <property name="max" value="120" />
+  </module>
   <module name="TreeWalker">
     <module name="RedundantImport" />
     <module name="RedundantModifier" />
@@ -32,9 +35,6 @@
     <module name="FinalClass" />
     <module name="EmptyCatchBlock">
       <property name="exceptionVariableName" value="expected" />
-    </module>
-    <module name="LineLength">
-      <property name="max" value="120" />
     </module>
     <module name="BooleanExpressionComplexity">
       <property name="max" value="4" />

--- a/src/main/resources/fester.yaml
+++ b/src/main/resources/fester.yaml
@@ -10,7 +10,7 @@ x-tagGroups:
     tags:
       - Collection
 info:
-  version: 0.1.0
+  version: 0.2.0
   title: Fester API
   description: "Fester, a IIIF manifest storage microservice, provides a simple storage and retrieval system
     for IIIF manifests. Amazon S3 is required. For more details on how to construct a IIIF manifest, consult these

--- a/src/test/java/edu/ucla/library/iiif/fester/it/ManifestUploadIT.java
+++ b/src/test/java/edu/ucla/library/iiif/fester/it/ManifestUploadIT.java
@@ -70,23 +70,26 @@ public class ManifestUploadIT {
     public final void test1_CheckThatServiceIsUp(final TestContext aContext) {
         final Async asyncTask = aContext.async();
 
-        // First, let's sanity-check our service status endpoint before we do anything real
-        myVertx.createHttpClient().getNow(PORT, Constants.UNSPECIFIED_HOST, STATUS, response -> {
-            final int statusCode = response.statusCode();
+        // Give our Jar-based application a second or two to start up
+        myVertx.setTimer(2000, timer -> {
+            // First, let's sanity-check our service status endpoint before we do anything real
+            myVertx.createHttpClient().getNow(PORT, Constants.UNSPECIFIED_HOST, STATUS, response -> {
+                final int statusCode = response.statusCode();
 
-            // Validate the response
-            if (statusCode == HTTP.OK) {
-                response.bodyHandler(body -> {
-                    aContext.assertEquals(body.getString(0, body.length()), HELLO);
-                    LOGGER.info(MessageCodes.MFS_030);
-                });
+                // Validate the response
+                if (statusCode == HTTP.OK) {
+                    response.bodyHandler(body -> {
+                        aContext.assertEquals(body.getString(0, body.length()), HELLO);
+                        LOGGER.info(MessageCodes.MFS_030);
+                    });
 
-                if (!asyncTask.isCompleted()) {
-                    asyncTask.complete();
+                    if (!asyncTask.isCompleted()) {
+                        asyncTask.complete();
+                    }
+                } else {
+                    aContext.fail(LOGGER.getMessage(MessageCodes.MFS_031));
                 }
-            } else {
-                aContext.fail(LOGGER.getMessage(MessageCodes.MFS_031));
-            }
+            });
         });
     }
 

--- a/src/test/scripts/post-it-shutdown.sh
+++ b/src/test/scripts/post-it-shutdown.sh
@@ -1,6 +1,5 @@
 #! /bin/sh
 
 # We have to provide a little wrapper script for exec-maven-plugin to background our job
-$* > /dev/null 2>&1 &
-echo $! > fester-it.pid
-exit 0
+kill `cat fester-it.pid`
+rm fester-it.pid

--- a/src/test/scripts/pre-it-startup.sh
+++ b/src/test/scripts/pre-it-startup.sh
@@ -1,6 +1,7 @@
 #! /bin/sh
 
 # We have to provide a little wrapper script for exec-maven-plugin to background our job
+echo "$*"
 $* > /dev/null 2>&1 &
 echo $! > fester-it.pid
 exit 0


### PR DESCRIPTION
* Update version of the parent project to pull in the latest and greatest conveniences
* Update freelib-utils to the split freelib-utils/freelib-maven-plugins versions to reduce output Jar size
* Update IT script to give the application a little more time to start before IT tests are run against it
* Update Fester API version in the OpenAPI documentation/spec
* Removed Jacoco plugin because that's now handled by a profile in the parent project