### PR TITLE
[IIIF-597] Check well-formedness of project's XML files

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
     <vertx.super.s3.version>1.2.1</vertx.super.s3.version>
     <jcip.annotations.version>1.0-1</jcip.annotations.version>
     <maven.failsafe.plugin.version>2.18.1</maven.failsafe.plugin.version>
-    <xml.maven.plugin.version>0.9.2</xml.maven.plugin.version>
+    <xml.maven.plugin.version>1.0.2</xml.maven.plugin.version>
 
     <!-- Name of the main Vert.x verticle -->
     <main.verticle>edu.ucla.library.iiif.fester.verticles.MainVerticle</main.verticle>
@@ -648,25 +648,34 @@
           </execution>
         </executions>
       </plugin>
-      
-      <!--  Validate all XML and XSL in the project during the validate phase -->
+
+      <!-- Check the well-formedness of the project's XML files -->
       <plugin>
-        <groupId>org.openjax.xml</groupId>
+        <groupId>org.codehaus.mojo</groupId>
         <artifactId>xml-maven-plugin</artifactId>
         <version>${xml.maven.plugin.version}</version>
         <executions>
           <execution>
+            <phase>validate</phase>
             <goals>
               <goal>validate</goal>
             </goals>
-            <configuration>
-              <includes>
-                <include>**/*.xsd</include>
-                <include>**/*.xml</include>
-              </includes>
-            </configuration>
           </execution>
         </executions>
+        <configuration>
+          <validationSets>
+            <validationSet>
+              <dir>src/main/resources</dir>
+              <includes>fester_messages.xml</includes>
+              <includes>checkstyle.xml</includes>
+              <includes>logback.xml</includes>
+            </validationSet>
+            <validationSet>
+              <dir>src/test/resources</dir>
+              <includes>logback-test.xml</includes>
+            </validationSet>
+          </validationSets>
+        </configuration>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
The old xml-maven-plugin we were using couldn't check the well-formedness of XML files without also trying to validate them (our XML files don't have schemas so our builds had misleading WARNING messages). In this PR we switch to a XML file checking plugin that can check well-formedness.