### PR TITLE
[IIIF-649] Fix typo bug

### DIFF
--- a/src/main/java/edu/ucla/library/iiif/fester/verticles/ManifestVerticle.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/verticles/ManifestVerticle.java
@@ -549,7 +549,7 @@ public class ManifestVerticle extends AbstractFesterVerticle {
             canvas.addImageContent(imageContent);
 
             if (aCsvHeaders.hasViewingHintIndex()) {
-                final String viewingHint = StringUtils.trimToNull(columns[aCsvHeaders.getTitleIndex()]);
+                final String viewingHint = StringUtils.trimToNull(columns[aCsvHeaders.getViewingHintIndex()]);
 
                 if (viewingHint != null) {
                     canvas.setViewingHint(new ViewingHint(viewingHint));


### PR DESCRIPTION
Fix typo that caused a RuntimeException to be thrown when a work's Title value wasn't a valid viewingHint.