### PR TITLE
[IIIF-727] Add Fester ingest form

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ Once run, the service can be verified/accessed at [http://localhost:8888/status/
 
 ## Debugging with Eclipse IDE
 
+You can run a development instance of Fester with debugging turned on by typing the following within the project root:
+
+    mvn -Pdebug test
 Development instances are configured to accept remote debugger connections on port `5555`.
 
 To debug Fester with [Eclipse IDE](https://www.eclipse.org/eclipseide/):

--- a/pom.xml
+++ b/pom.xml
@@ -709,7 +709,7 @@
       </dependencies>
     </profile>
     <profile>
-      <id>live</id>
+      <id>debug</id>
       <properties>
         <maven.test.skip>true</maven.test.skip>
         <jacoco.skip>true</jacoco.skip>
@@ -775,12 +775,88 @@
             </executions>
             <configuration>
               <verticle>${main.verticle}</verticle>
-              <redeploy>${live.test.reloads}</redeploy>
               <jvmArgs>
                 <jvmArg>-Dvertx.logger-delegate-factory-class-name=io.vertx.core.logging.SLF4JLogDelegateFactory</jvmArg>
                 <jvmArg>-Dvertx-config-path=target/test-classes/test-config.properties</jvmArg>
               </jvmArgs>
               <debugPort>${fester.debug.port}</debugPort>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>live</id>
+      <properties>
+        <maven.test.skip>true</maven.test.skip>
+        <jacoco.skip>true</jacoco.skip>
+      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-resources-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>copy-logging-config-for-testing</id>
+                <phase>test</phase>
+                <goals>
+                  <goal>copy-resources</goal>
+                </goals>
+                <configuration>
+                  <outputDirectory>${basedir}/target/classes/</outputDirectory>
+                  <resources>
+                    <resource>
+                      <directory>${basedir}/src/main/resources</directory>
+                      <filtering>true</filtering>
+                      <includes>
+                        <include>logback.xml</include>
+                        <include>fester.yaml</include>
+                      </includes>
+                    </resource>
+                  </resources>
+                </configuration>
+              </execution>
+              <execution>
+                <id>copy-application-config-for-testing</id>
+                <phase>test</phase>
+                <goals>
+                  <goal>copy-resources</goal>
+                </goals>
+                <configuration>
+                  <outputDirectory>${basedir}/target/test-classes/</outputDirectory>
+                  <resources>
+                    <resource>
+                      <directory>${basedir}/src/test/resources</directory>
+                      <filtering>true</filtering>
+                      <includes>
+                        <include>test-config.properties</include>
+                      </includes>
+                    </resource>
+                  </resources>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>io.reactiverse</groupId>
+            <artifactId>vertx-maven-plugin</artifactId>
+            <version>${vertx.plugin.version}</version>
+            <executions>
+              <execution>
+                <id>vertx-plugin</id>
+                <phase>test</phase>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+              </execution>
+            </executions>
+            <configuration>
+              <verticle>${main.verticle}</verticle>
+              <redeploy>${live.test.reloads}</redeploy>
+              <jvmArgs>
+                <jvmArg>-Dvertx.logger-delegate-factory-class-name=io.vertx.core.logging.SLF4JLogDelegateFactory</jvmArg>
+                <jvmArg>-Dvertx-config-path=target/test-classes/test-config.properties</jvmArg>
+              </jvmArgs>
             </configuration>
           </plugin>
         </plugins>

--- a/src/main/java/edu/ucla/library/iiif/fester/verticles/MainVerticle.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/verticles/MainVerticle.java
@@ -90,14 +90,22 @@ public class MainVerticle extends AbstractVerticle {
                             final StaticHandler staticHandler = StaticHandler.create().setWebRoot("webroot");
 
                             // Make sure uploaded files get deleted
-                            factory.addHandlerByOperationId(Op.POST_CSV, postCsvHandler)
-                                    .setBodyHandler(BodyHandler.create().setDeleteUploadedFilesOnEnd(true));
+                            factory.addHandlerByOperationId(Op.POST_CSV, postCsvHandler).setBodyHandler(BodyHandler
+                                    .create().setDeleteUploadedFilesOnEnd(true));
 
                             // After that, we can get a router that's been configured by our OpenAPI spec
                             router = factory.getRouter();
 
-                            // Serve Fester documentation
-                            router.get("/docs/fester*").handler(staticHandler.setIndexPage("index.html"));
+                            // Handle some simple, temporary redirecting
+                            router.getWithRegex("/fester/?").last().handler(event -> {
+                                event.reroute("/fester/docs");
+                            });
+                            router.getWithRegex("/fester/upload/?").last().handler(event -> {
+                                event.reroute("/fester/upload/csv");
+                            });
+
+                            // Serve Fester HTML pages
+                            router.get("/fester*").handler(staticHandler.setIndexPage("index.html"));
 
                             // If an incoming request doesn't match one of our spec operations, it's treated as a 404;
                             // catch these generic 404s with the handler below and return more specific response codes

--- a/src/main/webroot/css/fester-custom.css
+++ b/src/main/webroot/css/fester-custom.css
@@ -12,8 +12,3 @@ body {
   font-weight: bold;
   margin-bottom: 3px;
 }
-
-h1 {
-  text-align: center;
-  background-color: #eeeeee !important;
-}

--- a/src/main/webroot/docs/index.html
+++ b/src/main/webroot/docs/index.html
@@ -9,9 +9,9 @@
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1">
 
-<link rel="stylesheet" href="/docs/fester/css/bootstrap.min.css">
-<link rel="stylesheet" href="/docs/fester/css/fester-custom.css">
-<link rel="stylesheet" href="/docs/fester/css/redoc-custom.css">
+<link rel="stylesheet" href="/fester/css/bootstrap.min.css">
+<link rel="stylesheet" href="/fester/css/fester-custom.css">
+<link rel="stylesheet" href="/fester/css/redoc-custom.css">
 
 </head>
 
@@ -22,11 +22,11 @@
       aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>
     </button>
-    <a class="navbar-brand" href="/">Fester</a>
+    <a class="navbar-brand" href="/fester">Fester</a>
     <div class="collapse navbar-collapse" id="navbarNavAltMarkup">
       <div class="navbar-nav">
-        <a class="nav-item nav-link active"
-          href="/docs/fester">API Documentation</a>
+        <a class="nav-item nav-link active" href="/fester/upload/csv">CSV Upload</a> <a class="nav-item nav-link active"
+          href="/fester/docs">API Documentation</a>
       </div>
     </div>
   </nav>
@@ -35,5 +35,6 @@
 </body>
 
 <script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"></script>
-<script src="/docs/fester/javascripts/redoc-config.js"></script>
+<script src="/fester/javascripts/redoc-config.js"></script>
+
 </html>

--- a/src/main/webroot/error.html
+++ b/src/main/webroot/error.html
@@ -9,9 +9,9 @@
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
-<link rel="stylesheet" href="/css/bootstrap.min.css">
-<link rel="stylesheet" href="/css/fester-custom.css">
-<link rel="stylesheet" href="/css/fester-response.css">
+<link rel="stylesheet" href="/fester/css/bootstrap.min.css">
+<link rel="stylesheet" href="/fester/css/fester-custom.css">
+<link rel="stylesheet" href="/fester/css/fester-response.css">
 
 </head>
 
@@ -22,10 +22,10 @@
       aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>
     </button>
-    <a class="navbar-brand" href="/">Fester</a>
+    <a class="navbar-brand" href="/fester">Fester</a>
     <div class="collapse navbar-collapse" id="navbarNavAltMarkup">
       <div class="navbar-nav">
-        <a class="nav-item nav-link active" href="/docs/fester/">API Documentation</a>
+        <a class="nav-item nav-link active" href="/fester/docs">API Documentation</a>
       </div>
     </div>
   </nav>

--- a/src/main/webroot/error.html
+++ b/src/main/webroot/error.html
@@ -25,7 +25,8 @@
     <a class="navbar-brand" href="/fester">Fester</a>
     <div class="collapse navbar-collapse" id="navbarNavAltMarkup">
       <div class="navbar-nav">
-        <a class="nav-item nav-link active" href="/fester/docs">API Documentation</a>
+        <a class="nav-item nav-link active" href="/fester/upload/csv">CSV Upload</a> <a class="nav-item nav-link active"
+          href="/fester/docs">API Documentation</a>
       </div>
     </div>
   </nav>

--- a/src/main/webroot/javascripts/redoc-config.js
+++ b/src/main/webroot/javascripts/redoc-config.js
@@ -11,7 +11,7 @@
  *  #FF00A5 (pink)
  */
 
-Redoc.init('/docs/fester/fester.yaml', {
+Redoc.init('/fester/fester.yaml', {
   theme : {
     colors : {
       primary : {

--- a/src/main/webroot/success.html
+++ b/src/main/webroot/success.html
@@ -9,9 +9,9 @@
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
-<link rel="stylesheet" href="/css/bootstrap.min.css">
-<link rel="stylesheet" href="/css/fester-custom.css">
-<link rel="stylesheet" href="/css/fester-response.css">
+<link rel="stylesheet" href="/fester/css/bootstrap.min.css">
+<link rel="stylesheet" href="/fester/css/fester-custom.css">
+<link rel="stylesheet" href="/fester/css/fester-response.css">
 
 </head>
 
@@ -25,7 +25,7 @@
     <a class="navbar-brand" href="#">Fester</a>
     <div class="collapse navbar-collapse" id="navbarNavAltMarkup">
       <div class="navbar-nav">
-        <a class="nav-item nav-link active" href="/docs/fester/">API Documentation</a>
+        <a class="nav-item nav-link active" href="/fester/docs">API Documentation</a>
       </div>
     </div>
   </nav>

--- a/src/main/webroot/success.html
+++ b/src/main/webroot/success.html
@@ -22,10 +22,11 @@
       aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>
     </button>
-    <a class="navbar-brand" href="#">Fester</a>
+    <a class="navbar-brand" href="/fester">Fester</a>
     <div class="collapse navbar-collapse" id="navbarNavAltMarkup">
       <div class="navbar-nav">
-        <a class="nav-item nav-link active" href="/fester/docs">API Documentation</a>
+        <a class="nav-item nav-link active" href="/fester/upload/csv">CSV Upload</a> <a class="nav-item nav-link active"
+          href="/fester/docs">API Documentation</a>
       </div>
     </div>
   </nav>

--- a/src/main/webroot/upload/css/upload-custom.css
+++ b/src/main/webroot/upload/css/upload-custom.css
@@ -1,0 +1,37 @@
+
+.csv-upload-form {
+    padding-top: 20px;
+}
+
+.container-fluid p {
+    padding-top: 15px;
+}
+
+body {
+    padding-top: 80px;
+    font-family: Montserrat, sans-serif !important;
+}
+
+h1 {
+    font-weight: 400;
+    color: #003B5C;
+    font-size: 1.85714em;
+}
+
+info-form {
+    color: black;
+}
+
+#important {
+  margin-top: 60px;
+  font-style: italic;
+}
+
+.infotext {
+  font-size: smaller;
+  color: #003B5C;
+}
+
+.form-group {
+  padding-top: 10px;
+}

--- a/src/main/webroot/upload/csv/index.html
+++ b/src/main/webroot/upload/csv/index.html
@@ -45,7 +45,7 @@
             <div class="form-group">
               <label for="iiif-host">IIIF Host:</label> <input type="text" value="https://iiif.library.ucla.edu"
                 name="iiif-host" id="iiif-host" onfocus="this.value=''" />
-              <div class="infotext">Use the default IIIF URL (http://iiif.library.ucla.edu) or enter the base URL
+              <div class="infotext">Use the default IIIF URL (https://iiif.library.ucla.edu) or enter the base URL
                 for a different IIIF server.</div>
             </div>
             <div class="form-group">

--- a/src/main/webroot/upload/csv/index.html
+++ b/src/main/webroot/upload/csv/index.html
@@ -1,0 +1,108 @@
+<!DOCTYPE html>
+
+<html lang="en">
+
+<head>
+
+<title>Fester CSV Upload</title>
+
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+
+<link rel="stylesheet" href="/fester/css/bootstrap.min.css">
+<link rel="stylesheet" href="/fester/css/fester-custom.css">
+<link rel="stylesheet" href="/fester/upload/css/upload-custom.css">
+
+</head>
+
+<body>
+  <nav class="navbar navbar-expand-md bg-custom-grey navbar-dark bg-dark fixed-top">
+    <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse"
+      data-target="#navbarsExampleDefault" aria-controls="navbarsExampleDefault" aria-expanded="false"
+      aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <a class="navbar-brand" href="/fester">Fester</a>
+    <div class="collapse navbar-collapse" id="navbarNavAltMarkup">
+      <div class="navbar-nav">
+        <a class="nav-item nav-link active" href="/fester/upload/csv">CSV Upload</a> <a class="nav-item nav-link active"
+          href="/fester/docs">API Documentation</a>
+      </div>
+    </div>
+  </nav>
+
+  <div class="container-fluid">
+    <h1 id="csv-upload-title">CSV Upload</h1>
+    <p>The CSV upload form can be used to upload CSV files for processing by the Fester application.</p>
+    <div class="row csv-upload-form">
+      <div class="col-sm-3 offset-sm-1">
+        <div class="info-form">
+          <form class="form-inlin justify-content-center" action="/collections" method="post"
+            enctype="multipart/form-data">
+            <div class="form-group">
+              <label for="csv-file">File to upload:</label> <input type="file" name="csv-file" id="csv-file">
+            </div>
+            <div class="form-group">
+              <label for="iiif-host">IIIF Host:</label> <input type="text" value="https://iiif.library.ucla.edu"
+                name="iiif-host" id="iiif-host" onfocus="this.value=''" />
+              <div class="infotext">Use the default IIIF URL (http://iiif.library.ucla.edu) or enter the base URL
+                for a different IIIF server.</div>
+            </div>
+            <div class="form-group">
+              <input type="submit" value="Upload" name="submit">
+            </div>
+          </form>
+        </div>
+      </div>
+      <div class="col-sm-4 offset-sm-1">
+        <h4>Instructions</h4>
+        <p>
+          To start a batch job, upload a CSV file (like one of those found in the <a
+            href="https://github.com/UCLALibrary/eureka/">Eureka</a> GitHub repository). If you would like image
+          dimensions looked up in a different IIIF server from the one supplied in the "IIIF Host" box, be sure to put
+          that server's base URL in the text box.
+        </p>
+        <p>If most cases, with the exception being the Sinai CSVs, you are probably okay with just using the default
+          value.</p>
+        <p>The CSV columns that are required by the Fester service are:</p>
+        <ul>
+          <li><code>Item ARK</code></li>
+          <li><code>Parent ARK</code></li>
+          <li><code>Object Type</code></li>
+          <li><code>Title</code></li>
+          <li><code>File Name</code></li>
+          <li><code>Item Sequence</code></li>
+        </ul>
+        <p>There are also some optional columns that will be used if they're found:</p>
+        <ul>
+          <li><code>viewingHint</code></li>
+          <li><code>viewingDirection</code></li>
+          <li><code>Name.repository</code></li>
+          <li><code>Rights.statementLocal</code></li>
+          <li><code>Rights.servicesContract</code></li>
+          <li><code>IIIF Access URL</code></li>
+        </ul>
+        <br />
+        <h4>Problems?</h4>
+        <p>
+          It's possible to submit a job that takes longer than the timeout on your browser allows. For really large CSV
+          submissions, you might need to use the <a
+            href="https://github.com/UCLALibrary/fester/tree/master/src/main/scripts/festerize">Festerize</a> script,
+          which does not have a timeout.
+        </p>
+        <p>
+          If you run into issues when using this upload form, please feel free to contact us in the
+          <code>#softwaredev-services</code>
+          Slack channel. We will be glad to troubleshoot any problems that you may encounter. Thanks!
+        </p>
+      </div>
+    </div>
+  </div>
+
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js"></script>
+  <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js"></script>
+
+</body>
+
+</html>


### PR DESCRIPTION
I learned the debugging mode isn't compatible with the automatic reloading of resources in the vertx-maven-plugin so I added an additional profile. There is now one for debugging and one for live testing.

* Updated the paths for served HTML pages (@cachemeoutside will need to update the /docs links in the load balancer)
* Added an HTML form that submits an uploaded CSV file to the Fester service and returns an updated CSV file to the browser
* Updated some of the site's CSS stylings (minor changes)