### PR TITLE
[IIIF-698] Update generated API documentation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>fester</artifactId>
-  <version>0.0.1-SNAPSHOT</version>
+  <version>0.3.1-SNAPSHOT</version>
   <name>IIIF Fester</name>
   <description>A read/write interface for storing and retrieving IIIF manifests</description>
   <url>https://github.com/uclalibrary/fester</url>
@@ -197,6 +197,12 @@
   </dependencies>
 
   <build>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
     <testResources>
       <testResource>
         <directory>src/test/resources</directory>
@@ -241,7 +247,7 @@
         <executions>
           <execution>
             <id>copy-web-resources</id>
-            <phase>validate</phase>
+            <phase>process-resources</phase>
             <goals>
               <goal>copy-resources</goal>
             </goals>
@@ -252,7 +258,7 @@
                   <directory>${basedir}/src/main/webroot</directory>
                 </resource>
                 <resource>
-                  <directory>${basedir}/src/main/resources</directory>
+                  <directory>${basedir}/target/classes</directory>
                   <includes>
                     <include>fester.yaml</include>
                   </includes>
@@ -728,6 +734,7 @@
                       <filtering>true</filtering>
                       <includes>
                         <include>logback.xml</include>
+                        <include>fester.yaml</include>
                       </includes>
                     </resource>
                   </resources>

--- a/src/main/resources/fester.yaml
+++ b/src/main/resources/fester.yaml
@@ -5,12 +5,14 @@ x-tagGroups:
   - name: Implemented
     tags:
       - Manifest
+      - Collection
       - Utility
   - name: Proposed
     tags:
-      - Collection
+      - Collection (Proposed)
+
 info:
-  version: 0.2.0
+  version: ${project.version}
   title: Fester API
   description: "Fester, a IIIF manifest storage microservice, provides a simple storage and retrieval system
     for IIIF manifests. Amazon S3 is required. For more details on how to construct a IIIF manifest, consult these
@@ -100,7 +102,7 @@ paths:
                 format: binary
   /collections/{collectionName}:
     get:
-      tags: [Collection, Proposed]
+      tags: [Collection]
       summary: Get a collection
       description: Gets a specified collection.
       operationId: getCollection
@@ -110,7 +112,7 @@ paths:
         '404':
           description: Not found
     put:
-      tags: [Collection, Proposed]
+      tags: [Collection (Proposed)]
       summary: Put a collection
       description: Puts a provided IIIF collection.
       operationId: putCollection
@@ -133,7 +135,7 @@ paths:
         '500':
           description: Internal server error
     delete:
-      tags: [Collection, Proposed]
+      tags: [Collection (Proposed)]
       summary: Delete a collection
       description: Deletes a specified collection.
       operationId: deleteCollection

--- a/src/main/webroot/index.html
+++ b/src/main/webroot/index.html
@@ -26,7 +26,7 @@
     <div class="collapse navbar-collapse" id="navbarNavAltMarkup">
       <div class="navbar-nav">
         <a class="nav-item nav-link active"
-          href="/docs">API Documentation</a>
+          href="/docs/fester">API Documentation</a>
       </div>
     </div>
   </nav>


### PR DESCRIPTION
* Add actual version number to POM in preparation for doing deployments through Maven
* Filter the fester.yaml OpenAPI spec file in the Maven build process, adding version to it
* Change the Maven phase of the webroot population to catch the newly filtered file
* Change the location of the fester.yaml that the webroot population uses to use newly filtered file
* Fix the "API documentation" link in the HTML page to correctly point to the documentation
* Move the implemented collection GET to the "Implemented" tag, leaving just PUT and DELETE as "Proposed"