### PR TITLE
[IIIF-589] Put work manifests in a "works" directory inside S3 bucket

### DIFF
--- a/src/main/java/edu/ucla/library/iiif/fester/Constants.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/Constants.java
@@ -107,6 +107,11 @@ public final class Constants {
     public static final String MANIFEST_URI_PATH_SUFFIX = "/manifest";
 
     /**
+     * The prefix for work manifest S3 keys.
+     */
+    public static final String WORK_S3_KEY_PREFIX = "works/";
+
+    /**
      * The prefix for collection manifest S3 keys.
      */
     public static final String COLLECTION_S3_KEY_PREFIX = "collections/";

--- a/src/main/java/edu/ucla/library/iiif/fester/utils/IDUtils.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/utils/IDUtils.java
@@ -91,6 +91,7 @@ public final class IDUtils {
         if (aS3Key.contains(Constants.COLLECTION_S3_KEY_PREFIX)) {
             path = Constants.COLLECTION_URI_PATH_PREFIX + encodedID;
         } else {
+            // TODO: check (aS3Key.contains(Constants.WORK_S3_KEY_PREFIX))
             path = Constants.SLASH + encodedID + Constants.MANIFEST_URI_PATH_SUFFIX;
         }
         return path;
@@ -107,7 +108,8 @@ public final class IDUtils {
         if (aS3Key.contains(Constants.COLLECTION_S3_KEY_PREFIX)) {
             s3KeyPrefix = Constants.COLLECTION_S3_KEY_PREFIX;
         } else {
-            s3KeyPrefix = Constants.EMPTY;
+            // TODO: check (aS3Key.contains(Constants.WORK_S3_KEY_PREFIX))
+            s3KeyPrefix = Constants.WORK_S3_KEY_PREFIX;
         }
         return FileUtils.stripExt(aS3Key.substring(s3KeyPrefix.length()));
     }
@@ -141,8 +143,9 @@ public final class IDUtils {
             s3KeyPrefix = Constants.COLLECTION_S3_KEY_PREFIX;
             endIndex = path.length();
         } else {
+            // TODO: check (path.contains(Constants.MANIFEST_URI_PATH_SUFFIX))
             uriPathPrefix = Constants.SLASH;
-            s3KeyPrefix = Constants.EMPTY;
+            s3KeyPrefix = Constants.WORK_S3_KEY_PREFIX;
             endIndex = path.length() - Constants.MANIFEST_URI_PATH_SUFFIX.length();
         }
         encodedID = path.substring(uriPathPrefix.length(), endIndex);
@@ -158,7 +161,7 @@ public final class IDUtils {
      * @return An S3 key
      */
     public static String getWorkS3Key(final String aID) {
-        return aID + Constants.DOT + Constants.JSON_EXT;
+        return Constants.WORK_S3_KEY_PREFIX + aID + Constants.DOT + Constants.JSON_EXT;
     }
 
     /**
@@ -173,9 +176,9 @@ public final class IDUtils {
     @Deprecated
     public static String getWorkS3Key(final String aID, final String aExt) {
         if (FileUtils.getExt(aID).equals(aExt)) {
-            return aID;
+            return Constants.WORK_S3_KEY_PREFIX + aID;
         } else {
-            return aID + Constants.DOT + aExt;
+            return Constants.WORK_S3_KEY_PREFIX + aID + Constants.DOT + aExt;
         }
     }
 

--- a/src/test/java/edu/ucla/library/iiif/fester/handlers/AbstractFesterHandlerTest.java
+++ b/src/test/java/edu/ucla/library/iiif/fester/handlers/AbstractFesterHandlerTest.java
@@ -57,6 +57,8 @@ abstract class AbstractFesterHandlerTest {
 
     protected String myS3Bucket;
 
+    protected String myManifestID;
+
     protected String myManifestS3Key;
 
     /**
@@ -79,7 +81,8 @@ abstract class AbstractFesterHandlerTest {
         options.setConfig(new JsonObject().put(Config.HTTP_PORT, port).put(Config.IIIF_BASE_URL, IIIF_URL));
         socket.close();
 
-        myManifestS3Key = IDUtils.getWorkS3Key(UUID.randomUUID().toString());
+        myManifestID = UUID.randomUUID().toString();
+        myManifestS3Key = IDUtils.getWorkS3Key(myManifestID);
 
         // We only need to initialize our testing tools once; if done, skip
         if (myVertx == null) {

--- a/src/test/java/edu/ucla/library/iiif/fester/handlers/PutManifestHandlerTest.java
+++ b/src/test/java/edu/ucla/library/iiif/fester/handlers/PutManifestHandlerTest.java
@@ -2,6 +2,7 @@
 package edu.ucla.library.iiif.fester.handlers;
 
 import java.io.IOException;
+import java.util.UUID;
 
 import org.junit.After;
 import org.junit.Before;
@@ -24,6 +25,8 @@ public class PutManifestHandlerTest extends AbstractFesterHandlerTest {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(PutManifestHandlerTest.class, Constants.MESSAGES);
 
+    private String myPutManifestID;
+
     private String myPutManifestS3Key;
 
     /**
@@ -38,7 +41,8 @@ public class PutManifestHandlerTest extends AbstractFesterHandlerTest {
 
         final String putPrefix = "PUT_";
 
-        myPutManifestS3Key = putPrefix + myManifestS3Key;
+        myPutManifestID = putPrefix + UUID.randomUUID().toString();
+        myPutManifestS3Key = IDUtils.getWorkS3Key(myPutManifestID);
     }
 
     /**

--- a/src/test/java/edu/ucla/library/iiif/fester/utils/IDUtilsTest.java
+++ b/src/test/java/edu/ucla/library/iiif/fester/utils/IDUtilsTest.java
@@ -21,7 +21,7 @@ public class IDUtilsTest {
 
     private static final String WORK_MANIFEST_URI = FAKE_HOST + WORK_MANIFEST_URI_PATH;
 
-    private static final String WORK_MANIFEST_S3_KEY = "ark:/21198/zz000bjfsv.json";
+    private static final String WORK_MANIFEST_S3_KEY = "works/ark:/21198/zz000bjfsv.json";
 
 
     private static final String COLLECTION_MANIFEST_ID = "ark:/21198/zz0009gss9";

--- a/src/test/java/edu/ucla/library/iiif/fester/verticles/ManifestVerticleTest.java
+++ b/src/test/java/edu/ucla/library/iiif/fester/verticles/ManifestVerticleTest.java
@@ -28,6 +28,7 @@ import edu.ucla.library.iiif.fester.Config;
 import edu.ucla.library.iiif.fester.Constants;
 import edu.ucla.library.iiif.fester.ImageInfoLookup;
 import edu.ucla.library.iiif.fester.MessageCodes;
+import edu.ucla.library.iiif.fester.utils.IDUtils;
 import io.vertx.core.DeploymentOptions;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
@@ -130,7 +131,7 @@ public class ManifestVerticleTest {
     @Test
     public final void testSinaiWorksManifest(final TestContext aContext) {
         final String jsonFile = myJsonFiles + Constants.SLASH
-                + URLEncoder.encode("ark:/21198/z16t1r0h.json", StandardCharsets.UTF_8);
+                + URLEncoder.encode(IDUtils.getWorkS3Key("ark:/21198/z16t1r0h"), StandardCharsets.UTF_8);
         final String path = StringUtils.format(SINAI_WORKS_CSV, SINAI);
         final JsonObject message = new JsonObject();
         final Async asyncTask = aContext.async();
@@ -264,7 +265,8 @@ public class ManifestVerticleTest {
      */
     @Test
     public final void testPageOrder(final TestContext aContext) {
-        final String foundFile = myJsonFiles + "/ark%3A%2F21198%2Fz12f8rtw.json";
+        final String foundFile = myJsonFiles + Constants.SLASH
+                + URLEncoder.encode(IDUtils.getWorkS3Key("ark:/21198/z12f8rtw"), StandardCharsets.UTF_8);
         final String expectedFile = "src/test/resources/json/pages-ordered.json";
         final String filePath = "src/test/resources/csv/ara249.csv";
         final JsonObject message = new JsonObject();


### PR DESCRIPTION
- prefix work manifest S3 keys with "works/"
- add TODOs for better checking of resource types in the future (didn't attempt to fix now since would require callers of those IDUtils methods to handle exceptions thrown by them)