### PR TITLE
[IIIF-788] Clean up obsolete Docker networks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -330,6 +330,28 @@
           </execution>
         </executions>
       </plugin>
+      <!-- Makes sure TestContainers doesn't leave unused networks around -->
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>docker-network-prune</id>
+            <phase>post-integration-test</phase>
+            <goals>
+              <goal>exec</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <executable>docker</executable>
+          <arguments>
+            <argument>network</argument>
+            <argument>prune</argument>
+            <argument>-f</argument>
+          </arguments>
+        </configuration>
+      </plugin>
       <!-- The build-helper plug-in gets us a dynamic port for testing -->
       <plugin>
         <groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
TestContainers seems to leave networks around despite Ryuk supposedly being responsible for cleaning them up. We add an additional cleanup as a part of our build so we don't get to the point where all Docker's networks are used up and we can't run the build.