### PR TITLE
[IIIF-644] Implement PUT for collection docs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>fester</artifactId>
-  <version>0.3.1-SNAPSHOT</version>
+  <version>0.4.0-SNAPSHOT</version>
   <name>IIIF Fester</name>
   <description>A read/write interface for storing and retrieving IIIF manifests</description>
   <url>https://github.com/uclalibrary/fester</url>

--- a/src/main/java/edu/ucla/library/iiif/fester/Constants.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/Constants.java
@@ -17,6 +17,17 @@ public final class Constants {
     public static final String UNSPECIFIED_HOST = "0.0.0.0";
 
     /**
+     * The message header key associated with the Fester operation (HTTP request) that caused the message send.
+     */
+    public static final String ACTION = "action";
+
+    /**
+     * The message body key associated with the Fester operation input data (HTTP request body) that caused the message
+     * send.
+     */
+    public static final String DATA = "data";
+
+    /**
      * The name of the manifest ID parameter.
      */
     public static final String MANIFEST_ID = "manifestId";

--- a/src/main/java/edu/ucla/library/iiif/fester/handlers/AbstractFesterHandler.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/handlers/AbstractFesterHandler.java
@@ -62,29 +62,30 @@ abstract class AbstractFesterHandler implements Handler<RoutingContext> {
     /**
      * Sends a message to another verticle with a supplied timeout value.
      *
-     * @param aJsonObject A JSON message
      * @param aVerticleName A verticle name that will respond to the message
-     * @param aTimeout A timeout measured in milliseconds
+     * @param aMessage A JSON message
+     * @param aHeaders Message headers
      * @param aHandler A handler to handle the result of the message delivery
+     * @param aTimeout A timeout measured in milliseconds
      */
-    protected void sendMessage(final String aVerticleName, final JsonObject aJsonObject, final long aTimeout,
-            final Handler<AsyncResult<Message<JsonObject>>> aHandler) {
-        final DeliveryOptions options = new DeliveryOptions().setSendTimeout(aTimeout);
+    protected void sendMessage(final String aVerticleName, final JsonObject aMessage, final DeliveryOptions aHeaders,
+            final long aTimeout, final Handler<AsyncResult<Message<JsonObject>>> aHandler) {
+        aHeaders.setSendTimeout(aTimeout);
 
-        LOGGER.debug(MessageCodes.MFS_102, aVerticleName, aJsonObject.encodePrettily());
-        myVertx.eventBus().request(aVerticleName, aJsonObject, options, aHandler);
+        LOGGER.debug(MessageCodes.MFS_102, aVerticleName, aMessage.encodePrettily());
+        myVertx.eventBus().request(aVerticleName, aMessage, aHeaders, aHandler);
     }
 
     /**
      * Send a message to another verticle.
      *
-     * @param aJsonObject A JSON message
      * @param aVerticleName A verticle name that will respond to the message
+     * @param aMessage A JSON message
+     * @param aHeaders Message headers
      * @param aHandler A handler to handle the result of the message delivery
      */
-    protected void sendMessage(final String aVerticleName, final JsonObject aJsonObject,
+    protected void sendMessage(final String aVerticleName, final JsonObject aMessage, final DeliveryOptions aHeaders,
             final Handler<AsyncResult<Message<JsonObject>>> aHandler) {
-        sendMessage(aVerticleName, aJsonObject, DeliveryOptions.DEFAULT_TIMEOUT, aHandler);
+        sendMessage(aVerticleName, aMessage, aHeaders, DeliveryOptions.DEFAULT_TIMEOUT, aHandler);
     }
-
 }

--- a/src/main/java/edu/ucla/library/iiif/fester/handlers/GetCollectionHandler.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/handlers/GetCollectionHandler.java
@@ -50,7 +50,7 @@ public class GetCollectionHandler extends AbstractFesterHandler implements Handl
             } else {
                 final Throwable aThrowable = send.cause();
                 final String exceptionMessage = aThrowable.getMessage();
-                final String errorMessage = LOGGER.getMessage(MessageCodes.MFS_009, exceptionMessage);
+                final String errorMessage = LOGGER.getMessage(MessageCodes.MFS_009, collectionName);
 
                 LOGGER.error(aThrowable, errorMessage);
 

--- a/src/main/java/edu/ucla/library/iiif/fester/handlers/PutCollectionHandler.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/handlers/PutCollectionHandler.java
@@ -1,0 +1,60 @@
+package edu.ucla.library.iiif.fester.handlers;
+
+import edu.ucla.library.iiif.fester.Constants;
+import edu.ucla.library.iiif.fester.HTTP;
+import edu.ucla.library.iiif.fester.MessageCodes;
+import edu.ucla.library.iiif.fester.Op;
+import edu.ucla.library.iiif.fester.verticles.S3BucketVerticle;
+import info.freelibrary.util.Logger;
+import info.freelibrary.util.LoggerFactory;
+import io.vertx.core.Vertx;
+import io.vertx.core.eventbus.DeliveryOptions;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.RoutingContext;
+
+public class PutCollectionHandler extends AbstractFesterHandler {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PutCollectionHandler.class, Constants.MESSAGES);
+
+    /**
+     * Creates a handler that creates IIIF collection manifests in Fester.
+     *
+     * @param aVertx A Vert.x instance
+     * @param aConfig A JSON configuration
+     */
+    public PutCollectionHandler(final Vertx aVertx, final JsonObject aConfig) {
+        super(aVertx, aConfig);
+    }
+
+    @Override
+    public void handle(final RoutingContext aContext) {
+        final HttpServerResponse response = aContext.response();
+        final String collectionName = aContext.request().getParam(Constants.COLLECTION_NAME);
+        final JsonObject message = new JsonObject();
+        final DeliveryOptions options = new DeliveryOptions();
+
+        message.put(Constants.COLLECTION_NAME, collectionName).put(Constants.DATA, aContext.getBodyAsJson());
+        options.addHeader(Constants.ACTION, Op.PUT_COLLECTION);
+
+        sendMessage(S3BucketVerticle.class.getName(), message, options, send -> {
+            if (send.succeeded()) {
+                response.setStatusCode(HTTP.OK);
+                response.end();
+            } else {
+                final Throwable aThrowable = send.cause();
+                final String exceptionMessage;
+                final String errorMessage;
+
+                exceptionMessage = aThrowable.getMessage();
+                errorMessage = LOGGER.getMessage(MessageCodes.MFS_015, exceptionMessage);
+
+                LOGGER.error(aThrowable, errorMessage);
+
+                response.setStatusCode(HTTP.INTERNAL_SERVER_ERROR);
+                response.setStatusMessage(exceptionMessage);
+                response.end(errorMessage);
+            }
+        });
+    }
+}

--- a/src/main/java/edu/ucla/library/iiif/fester/handlers/PutCollectionHandler.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/handlers/PutCollectionHandler.java
@@ -39,21 +39,15 @@ public class PutCollectionHandler extends AbstractFesterHandler {
 
         sendMessage(S3BucketVerticle.class.getName(), message, options, send -> {
             if (send.succeeded()) {
-                response.setStatusCode(HTTP.OK);
-                response.end();
+                response.setStatusCode(HTTP.OK).end();
             } else {
                 final Throwable aThrowable = send.cause();
-                final String exceptionMessage;
-                final String errorMessage;
-
-                exceptionMessage = aThrowable.getMessage();
-                errorMessage = LOGGER.getMessage(MessageCodes.MFS_015, exceptionMessage);
+                final String exceptionMessage = aThrowable.getMessage();
+                final String errorMessage = LOGGER.getMessage(MessageCodes.MFS_015, exceptionMessage);
 
                 LOGGER.error(aThrowable, errorMessage);
 
-                response.setStatusCode(HTTP.INTERNAL_SERVER_ERROR);
-                response.setStatusMessage(exceptionMessage);
-                response.end(errorMessage);
+                response.setStatusCode(HTTP.INTERNAL_SERVER_ERROR).setStatusMessage(exceptionMessage).end(errorMessage);
             }
         });
     }

--- a/src/main/java/edu/ucla/library/iiif/fester/verticles/AbstractFesterVerticle.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/verticles/AbstractFesterVerticle.java
@@ -6,7 +6,6 @@ import info.freelibrary.util.LoggerFactory;
 
 import edu.ucla.library.iiif.fester.Constants;
 import edu.ucla.library.iiif.fester.MessageCodes;
-import edu.ucla.library.iiif.fester.ObjectType;
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
@@ -57,55 +56,30 @@ public abstract class AbstractFesterVerticle extends AbstractVerticle {
     /**
      * Sends a message to another verticle with a supplied timeout value.
      *
-     * @param aJsonObject A JSON message
      * @param aVerticleName A verticle name that will respond to the message
-     * @param aTimeout A timeout measured in milliseconds
+     * @param aMessage A JSON message
+     * @param aHeaders Message headers
      * @param aHandler A handler to handle the result of the message delivery
+     * @param aTimeout A timeout measured in milliseconds
      */
-    protected void sendMessage(final JsonObject aJsonObject, final String aVerticleName, final long aTimeout,
-            final Handler<AsyncResult<Message<JsonObject>>> aHandler) {
-        final DeliveryOptions options = new DeliveryOptions().setSendTimeout(aTimeout);
+    protected void sendMessage(final String aVerticleName, final JsonObject aMessage, final DeliveryOptions aHeaders,
+            final long aTimeout, final Handler<AsyncResult<Message<JsonObject>>> aHandler) {
+        aHeaders.setSendTimeout(aTimeout);
 
-        LOGGER.debug(MessageCodes.MFS_102, aVerticleName, aJsonObject.encode());
-        vertx.eventBus().request(aVerticleName, aJsonObject, options, aHandler);
+        LOGGER.debug(MessageCodes.MFS_102, aVerticleName, aMessage.encodePrettily());
+        vertx.eventBus().request(aVerticleName, aMessage, aHeaders, aHandler);
     }
 
     /**
      * Send a message to another verticle.
      *
-     * @param aJsonObject A JSON message
      * @param aVerticleName A verticle name that will respond to the message
+     * @param aMessage A JSON message
+     * @param aHeaders Message headers
      * @param aHandler A handler to handle the result of the message delivery
      */
-    protected void sendMessage(final JsonObject aJsonObject, final String aVerticleName,
+    protected void sendMessage(final String aVerticleName, final JsonObject aMessage, final DeliveryOptions aHeaders,
             final Handler<AsyncResult<Message<JsonObject>>> aHandler) {
-        sendMessage(aJsonObject, aVerticleName, DeliveryOptions.DEFAULT_TIMEOUT, aHandler);
-    }
-
-    /**
-     * Sends an ID to the supplied verticle.
-     *
-     * @param aID A manifest ID
-     * @param aManifestType The type of manifest (work or collection) to get
-     * @param aVerticleName The name of the verticle to which to send the ID
-     * @param aHandler A handler to handle the result of sending the ID
-     */
-    protected void getS3Manifest(final String aID, final ObjectType aManifestType, final String aVerticleName,
-            final Handler<AsyncResult<Message<JsonObject>>> aHandler) {
-        getS3Manifest(aID, aManifestType, aVerticleName, DeliveryOptions.DEFAULT_TIMEOUT, aHandler);
-    }
-
-    /**
-     * Sends an ID to the supplied verticle.
-     *
-     * @param aID A manifest ID\
-     * @param aManifestType The type of manifest (work or collection) to get
-     * @param aVerticleName The name of the verticle to which to send the ID
-     * @param aTimeout A timeout after which to give up waiting for a response
-     * @param aHandler A handler to handle the result of sending the ID
-     */
-    protected void getS3Manifest(final String aID, final ObjectType aManifestType, final String aVerticleName,
-            final long aTimeout, final Handler<AsyncResult<Message<JsonObject>>> aHandler) {
-        sendMessage(new JsonObject().put(aManifestType.getValue(), aID), aVerticleName, aTimeout, aHandler);
+        sendMessage(aVerticleName, aMessage, aHeaders, DeliveryOptions.DEFAULT_TIMEOUT, aHandler);
     }
 }

--- a/src/main/java/edu/ucla/library/iiif/fester/verticles/MainVerticle.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/verticles/MainVerticle.java
@@ -21,6 +21,7 @@ import edu.ucla.library.iiif.fester.handlers.GetManifestHandler;
 import edu.ucla.library.iiif.fester.handlers.GetStatusHandler;
 import edu.ucla.library.iiif.fester.handlers.MatchingOpNotFoundHandler;
 import edu.ucla.library.iiif.fester.handlers.PostCsvHandler;
+import edu.ucla.library.iiif.fester.handlers.PutCollectionHandler;
 import edu.ucla.library.iiif.fester.handlers.PutManifestHandler;
 import io.vertx.config.ConfigRetriever;
 import io.vertx.config.ConfigRetrieverOptions;
@@ -81,6 +82,7 @@ public class MainVerticle extends AbstractVerticle {
                         factory.addHandlerByOperationId(Op.PUT_MANIFEST, new PutManifestHandler(vertx, config));
                         factory.addHandlerByOperationId(Op.DELETE_MANIFEST, new DeleteManifestHandler(vertx, config));
                         factory.addHandlerByOperationId(Op.GET_COLLECTION, new GetCollectionHandler(vertx, config));
+                        factory.addHandlerByOperationId(Op.PUT_COLLECTION, new PutCollectionHandler(vertx, config));
 
                         try {
                             final int port = config.getInteger(Config.HTTP_PORT, DEFAULT_PORT);

--- a/src/main/java/edu/ucla/library/iiif/fester/verticles/ManifestVerticle.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/verticles/ManifestVerticle.java
@@ -167,10 +167,9 @@ public class ManifestVerticle extends AbstractFesterVerticle {
                     break;
                 }
                 default: {
-                    final String errorMessage = StringUtils.format(MessageCodes.MFS_139,
-                            this.getClass().toString(), message.toString(), action);
+                    final String errorMessage = StringUtils.format(MessageCodes.MFS_139, getClass().toString(),
+                            message.toString(), action);
                     message.fail(CodeUtils.getInt(MessageCodes.MFS_139), errorMessage);
-                    break;
                 }
             }
         });

--- a/src/main/java/edu/ucla/library/iiif/fester/verticles/S3BucketVerticle.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/verticles/S3BucketVerticle.java
@@ -92,10 +92,9 @@ public class S3BucketVerticle extends AbstractFesterVerticle {
                     put(IDUtils.getCollectionS3Key(manifestID), manifest, message);
                     break;
                 default:
-                    final String errorMessage = StringUtils.format(MessageCodes.MFS_139,
-                            this.getClass().toString(), message.toString(), action);
+                    final String errorMessage = StringUtils.format(MessageCodes.MFS_139, getClass().toString(),
+                            message.toString(), action);
                     message.fail(CodeUtils.getInt(MessageCodes.MFS_139), errorMessage);
-                    break;
             }
         });
     }

--- a/src/main/resources/fester.yaml
+++ b/src/main/resources/fester.yaml
@@ -112,7 +112,7 @@ paths:
         '404':
           description: Not found
     put:
-      tags: [Collection (Proposed)]
+      tags: [Collection]
       summary: Put a collection
       description: Puts a provided IIIF collection.
       operationId: putCollection

--- a/src/main/resources/fester_messages.xml
+++ b/src/main/resources/fester_messages.xml
@@ -22,7 +22,7 @@
   <entry key="MFS-006">Putting '{}' (test object) into S3 bucket: {}</entry>
   <entry key="MFS-007">S3 client credentials: {} | {}</entry>
   <entry key="MFS-008">Test GetManifestHandler with a test manifest: {}</entry>
-  <entry key="MFS-009">Manifest not found: {}</entry>
+  <entry key="MFS-009">Manifest '{}' not found</entry>
   <entry key="MFS-010">Internal server error while trying to retrieve manifest: {}</entry>
   <entry key="MFS-011">Unexpected response code while trying to retrieve manifest: {}</entry>
   <entry key="MFS-012">Test DeleteManifestHandler with a test manifest: {}</entry>
@@ -43,13 +43,13 @@
   <entry key="MFS-027">Test GETing a test manifest from: {}</entry>
   <entry key="MFS-028">Test DELETing a test manifest at: {}</entry>
   <entry key="MFS-029">Confirming test manifest has been deleted from: {}</entry>
-  <entry key="MFS-030">Fester service confirmed to be available.</entry>
-  <entry key="MFS-031">FAIL--fester service is unavailable.</entry>
-  <entry key="MFS-032">FAIL--unable to put manifest</entry>
-  <entry key="MFS-033">FAIL--found manifest does not match expected manifest</entry>
-  <entry key="MFS-034">FAIL--manifest not found</entry>
-  <entry key="MFS-035">FAIL--unable to DELETE manifest</entry>
-  <entry key="MFS-036">FAIL--manifest found when it should have been deleted</entry>
+  <entry key="MFS-030">Fester service confirmed to be available</entry>
+  <entry key="MFS-031">Fester service is unavailable</entry>
+
+  <entry key="MFS-033">Found manifest '{}' does not match expected manifest '{}'</entry>
+
+  <entry key="MFS-035">Unable to DELETE manifest '{}'</entry>
+  <entry key="MFS-036">Manifest '{}' found when it should have been deleted</entry>
   <entry key="MFS-037">Not processed. The submission is missing a CSV file.</entry>
   <entry key="MFS-038">Uploaded CSV file received: {} [{}]</entry>
   <entry key="MFS-039">Unexpected POST response: [{}] {}</entry>

--- a/src/main/resources/fester_messages.xml
+++ b/src/main/resources/fester_messages.xml
@@ -133,6 +133,6 @@
   <entry key="MFS-137">Test GetCollectionHandler with a test manifest: {}</entry>
   <entry key="MFS-138">Supplied S3 key '{}' does not match what would have been derived from the IIIF resource URI: '{}'</entry>
   <entry key="MFS-139">'{}' unable to handle message '{}': unknown action '{}'</entry>
-  <entry key="MFS-140">FAIL--manifest '{}' not found when it should have been put</entry>
-  <entry key="MFS-141">FAIL--manifest '{}' found when it should not have been put</entry>
+  <entry key="MFS-140">Manifest '{}' not found when it should have been put</entry>
+  <entry key="MFS-141">Manifest '{}' found when it should not have been put</entry>
 </properties>

--- a/src/main/resources/fester_messages.xml
+++ b/src/main/resources/fester_messages.xml
@@ -133,4 +133,6 @@
   <entry key="MFS-137">Test GetCollectionHandler with a test manifest: {}</entry>
   <entry key="MFS-138">Supplied S3 key '{}' does not match what would have been derived from the IIIF resource URI: '{}'</entry>
   <entry key="MFS-139">'{}' unable to handle message '{}': unknown action '{}'</entry>
+  <entry key="MFS-140">FAIL--manifest '{}' not found when it should have been put</entry>
+  <entry key="MFS-141">FAIL--manifest '{}' found when it should not have been put</entry>
 </properties>

--- a/src/main/resources/fester_messages.xml
+++ b/src/main/resources/fester_messages.xml
@@ -131,4 +131,6 @@
   <entry key="MFS-135">Regular expression '{}' does not match '{}'</entry>
   <entry key="MFS-136">Cannot retrieve object '{}' from S3: unknown type '{}'</entry>
   <entry key="MFS-137">Test GetCollectionHandler with a test manifest: {}</entry>
+  <entry key="MFS-138">Supplied S3 key '{}' does not match what would have been derived from the IIIF resource URI: '{}'</entry>
+  <entry key="MFS-139">'{}' unable to handle message '{}': unknown action '{}'</entry>
 </properties>

--- a/src/test/java/edu/ucla/library/iiif/fester/handlers/PutCollectionHandlerTest.java
+++ b/src/test/java/edu/ucla/library/iiif/fester/handlers/PutCollectionHandlerTest.java
@@ -90,28 +90,26 @@ public class PutCollectionHandlerTest extends AbstractFesterHandlerTest {
         myVertx.createHttpClient().put(requestOpts, putResponse -> {
             final int putStatusCode = putResponse.statusCode();
 
-            switch (putStatusCode) {
-                case HTTP.OK:
-                    // Send a GET request to the same path to make sure PUT succeeded
-                    myVertx.createHttpClient().getNow(port, Constants.UNSPECIFIED_HOST, requestPath, getResponse -> {
-                        final int getStatusCode = getResponse.statusCode();
+            if (putStatusCode == HTTP.OK) {
+                // Send a GET request to the same path to make sure PUT succeeded
+                myVertx.createHttpClient().getNow(port, Constants.UNSPECIFIED_HOST, requestPath, getResponse -> {
+                    final int getStatusCode = getResponse.statusCode();
 
-                        if (getStatusCode == HTTP.OK) {
-                            getResponse.bodyHandler(body -> {
-                                final String foundCollection = body.toString(StandardCharsets.UTF_8);
-                                aContext.assertEquals(new JsonObject(manifest), new JsonObject(foundCollection));
+                    if (getStatusCode == HTTP.OK) {
+                        getResponse.bodyHandler(body -> {
+                            final String foundCollection = body.toString(StandardCharsets.UTF_8);
+                            aContext.assertEquals(new JsonObject(manifest), new JsonObject(foundCollection));
 
-                                if (!asyncTask.isCompleted()) {
-                                    asyncTask.complete();
-                                }
-                            });
-                        } else {
-                            aContext.fail(LOGGER.getMessage(MessageCodes.MFS_140, myPutCollectionID));
-                        }
-                    });
-                    break;
-                default:
-                    aContext.fail(LOGGER.getMessage(MessageCodes.MFS_018, manifestPath, putStatusCode));
+                            if (!asyncTask.isCompleted()) {
+                                asyncTask.complete();
+                            }
+                        });
+                    } else {
+                        aContext.fail(LOGGER.getMessage(MessageCodes.MFS_140, myPutCollectionID));
+                    }
+                });
+            } else {
+                aContext.fail(LOGGER.getMessage(MessageCodes.MFS_018, manifestPath, putStatusCode));
             }
         }).end(manifest);
     }

--- a/src/test/java/edu/ucla/library/iiif/fester/handlers/PutCollectionHandlerTest.java
+++ b/src/test/java/edu/ucla/library/iiif/fester/handlers/PutCollectionHandlerTest.java
@@ -1,0 +1,212 @@
+package edu.ucla.library.iiif.fester.handlers;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.amazonaws.SdkClientException;
+
+import edu.ucla.library.iiif.fester.Config;
+import edu.ucla.library.iiif.fester.Constants;
+import edu.ucla.library.iiif.fester.HTTP;
+import edu.ucla.library.iiif.fester.MessageCodes;
+import edu.ucla.library.iiif.fester.utils.IDUtils;
+import info.freelibrary.util.Logger;
+import info.freelibrary.util.LoggerFactory;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.RequestOptions;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+
+public class PutCollectionHandlerTest extends AbstractFesterHandlerTest {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PutCollectionHandlerTest.class, Constants.MESSAGES);
+
+    private String myPutCollectionID;
+
+    private String myPutCollectionS3Key;
+
+    /**
+     * Test set up.
+     *
+     * @param aContext A testing context
+     */
+    @Override
+    @Before
+    public void setUp(final TestContext aContext) throws IOException {
+        super.setUp(aContext);
+
+        final String putPrefix = "PUT_";
+
+        myPutCollectionID = putPrefix + UUID.randomUUID().toString();
+        myPutCollectionS3Key = IDUtils.getCollectionS3Key(myPutCollectionID);
+    }
+
+    /**
+     * Test tear down.
+     *
+     * @param aContext A testing context
+     */
+    @Override
+    @After
+    public void tearDown(final TestContext aContext) {
+        super.tearDown(aContext);
+
+        try {
+            // If object doesn't exist, this still completes successfully
+            myS3Client.deleteObject(myS3Bucket, myPutCollectionS3Key);
+        } catch (final SdkClientException details) {
+            aContext.fail(details);
+        }
+
+        myVertx.close(aContext.asyncAssertSuccess());
+    }
+
+    /**
+     * Test the PutCollectionHandler.
+     *
+     * @param aContext A testing context
+     */
+    @Test
+    @SuppressWarnings("deprecation")
+    public void testPutCollectionHandler(final TestContext aContext) throws IOException {
+        final String manifestPath = COLLECTION_FILE.getAbsolutePath();
+        final Buffer manifest = myVertx.fileSystem().readFileBlocking(manifestPath);
+        final Async asyncTask = aContext.async();
+        final int port = aContext.get(Config.HTTP_PORT);
+        final String requestPath = IDUtils.getResourceURIPath(myPutCollectionS3Key);
+        final RequestOptions requestOpts = new RequestOptions();
+
+        LOGGER.debug(MessageCodes.MFS_016, requestPath);
+
+        requestOpts.setPort(port).setHost(Constants.UNSPECIFIED_HOST).setURI(requestPath);
+        requestOpts.addHeader(Constants.CONTENT_TYPE, Constants.JSON_MEDIA_TYPE);
+
+        myVertx.createHttpClient().put(requestOpts, putResponse -> {
+            final int putStatusCode = putResponse.statusCode();
+
+            switch (putStatusCode) {
+                case HTTP.OK:
+                    // Send a GET request to the same path to make sure PUT succeeded
+                    myVertx.createHttpClient().getNow(port, Constants.UNSPECIFIED_HOST, requestPath, getResponse -> {
+                        final int getStatusCode = getResponse.statusCode();
+
+                        if (getStatusCode == HTTP.OK) {
+                            getResponse.bodyHandler(body -> {
+                                final String foundCollection = body.toString(StandardCharsets.UTF_8);
+                                aContext.assertEquals(new JsonObject(manifest), new JsonObject(foundCollection));
+
+                                if (!asyncTask.isCompleted()) {
+                                    asyncTask.complete();
+                                }
+                            });
+                        } else {
+                            aContext.fail(LOGGER.getMessage(MessageCodes.MFS_140, myPutCollectionID));
+                        }
+                    });
+                    break;
+                default:
+                    aContext.fail(LOGGER.getMessage(MessageCodes.MFS_018, manifestPath, putStatusCode));
+            }
+        }).end(manifest);
+    }
+
+    /**
+     * Test the PutCollectionHandler.
+     *
+     * @param aContext A testing context
+     */
+    @Test
+    @SuppressWarnings("deprecation")
+    public void testPutCollectionHandlerMissingMediaType(final TestContext aContext) throws IOException {
+        final String manifestPath = COLLECTION_FILE.getAbsolutePath();
+        final Buffer manifest = myVertx.fileSystem().readFileBlocking(manifestPath);
+        final Async asyncTask = aContext.async();
+        final int port = aContext.get(Config.HTTP_PORT);
+        final String requestPath = IDUtils.getResourceURIPath(myPutCollectionS3Key);
+        final RequestOptions requestOpts = new RequestOptions();
+
+        LOGGER.debug(MessageCodes.MFS_016, requestPath);
+
+        requestOpts.setPort(port).setHost(Constants.UNSPECIFIED_HOST).setURI(requestPath);
+        // Fail to set the content-type header
+
+        myVertx.createHttpClient().put(requestOpts, putResponse -> {
+            final int putStatusCode = putResponse.statusCode();
+
+            switch (putStatusCode) {
+                case HTTP.UNSUPPORTED_MEDIA_TYPE:
+                case HTTP.METHOD_NOT_ALLOWED:
+                    // Send a GET request to the same path to make sure PUT failed
+                    myVertx.createHttpClient().getNow(port, Constants.UNSPECIFIED_HOST, requestPath, getResponse -> {
+                        final int getStatusCode = getResponse.statusCode();
+
+                        if (getStatusCode == HTTP.NOT_FOUND) {
+                            if (!asyncTask.isCompleted()) {
+                                asyncTask.complete();
+                            }
+                        } else if (getStatusCode == HTTP.OK) {
+                            aContext.fail(LOGGER.getMessage(MessageCodes.MFS_141, myPutCollectionID));
+                        } else {
+                            aContext.fail(LOGGER.getMessage(MessageCodes.MFS_010, getStatusCode));
+                        }
+                    });
+                    break;
+                default:
+                    aContext.fail(LOGGER.getMessage(MessageCodes.MFS_019, manifestPath, putStatusCode));
+            }
+        }).end(manifest);
+    }
+
+    /**
+     * Test the PutCollectionHandler.
+     *
+     * @param aContext A testing context
+     */
+    @Test
+    @SuppressWarnings("deprecation")
+    public void testPutCollectionHandlerUnsupportedMediaType(final TestContext aContext) throws IOException {
+        final String manifestPath = COLLECTION_FILE.getAbsolutePath();
+        final Buffer manifest = myVertx.fileSystem().readFileBlocking(manifestPath);
+        final Async asyncTask = aContext.async();
+        final int port = aContext.get(Config.HTTP_PORT);
+        final String requestPath = IDUtils.getResourceURIPath(myPutCollectionS3Key);
+        final RequestOptions requestOpts = new RequestOptions();
+
+        LOGGER.debug(MessageCodes.MFS_016, requestPath);
+
+        requestOpts.setPort(port).setHost(Constants.UNSPECIFIED_HOST).setURI(requestPath);
+        requestOpts.addHeader(Constants.CONTENT_TYPE, "text/plain"); // wrong media type
+
+        myVertx.createHttpClient().put(requestOpts, putResponse -> {
+            final int putStatusCode = putResponse.statusCode();
+
+            switch (putStatusCode) {
+                case HTTP.UNSUPPORTED_MEDIA_TYPE:
+                case HTTP.METHOD_NOT_ALLOWED:
+                    // Send a GET request to the same path to make sure PUT failed
+                    myVertx.createHttpClient().getNow(port, Constants.UNSPECIFIED_HOST, requestPath, getResponse -> {
+                        final int getStatusCode = getResponse.statusCode();
+
+                        if (getStatusCode == HTTP.NOT_FOUND) {
+                            if (!asyncTask.isCompleted()) {
+                                asyncTask.complete();
+                            }
+                        } else if (getStatusCode == HTTP.OK) {
+                            aContext.fail(LOGGER.getMessage(MessageCodes.MFS_141, myPutCollectionID));
+                        } else {
+                            aContext.fail(LOGGER.getMessage(MessageCodes.MFS_010, getStatusCode));
+                        }
+                    });
+                    break;
+                default:
+                    aContext.fail(LOGGER.getMessage(MessageCodes.MFS_022, manifestPath, putStatusCode));
+            }
+        }).end(manifest);
+    }
+}

--- a/src/test/java/edu/ucla/library/iiif/fester/it/ManifestUploadIT.java
+++ b/src/test/java/edu/ucla/library/iiif/fester/it/ManifestUploadIT.java
@@ -117,7 +117,7 @@ public class ManifestUploadIT {
             if (statusCode == HTTP.OK) {
                 asyncTask.complete();
             } else {
-                aContext.fail(LOGGER.getMessage(MessageCodes.MFS_032));
+                aContext.fail(LOGGER.getMessage(MessageCodes.MFS_018, myPutManifestID, response.statusMessage()));
             }
         }).end(myManifest);
     }
@@ -149,11 +149,11 @@ public class ManifestUploadIT {
                     if (new JsonObject(expectedManifest).equals(new JsonObject(foundManifest))) {
                         asyncTask.complete();
                     } else {
-                        aContext.fail(LOGGER.getMessage(MessageCodes.MFS_033));
+                        aContext.fail(LOGGER.getMessage(MessageCodes.MFS_033, foundManifest, expectedManifest));
                     }
                 });
             } else {
-                aContext.fail(LOGGER.getMessage(MessageCodes.MFS_034));
+                aContext.fail(LOGGER.getMessage(MessageCodes.MFS_009, myPutManifestID));
             }
         });
     }
@@ -178,7 +178,7 @@ public class ManifestUploadIT {
             if (statusCode == HTTP.SUCCESS_NO_CONTENT) {
                 asyncTask.complete();
             } else {
-                aContext.fail(LOGGER.getMessage(MessageCodes.MFS_035));
+                aContext.fail(LOGGER.getMessage(MessageCodes.MFS_035, myPutManifestID));
             }
         }).end();
     }
@@ -201,7 +201,7 @@ public class ManifestUploadIT {
             final int statusCode = response.statusCode();
 
             if (statusCode == HTTP.OK) {
-                aContext.fail(LOGGER.getMessage(MessageCodes.MFS_036));
+                aContext.fail(LOGGER.getMessage(MessageCodes.MFS_036, myPutManifestID));
             } else {
                 asyncTask.complete();
             }

--- a/src/test/java/edu/ucla/library/iiif/fester/verticles/ManifestVerticleTest.java
+++ b/src/test/java/edu/ucla/library/iiif/fester/verticles/ManifestVerticleTest.java
@@ -28,9 +28,11 @@ import edu.ucla.library.iiif.fester.Config;
 import edu.ucla.library.iiif.fester.Constants;
 import edu.ucla.library.iiif.fester.ImageInfoLookup;
 import edu.ucla.library.iiif.fester.MessageCodes;
+import edu.ucla.library.iiif.fester.Op;
 import edu.ucla.library.iiif.fester.utils.IDUtils;
 import io.vertx.core.DeploymentOptions;
 import io.vertx.core.Vertx;
+import io.vertx.core.eventbus.DeliveryOptions;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.shareddata.LocalMap;
 import io.vertx.ext.unit.Async;
@@ -134,14 +136,16 @@ public class ManifestVerticleTest {
                 + URLEncoder.encode(IDUtils.getWorkS3Key("ark:/21198/z16t1r0h"), StandardCharsets.UTF_8);
         final String path = StringUtils.format(SINAI_WORKS_CSV, SINAI);
         final JsonObject message = new JsonObject();
+        final DeliveryOptions options = new DeliveryOptions();
         final Async asyncTask = aContext.async();
 
         message.put(Constants.CSV_FILE_NAME, myRunID).put(Constants.CSV_FILE_PATH, path);
         message.put(Constants.FESTER_HOST, MANIFEST_HOST);
+        options.addHeader(Constants.ACTION, Op.POST_CSV);
 
         LOGGER.debug(MessageCodes.MFS_120, SINAI, ManifestVerticle.class.getName());
 
-        myVertx.eventBus().request(ManifestVerticle.class.getName(), message, request -> {
+        myVertx.eventBus().request(ManifestVerticle.class.getName(), message, options, request -> {
             if (request.succeeded()) {
                 final JsonObject manifest = new JsonObject(myVertx.fileSystem().readFileBlocking(jsonFile));
 
@@ -166,14 +170,16 @@ public class ManifestVerticleTest {
     public final void testHathawayManifest(final TestContext aContext) {
         final String filePath = StringUtils.format(CSV_FILE_PATH, HATHAWAY);
         final JsonObject message = new JsonObject();
+        final DeliveryOptions options = new DeliveryOptions();
         final Async asyncTask = aContext.async();
 
         message.put(Constants.CSV_FILE_NAME, myRunID).put(Constants.CSV_FILE_PATH, filePath);
         message.put(Constants.FESTER_HOST, MANIFEST_HOST);
+        options.addHeader(Constants.ACTION, Op.POST_CSV);
 
         LOGGER.debug(MessageCodes.MFS_120, HATHAWAY, ManifestVerticle.class.getName());
 
-        myVertx.eventBus().request(ManifestVerticle.class.getName(), message, request -> {
+        myVertx.eventBus().request(ManifestVerticle.class.getName(), message, options, request -> {
             if (request.succeeded()) {
                 asyncTask.complete();
             } else {
@@ -191,14 +197,16 @@ public class ManifestVerticleTest {
     public final void testPostcardsManifest(final TestContext aContext) {
         final String filePath = StringUtils.format(CSV_FILE_PATH, POSTCARDS);
         final JsonObject message = new JsonObject();
+        final DeliveryOptions options = new DeliveryOptions();
         final Async asyncTask = aContext.async();
 
         message.put(Constants.CSV_FILE_NAME, myRunID).put(Constants.CSV_FILE_PATH, filePath);
         message.put(Constants.FESTER_HOST, MANIFEST_HOST);
+        options.addHeader(Constants.ACTION, Op.POST_CSV);
 
         LOGGER.debug(MessageCodes.MFS_120, POSTCARDS, ManifestVerticle.class.getName());
 
-        myVertx.eventBus().request(ManifestVerticle.class.getName(), message, request -> {
+        myVertx.eventBus().request(ManifestVerticle.class.getName(), message, options, request -> {
             if (request.succeeded()) {
                 asyncTask.complete();
             } else {
@@ -217,14 +225,16 @@ public class ManifestVerticleTest {
         final String hathawayWorks = HATHAWAY + "/batch1/works";
         final String filePath = StringUtils.format(CSV_FILE_PATH, hathawayWorks);
         final JsonObject message = new JsonObject();
+        final DeliveryOptions options = new DeliveryOptions();
         final Async asyncTask = aContext.async();
 
         message.put(Constants.CSV_FILE_NAME, myRunID).put(Constants.CSV_FILE_PATH, filePath);
         message.put(Constants.FESTER_HOST, MANIFEST_HOST);
+        options.addHeader(Constants.ACTION, Op.POST_CSV);
 
         LOGGER.debug(MessageCodes.MFS_120, hathawayWorks, ManifestVerticle.class.getName());
 
-        myVertx.eventBus().request(ManifestVerticle.class.getName(), message, request -> {
+        myVertx.eventBus().request(ManifestVerticle.class.getName(), message, options, request -> {
             if (request.succeeded()) {
                 asyncTask.complete();
             } else {
@@ -242,14 +252,16 @@ public class ManifestVerticleTest {
     public final void testPagesManifest(final TestContext aContext) {
         final String filePath = StringUtils.format(WORKS_CSV, HATHAWAY, HATHAWAY);
         final JsonObject message = new JsonObject();
+        final DeliveryOptions options = new DeliveryOptions();
         final Async asyncTask = aContext.async();
 
         message.put(Constants.CSV_FILE_NAME, myRunID).put(Constants.CSV_FILE_PATH, filePath);
         message.put(Constants.FESTER_HOST, MANIFEST_HOST);
+        options.addHeader(Constants.ACTION, Op.POST_CSV);
 
         LOGGER.debug(MessageCodes.MFS_120, WORKS, ManifestVerticle.class.getName());
 
-        myVertx.eventBus().request(ManifestVerticle.class.getName(), message, request -> {
+        myVertx.eventBus().request(ManifestVerticle.class.getName(), message, options, request -> {
             if (request.succeeded()) {
                 asyncTask.complete();
             } else {
@@ -270,15 +282,17 @@ public class ManifestVerticleTest {
         final String expectedFile = "src/test/resources/json/pages-ordered.json";
         final String filePath = "src/test/resources/csv/ara249.csv";
         final JsonObject message = new JsonObject();
+        final DeliveryOptions options = new DeliveryOptions();
         final Async asyncTask = aContext.async();
 
         message.put(Constants.CSV_FILE_NAME, myRunID).put(Constants.CSV_FILE_PATH, filePath);
         message.put(Constants.IIIF_HOST, ImageInfoLookup.FAKE_IIIF_SERVER);
         message.put(Constants.FESTER_HOST, MANIFEST_HOST);
+        options.addHeader(Constants.ACTION, Op.POST_CSV);
 
         LOGGER.debug(MessageCodes.MFS_120, WORKS, ManifestVerticle.class.getName());
 
-        myVertx.eventBus().request(ManifestVerticle.class.getName(), message, request -> {
+        myVertx.eventBus().request(ManifestVerticle.class.getName(), message, options, request -> {
             if (request.succeeded()) {
                 final JsonObject found = new JsonObject(myVertx.fileSystem().readFileBlocking(foundFile));
                 final JsonObject expected = new JsonObject(myVertx.fileSystem().readFileBlocking(expectedFile));


### PR DESCRIPTION
In addition to the notes in the commits:
- I removed `AbstractFesterVerticle.getS3Manifest` (since it was only being called once) and replaced the call to it with the more generic `sendMessage`, but I'm not super opinionated on removing it if it's deemed useful.
- `FakeS3BucketVerticle`'s `JSON_FILES` is now mutable, so that it supports PUT.
- Note: all that's really going on at `@@ -92,72 +92,86 @@ public void start(final Promise<Void> aPromise) {` in the diff for `ManifestVerticle` is a change in indentation, since that code block is now inside a switch statement.