### PR TITLE
[IIIF-690] Work around Cantaloupe returning a 403 for a 404 image

### DIFF
--- a/src/main/java/edu/ucla/library/iiif/fester/ImageInfoLookup.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/ImageInfoLookup.java
@@ -37,7 +37,7 @@ public class ImageInfoLookup {
      *
      * @param aURL A URL for an image's info.json file
      */
-    public ImageInfoLookup(final String aURL) throws MalformedURLException, IOException, ManifestNotFoundException {
+    public ImageInfoLookup(final String aURL) throws MalformedURLException, IOException, ImageNotFoundException {
         LOGGER.debug(MessageCodes.MFS_072, aURL);
 
         // If our images are using an unspecified host, we're running in test mode and will use fake values
@@ -75,9 +75,10 @@ public class ImageInfoLookup {
                         LOGGER.warn(MessageCodes.MFS_073, aURL);
                     }
                 }
-            } else if (responseCode == 404) {
+            } else if (responseCode == HTTP.NOT_FOUND || responseCode == HTTP.FORBIDDEN) {
+                // Cantaloupe returns 403 for not found images sometimes (which seems like a bug?)
                 final String id = IDUtils.getResourceID(URI.create(aURL));
-                throw new ManifestNotFoundException(MessageCodes.MFS_070, id);
+                throw new ImageNotFoundException(MessageCodes.MFS_070, id);
             } else {
                 final String responseMessage = connection.getResponseMessage();
                 throw new IOException(LOGGER.getMessage(MessageCodes.MFS_071, responseCode, responseMessage));

--- a/src/main/java/edu/ucla/library/iiif/fester/ImageInfoLookup.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/ImageInfoLookup.java
@@ -51,7 +51,7 @@ public class ImageInfoLookup {
             connection.setReadTimeout(CANTALOUPE_TIMEOUT);
             responseCode = connection.getResponseCode();
 
-            if (responseCode == 200) {
+            if (responseCode == HTTP.OK) {
                 final InputStream inStream = new BufferedInputStream(connection.getInputStream());
                 final StringBuilder result = new StringBuilder();
                 final JsonObject jsonObject;

--- a/src/main/java/edu/ucla/library/iiif/fester/ImageNotFoundException.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/ImageNotFoundException.java
@@ -4,17 +4,17 @@ package edu.ucla.library.iiif.fester;
 import info.freelibrary.util.I18nException;
 
 /**
- * An exception thrown when the manifest couldn't be found on the IIIF server.
+ * An exception thrown when an image can't be found on the IIIF server.
  */
 public class ImageNotFoundException extends I18nException {
 
     /**
-     * The <code>serialVersionUID</code> for a ManifestNotFoundException.
+     * The <code>serialVersionUID</code> for an ImageNotFoundException.
      */
     private static final long serialVersionUID = -1307404135679864330L;
 
     /**
-     * Creates a new manifest not found exception.
+     * Creates a new image not found exception.
      *
      * @param aMessageCode A message code
      */
@@ -23,7 +23,7 @@ public class ImageNotFoundException extends I18nException {
     }
 
     /**
-     * Creates a new manifest not found exception.
+     * Creates a new image not found exception.
      *
      * @param aMessageCode A message code
      * @param aDetails Additional details about the exception

--- a/src/main/java/edu/ucla/library/iiif/fester/ImageNotFoundException.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/ImageNotFoundException.java
@@ -6,7 +6,7 @@ import info.freelibrary.util.I18nException;
 /**
  * An exception thrown when the manifest couldn't be found on the IIIF server.
  */
-public class ManifestNotFoundException extends I18nException {
+public class ImageNotFoundException extends I18nException {
 
     /**
      * The <code>serialVersionUID</code> for a ManifestNotFoundException.
@@ -18,7 +18,7 @@ public class ManifestNotFoundException extends I18nException {
      *
      * @param aMessageCode A message code
      */
-    public ManifestNotFoundException(final String aMessageCode) {
+    public ImageNotFoundException(final String aMessageCode) {
         super(Constants.MESSAGES, aMessageCode);
     }
 
@@ -28,7 +28,7 @@ public class ManifestNotFoundException extends I18nException {
      * @param aMessageCode A message code
      * @param aDetails Additional details about the exception
      */
-    public ManifestNotFoundException(final String aMessageCode, final Object... aDetails) {
+    public ImageNotFoundException(final String aMessageCode, final Object... aDetails) {
         super(Constants.MESSAGES, aMessageCode, aDetails);
     }
 

--- a/src/main/java/edu/ucla/library/iiif/fester/verticles/ManifestVerticle.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/verticles/ManifestVerticle.java
@@ -42,8 +42,8 @@ import edu.ucla.library.iiif.fester.CsvHeaders;
 import edu.ucla.library.iiif.fester.CsvMetadata;
 import edu.ucla.library.iiif.fester.CsvParsingException;
 import edu.ucla.library.iiif.fester.ImageInfoLookup;
+import edu.ucla.library.iiif.fester.ImageNotFoundException;
 import edu.ucla.library.iiif.fester.LockedManifest;
-import edu.ucla.library.iiif.fester.ManifestNotFoundException;
 import edu.ucla.library.iiif.fester.MessageCodes;
 import edu.ucla.library.iiif.fester.ObjectType;
 import edu.ucla.library.iiif.fester.Op;
@@ -510,17 +510,21 @@ public class ManifestVerticle extends AbstractFesterVerticle {
             try {
                 final ImageInfoLookup infoLookup = new ImageInfoLookup(pageURI);
 
+                // Create a canvas using the width and height of the related image
                 canvas = new Canvas(canvasID, pageLabel, infoLookup.getWidth(), infoLookup.getHeight());
-            } catch (final ManifestNotFoundException details) {
+            } catch (final ImageNotFoundException details) {
                 final int width;
                 final int height;
+
+                // Note that we couldn't find the image and are trying to provide a workaround
+                LOGGER.debug(MessageCodes.MFS_078);
 
                 // First check the last canvas that we've processed (if there is one)
                 if (lastCanvas != null) {
                     width = lastCanvas.getWidth();
                     height = lastCanvas.getHeight();
                 } else {
-                    // If we've not processed any, check to sequence to find one
+                    // If we've not processed any, check the sequence to find one
                     final List<Canvas> canvases = aSequence.getCanvases();
 
                     // If there is one use that; else, just use zeros for the w/h values

--- a/src/main/resources/fester_messages.xml
+++ b/src/main/resources/fester_messages.xml
@@ -91,6 +91,7 @@
   <entry key="MFS-075">Multiple temporary fake s3 directories matching '{}' found</entry>
   <entry key="MFS-076">The '{}' verticle's ID [{}] has been registered in the application's shared data map</entry>
   <entry key="MFS-077">Verticle deployment key not found in shared data map: {}</entry>
+  <entry key="MFS-078">Image for w/h lookup wasn't found; trying to find a sibling image</entry>
 
   <entry key="MFS-100">Stopping the {} verticle [id: {}]</entry>
   <entry key="MFS-101">Getting message consumer for: {}</entry>


### PR DESCRIPTION
Image w/h lookups were failing despite us having a fallback mechanism in place for supplying a w/h that's a "good enough" guess. This is happening because Cantaloupe returns a 403 response code for an image that can't be found in S3 (and we're checking for a 404). This PR treats 403s from Cantaloupe like they were 404s. It also renames ManifestNotFoundException to ImageNotFoundException because it's actually an image that can't be found, not a manifest.