### PR TITLE
[IIIF-770] Fix double release build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
 
 services: docker
 
-# We want all PRs built but only merges on master branch and tags under semantic version scheme
+# We want all PRs built but only merges on master branch
 branches:
   only:
   - master
-  - /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*)?(\+[0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*)?$/
 
 jobs:
   include:


### PR DESCRIPTION
With the new release mechanism, we base Docker image tags on the version in the POM rather than on the version in the GitHub tag, so we don't need to run Travis on tag branches anymore. Doing so causes an extra unnecessary Travis run.