### PR TITLE
[IIIF-764] Reduce log output in Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ jobs:
       install:
         - mvn install -q -Dmaven.test.skip -Dmaven.javadoc.skip -B -V
       script:
-        - mvn verify -Dfester.s3.bucket="${AWS_BUCKET}" -Dfester.s3.access_key="${AWS_ACCESS_KEY_ID}" -Dfester.s3.secret_key="${AWS_SECRET_ACCESS_KEY}"
+        - mvn verify -q -Dfester.s3.bucket="${AWS_BUCKET}" -Dfester.s3.access_key="${AWS_ACCESS_KEY_ID}" -Dfester.s3.secret_key="${AWS_SECRET_ACCESS_KEY}"
       # Cache the local Maven repo to save time
       cache:
         directories:


### PR DESCRIPTION
With the new Docker test stuff, the Maven log gets longer than Travis' max log length. This PR is to make the Maven log output a little less voluminous.