### PR TITLE
[IIIF-707] Update CSS to fix text under top bar

### DIFF
--- a/src/main/webroot/css/redoc-custom.css
+++ b/src/main/webroot/css/redoc-custom.css
@@ -18,6 +18,10 @@ body {
   padding-top: 2em;
 }
 
+.kGvRyb {
+  margin-top: 35px;
+}
+
 .sc-jAaTju, .sc-cMljjf > div:nth-child(1) > span:nth-child(1) > div:nth-child(1) {
   color: white !important;
 }


### PR DESCRIPTION
Push the anchor headers down so that they do not display underneath the top menu bar (when someone clicks on them to go to the anchor location).

I added "before" and "after" screenshots to the Jira issue for this.