### PR TITLE
[IIIF-464] Add human friendly responses to endpoints

### DIFF
--- a/src/main/java/edu/ucla/library/iiif/fester/Constants.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/Constants.java
@@ -63,6 +63,11 @@ public final class Constants {
     public static final String CSV_MEDIA_TYPE = "text/csv";
 
     /**
+     * The plain text content-type.
+     */
+    public static final String PLAIN_TEXT_TYPE = "text/plain";
+
+    /**
      * COR header for allowing access to our manifests to the world
      */
     public static final String CORS_HEADER = "Access-Control-Allow-Origin";

--- a/src/main/java/edu/ucla/library/iiif/fester/handlers/DeleteManifestHandler.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/handlers/DeleteManifestHandler.java
@@ -36,13 +36,13 @@ public class DeleteManifestHandler extends AbstractFesterHandler {
     public void handle(final RoutingContext aContext) {
         final HttpServerResponse response = aContext.response();
         final HttpServerRequest request = aContext.request();
-        final String manifestId = request.getParam(Constants.MANIFEST_ID);
+        final String manifestID = request.getParam(Constants.MANIFEST_ID);
         final String manifestS3Key;
 
-        if (FileUtils.getExt(manifestId).equals(Constants.JSON_EXT)) {
-            manifestS3Key = IDUtils.getWorkS3Key(manifestId, Constants.JSON_EXT);
+        if (FileUtils.getExt(manifestID).equals(Constants.JSON_EXT)) {
+            manifestS3Key = IDUtils.getWorkS3Key(manifestID, Constants.JSON_EXT);
         } else {
-            manifestS3Key = IDUtils.getWorkS3Key(manifestId);
+            manifestS3Key = IDUtils.getWorkS3Key(manifestID);
         }
 
         myS3Client.delete(myS3Bucket, manifestS3Key, deleteResponse -> {
@@ -51,26 +51,34 @@ public class DeleteManifestHandler extends AbstractFesterHandler {
             switch (statusCode) {
                 case HTTP.SUCCESS_NO_CONTENT:
                     response.setStatusCode(HTTP.SUCCESS_NO_CONTENT);
-                    response.end();
+                    response.putHeader(Constants.CONTENT_TYPE, Constants.PLAIN_TEXT_TYPE);
+                    response.end(LOGGER.getMessage(MessageCodes.MFS_088, manifestID));
 
                     break;
                 case HTTP.FORBIDDEN:
                     response.setStatusCode(HTTP.FORBIDDEN);
-                    response.end();
+                    response.putHeader(Constants.CONTENT_TYPE, Constants.PLAIN_TEXT_TYPE);
+                    response.end(LOGGER.getMessage(MessageCodes.MFS_089, manifestID));
 
                     break;
                 case HTTP.INTERNAL_SERVER_ERROR:
-                    LOGGER.error(MessageCodes.MFS_014, manifestId);
+                    final String serverErrorMessage = LOGGER.getMessage(MessageCodes.MFS_014, manifestID);
+
+                    LOGGER.error(serverErrorMessage);
 
                     response.setStatusCode(HTTP.INTERNAL_SERVER_ERROR);
-                    response.end();
+                    response.putHeader(Constants.CONTENT_TYPE, Constants.PLAIN_TEXT_TYPE);
+                    response.end(serverErrorMessage);
 
                     break;
                 default:
-                    LOGGER.warn(MessageCodes.MFS_013, statusCode, manifestId);
+                    final String genericErrorMessage = LOGGER.getMessage(MessageCodes.MFS_013, manifestID);
+
+                    LOGGER.warn(genericErrorMessage);
 
                     response.setStatusCode(statusCode);
-                    response.end();
+                    response.putHeader(Constants.CONTENT_TYPE, Constants.PLAIN_TEXT_TYPE);
+                    response.end(genericErrorMessage);
             }
         });
     }

--- a/src/main/java/edu/ucla/library/iiif/fester/handlers/GetCollectionHandler.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/handlers/GetCollectionHandler.java
@@ -59,6 +59,7 @@ public class GetCollectionHandler extends AbstractFesterHandler implements Handl
 
                 response.setStatusCode(HTTP.NOT_FOUND);
                 response.setStatusMessage(exceptionMessage);
+                response.putHeader(Constants.CONTENT_TYPE, Constants.PLAIN_TEXT_TYPE);
                 response.end(errorMessage);
             }
         });

--- a/src/main/java/edu/ucla/library/iiif/fester/handlers/GetManifestHandler.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/handlers/GetManifestHandler.java
@@ -37,13 +37,13 @@ public class GetManifestHandler extends AbstractFesterHandler {
     public void handle(final RoutingContext aContext) {
         final HttpServerResponse response = aContext.response();
         final HttpServerRequest request = aContext.request();
-        final String manifestId = request.getParam(Constants.MANIFEST_ID);
+        final String manifestID = request.getParam(Constants.MANIFEST_ID);
         final String manifestS3Key;
 
-        if (FileUtils.getExt(manifestId).equals(Constants.JSON_EXT)) {
-            manifestS3Key = IDUtils.getWorkS3Key(manifestId, Constants.JSON_EXT);
+        if (FileUtils.getExt(manifestID).equals(Constants.JSON_EXT)) {
+            manifestS3Key = IDUtils.getWorkS3Key(manifestID, Constants.JSON_EXT);
         } else {
-            manifestS3Key = IDUtils.getWorkS3Key(manifestId);
+            manifestS3Key = IDUtils.getWorkS3Key(manifestID);
         }
 
         // set a very permissive CORS response header
@@ -67,45 +67,50 @@ public class GetManifestHandler extends AbstractFesterHandler {
 
                         break;
                     case HTTP.NOT_FOUND:
-                        message = LOGGER.getMessage(MessageCodes.MFS_009, manifestId, statusCode, statusMessage);
+                        message = LOGGER.getMessage(MessageCodes.MFS_009, manifestID, statusCode, statusMessage);
                         response.setStatusCode(HTTP.NOT_FOUND);
                         response.setStatusMessage(message);
+                        response.putHeader(Constants.CONTENT_TYPE, Constants.PLAIN_TEXT_TYPE);
                         response.end(message);
 
                         break;
                     case HTTP.INTERNAL_SERVER_ERROR:
-                        message = LOGGER.getMessage(MessageCodes.MFS_010, manifestId, statusCode, statusMessage);
+                        message = LOGGER.getMessage(MessageCodes.MFS_010, manifestID, statusCode, statusMessage);
                         response.setStatusCode(HTTP.INTERNAL_SERVER_ERROR);
                         response.setStatusMessage(message);
+                        response.putHeader(Constants.CONTENT_TYPE, Constants.PLAIN_TEXT_TYPE);
                         response.end(message);
 
                         LOGGER.error(message);
 
                         break;
                     default:
-                        message = LOGGER.getMessage(MessageCodes.MFS_011, manifestId, statusCode, statusMessage);
+                        message = LOGGER.getMessage(MessageCodes.MFS_011, manifestID, statusCode, statusMessage);
                         response.setStatusCode(statusCode);
                         response.setStatusMessage(message);
+                        response.putHeader(Constants.CONTENT_TYPE, Constants.PLAIN_TEXT_TYPE);
                         response.end(message);
 
                         LOGGER.error(message);
                 }
             }, exception -> {
-                final String message = LOGGER.getMessage(MessageCodes.MFS_009, manifestId, HTTP.INTERNAL_SERVER_ERROR,
+                final String message = LOGGER.getMessage(MessageCodes.MFS_009, manifestID, HTTP.INTERNAL_SERVER_ERROR,
                         exception.getMessage());
 
                 response.setStatusCode(HTTP.INTERNAL_SERVER_ERROR);
                 response.setStatusMessage(message);
+                response.putHeader(Constants.CONTENT_TYPE, Constants.PLAIN_TEXT_TYPE);
                 response.end(message);
 
                 LOGGER.error(exception, message);
             });
         } catch (final Throwable aThrowable) {
-            final String message = LOGGER.getMessage(MessageCodes.MFS_009, manifestId, HTTP.INTERNAL_SERVER_ERROR,
+            final String message = LOGGER.getMessage(MessageCodes.MFS_009, manifestID, HTTP.INTERNAL_SERVER_ERROR,
                     aThrowable.getMessage());
 
             response.setStatusCode(HTTP.INTERNAL_SERVER_ERROR);
             response.setStatusMessage(message);
+            response.putHeader(Constants.CONTENT_TYPE, Constants.PLAIN_TEXT_TYPE);
             response.end(message);
 
             LOGGER.error(message);

--- a/src/main/java/edu/ucla/library/iiif/fester/handlers/GetStatusHandler.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/handlers/GetStatusHandler.java
@@ -5,6 +5,7 @@ import info.freelibrary.util.Logger;
 import info.freelibrary.util.LoggerFactory;
 
 import edu.ucla.library.iiif.fester.Constants;
+import edu.ucla.library.iiif.fester.HTTP;
 import edu.ucla.library.iiif.fester.Status;
 import io.vertx.core.Handler;
 import io.vertx.core.http.HttpServerResponse;
@@ -38,7 +39,8 @@ public class GetStatusHandler implements Handler<RoutingContext> {
 
             LOGGER.error(aThrowable, exceptionMessage);
 
-            response.setStatusCode(500);
+            response.setStatusCode(HTTP.INTERNAL_SERVER_ERROR);
+            response.putHeader(Constants.CONTENT_TYPE, Constants.PLAIN_TEXT_TYPE);
             response.end(exceptionMessage);
         }
     }

--- a/src/main/java/edu/ucla/library/iiif/fester/handlers/MatchingOpNotFoundHandler.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/handlers/MatchingOpNotFoundHandler.java
@@ -1,8 +1,12 @@
 
 package edu.ucla.library.iiif.fester.handlers;
 
+import info.freelibrary.util.Logger;
+import info.freelibrary.util.LoggerFactory;
+
 import edu.ucla.library.iiif.fester.Constants;
 import edu.ucla.library.iiif.fester.HTTP;
+import edu.ucla.library.iiif.fester.MessageCodes;
 import io.vertx.core.Handler;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerRequest;
@@ -18,6 +22,8 @@ import io.vertx.ext.web.RoutingContext;
  */
 public class MatchingOpNotFoundHandler implements Handler<RoutingContext> {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(MatchingOpNotFoundHandler.class, Constants.MESSAGES);
+
     @Override
     public void handle(final RoutingContext aContext) {
         final HttpServerRequest request = aContext.request();
@@ -27,7 +33,9 @@ public class MatchingOpNotFoundHandler implements Handler<RoutingContext> {
         if (method.equals(HttpMethod.PUT)) {
             handlePuts(aContext);
         } else {
-            response.setStatusCode(HTTP.NOT_FOUND).end();
+            response.setStatusCode(HTTP.NOT_FOUND);
+            response.putHeader(Constants.CONTENT_TYPE, Constants.PLAIN_TEXT_TYPE);
+            response.end(LOGGER.getMessage(MessageCodes.MFS_091, request.path()));
         }
     }
 
@@ -42,7 +50,9 @@ public class MatchingOpNotFoundHandler implements Handler<RoutingContext> {
         } else if (mediaType == null) {
             aContext.fail(HTTP.UNSUPPORTED_MEDIA_TYPE, new MissingMediaTypeException());
         } else {
-            response.setStatusCode(HTTP.NOT_FOUND).end();
+            response.setStatusCode(HTTP.NOT_FOUND);
+            response.putHeader(Constants.CONTENT_TYPE, Constants.PLAIN_TEXT_TYPE);
+            response.end(LOGGER.getMessage(MessageCodes.MFS_091, request.path()));
         }
     }
 }

--- a/src/main/java/edu/ucla/library/iiif/fester/handlers/PutCollectionHandler.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/handlers/PutCollectionHandler.java
@@ -1,12 +1,14 @@
+
 package edu.ucla.library.iiif.fester.handlers;
+
+import info.freelibrary.util.Logger;
+import info.freelibrary.util.LoggerFactory;
 
 import edu.ucla.library.iiif.fester.Constants;
 import edu.ucla.library.iiif.fester.HTTP;
 import edu.ucla.library.iiif.fester.MessageCodes;
 import edu.ucla.library.iiif.fester.Op;
 import edu.ucla.library.iiif.fester.verticles.S3BucketVerticle;
-import info.freelibrary.util.Logger;
-import info.freelibrary.util.LoggerFactory;
 import io.vertx.core.Vertx;
 import io.vertx.core.eventbus.DeliveryOptions;
 import io.vertx.core.http.HttpServerResponse;
@@ -47,7 +49,10 @@ public class PutCollectionHandler extends AbstractFesterHandler {
 
                 LOGGER.error(aThrowable, errorMessage);
 
-                response.setStatusCode(HTTP.INTERNAL_SERVER_ERROR).setStatusMessage(exceptionMessage).end(errorMessage);
+                response.setStatusCode(HTTP.INTERNAL_SERVER_ERROR);
+                response.setStatusMessage(exceptionMessage);
+                response.putHeader(Constants.CONTENT_TYPE, Constants.PLAIN_TEXT_TYPE);
+                response.end(errorMessage);
             }
         });
     }

--- a/src/main/java/edu/ucla/library/iiif/fester/handlers/PutManifestHandler.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/handlers/PutManifestHandler.java
@@ -37,13 +37,13 @@ public class PutManifestHandler extends AbstractFesterHandler {
         final HttpServerResponse response = aContext.response();
         final HttpServerRequest request = aContext.request();
         final JsonObject body = aContext.getBodyAsJson();
-        final String manifestId = request.getParam(Constants.MANIFEST_ID);
+        final String manifestID = request.getParam(Constants.MANIFEST_ID);
         final String manifestS3Key;
 
-        if (FileUtils.getExt(manifestId).equals(Constants.JSON_EXT)) {
-            manifestS3Key = IDUtils.getWorkS3Key(manifestId, Constants.JSON_EXT);
+        if (FileUtils.getExt(manifestID).equals(Constants.JSON_EXT)) {
+            manifestS3Key = IDUtils.getWorkS3Key(manifestID, Constants.JSON_EXT);
         } else {
-            manifestS3Key = IDUtils.getWorkS3Key(manifestId);
+            manifestS3Key = IDUtils.getWorkS3Key(manifestID);
         }
 
         // For now we're not going to check if it exists before we overwrite it
@@ -53,28 +53,36 @@ public class PutManifestHandler extends AbstractFesterHandler {
             switch (statusCode) {
                 case HTTP.OK:
                     response.setStatusCode(HTTP.OK);
-                    response.end();
+                    response.putHeader(Constants.CONTENT_TYPE, Constants.PLAIN_TEXT_TYPE);
+                    response.end(LOGGER.getMessage(MessageCodes.MFS_092, manifestID));
 
                     break;
                 case HTTP.FORBIDDEN:
-                    LOGGER.debug(MessageCodes.MFS_023, manifestId);
+                    LOGGER.debug(MessageCodes.MFS_023, manifestID);
 
                     response.setStatusCode(HTTP.FORBIDDEN);
-                    response.end();
+                    response.putHeader(Constants.CONTENT_TYPE, Constants.PLAIN_TEXT_TYPE);
+                    response.end(LOGGER.getMessage(MessageCodes.MFS_089, manifestID));
 
                     break;
                 case HTTP.INTERNAL_SERVER_ERROR:
-                    LOGGER.error(MessageCodes.MFS_015, manifestId);
+                    final String serverErrorMessage = LOGGER.getMessage(MessageCodes.MFS_015, manifestID);
+
+                    LOGGER.error(serverErrorMessage);
 
                     response.setStatusCode(HTTP.INTERNAL_SERVER_ERROR);
-                    response.end();
+                    response.putHeader(Constants.CONTENT_TYPE, Constants.PLAIN_TEXT_TYPE);
+                    response.end(serverErrorMessage);
 
                     break;
                 default:
-                    LOGGER.warn(MessageCodes.MFS_013, statusCode, manifestId);
+                    final String errorMessage = LOGGER.getMessage(MessageCodes.MFS_013, statusCode, manifestID);
+
+                    LOGGER.warn(errorMessage);
 
                     response.setStatusCode(statusCode);
-                    response.end();
+                    response.putHeader(Constants.CONTENT_TYPE, Constants.PLAIN_TEXT_TYPE);
+                    response.end(errorMessage);
             }
         });
     }

--- a/src/main/resources/fester.yaml
+++ b/src/main/resources/fester.yaml
@@ -41,6 +41,11 @@ paths:
                   type: object
           '500':
             description: There was an internal server error
+            content:
+              text/plain:
+                schema:
+                  type: string
+                  example: The status request failed because the slithy toves did gyre
   /collections:
     post:
       tags: [Collection]
@@ -106,8 +111,17 @@ paths:
       responses:
         '200':
           description: The IIIF collection for the requested ID
+          content:
+            application/json:
+              schema:
+                type: object
         '404':
           description: Not found
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: The collection 'FakeCollection' could not be found
     put:
       tags: [Collection]
       summary: Put a collection
@@ -123,14 +137,39 @@ paths:
       responses:
         '200':
           description: Updated or created the collection with the supplied name
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: The collection 'MyCollection' was successfully uploaded
         '400':
           description: Bad request
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: "Bad request while putting collection: MyCollection"
         '403':
           description: Forbidden
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: "You do not have permission to put collection: MyCollection"
         '415':
           description: Unsupported media type (i.e. not JSON)
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: Collection 'MyCollection' does not have a valid media type
         '500':
           description: Internal server error
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: "Internal server error: the slithy toves did gyre and gimble"
     delete:
       tags: [Collection (Proposed)]
       summary: Delete a collection
@@ -139,10 +178,25 @@ paths:
       responses:
         '204':
           description: Deleted the collection with the supplied name
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: "Collection successfully deleted: MyCollection"
         '403':
           description: Forbidden
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: Permission to delete collection 'MyCollection' denied
         '500':
           description: Internal server error
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: "Internal server error: the slithy toves did gyre and gimble"
     parameters:
        - in: path
          name: collectionName
@@ -159,10 +213,24 @@ paths:
       responses:
         '200':
           description: The IIIF manifest for the requested ID
+          content:
+            application/json:
+              schema:
+                type: object
         '400':
           description: Bad request
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: "Bad request while putting collection: XYZ"
         '404':
           description: Not found
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: The manifest 'XYZ' could not be found
     put:
       tags: [Manifest]
       summary: Put a manifest
@@ -182,14 +250,39 @@ paths:
       responses:
         '200':
           description: Updated or created the manifest at the supplied ID
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: "Manifest successfully uploaded to server: XYZ"
         '400':
           description: Bad request
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: "Bad request while submitting manifest: XYZ"
         '403':
           description: Forbidden
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: Permission to upload manifest 'XYZ' denied
         '415':
           description: Unsupported media type (i.e. not JSON)
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: Manifest 'XYZ' upload failed because of unsupported media type
         '500':
           description: Internal server error
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: "Internal server error: the slithy toves did gyre and gimble"
     delete:
       tags: [Manifest]
       summary: Delete a manifest
@@ -198,10 +291,25 @@ paths:
       responses:
         '204':
           description: Deleted the manifest at the supplied ID
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: Manifest 'XYZ' has been successfully deleted
         '403':
           description: Forbidden
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: Permission to delete manifest 'XYZ' denied
         '500':
           description: Internal server error
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: "Internal server error: the slithy toves did gyre and gimble"
     parameters:
        - in: path
          name: manifestId

--- a/src/main/resources/fester_messages.xml
+++ b/src/main/resources/fester_messages.xml
@@ -101,6 +101,14 @@
   <entry key="MFS-085">The '{}' feature is unavailable on this server</entry>
   <entry key="MFS-086">Turning the '{}' feature off</entry>
   <entry key="MFS-087">Unable to find the h1 element in the feature flag test</entry>
+  <entry key="MFS-088">Successfully deleted: {}</entry>
+  <entry key="MFS-089">Access forbidden: {}</entry>
+  <entry key="MFS-090">Unexpected response code [{}]: {}</entry>
+  <entry key="MFS-091">Resource not found: {}</entry>
+  <entry key="MFS-092">Manifest successfully PUT: {}</entry>
+  <entry key="MFS-093"></entry>
+  <entry key="MFS-094"></entry>
+  <entry key="MFS-095"></entry>
 
   <entry key="MFS-100">Stopping the {} verticle [id: {}]</entry>
   <entry key="MFS-101">Getting message consumer for: {}</entry>

--- a/src/test/java/edu/ucla/library/iiif/fester/verticles/ManifestVerticleTest.java
+++ b/src/test/java/edu/ucla/library/iiif/fester/verticles/ManifestVerticleTest.java
@@ -183,6 +183,7 @@ public class ManifestVerticleTest {
         message.put(Constants.CSV_FILE_NAME, myRunID).put(Constants.CSV_FILE_PATH, filePath);
         message.put(Constants.FESTER_HOST, MANIFEST_HOST);
         options.addHeader(Constants.ACTION, Op.POST_CSV);
+        options.setSendTimeout(60000);
 
         LOGGER.debug(MessageCodes.MFS_120, HATHAWAY, ManifestVerticle.class.getName());
 


### PR DESCRIPTION
* Add human friendly text to the responses of our endpoints (that don't already output something like HTML that's intended for the user)
* Minor refactor on a variable name for consistency on naming standards
* Bump up the timeout on one of the tests that fails periodically because the S3BucketVerticle/FakeS3BucketVerticle swap doesn't happen in a timely manner
* Update OpenAPI spec with response content types and examples