### PR TITLE
[IIIF-784] Update test logging config and options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ buildNumber.properties
 src/main/tools
 src/main/generated
 src/main/jbake/
+logback-test.xml
 
 ## Ignore project files created by IntelliJ IDEA
 *.iml

--- a/README.md
+++ b/README.md
@@ -60,6 +60,12 @@ When running the integration and functional tests, it may be desirable to turn o
 
 This will tunnel the container's logs (including the application within the container's logs) to Maven's logging mechanism so that you will be able to see what's happening in the container as the tests are being run against it.
 
+You might also want to adjust the logging level on the tests themselves. By default, the test loggers are configured to write DEBUG logs to a log file in the `target` directory and ERROR logs to standard out. To change the log level of the standard out logging, run Maven with the `testLogLevel` argument; for instance:
+
+    mvn -DtestLogLevel=DEBUG test
+
+If you want more fine-grained control over the logging, you can copy the `src/test/resources/logback-test.xml` file to the project's root directory and modify it. A `logback-test.xml` file in the project's home directory will be used instead of the standard one in `src/rest/resources` if it's available. That hypothetical file has also been added to the project's `.gitignore` so you don't need to worry about checking it into Git.
+
 ## Running the Application for Development
 
 You can run a development instance of Fester by typing the following within the project root:

--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,9 @@
     <seeLogsIT>false</seeLogsIT>
     <seeLogsFfT>false</seeLogsFfT>
 
+    <!-- What level of logging we want to see, by default, in our tests -->
+    <testLogLevel>ERROR</testLogLevel>
+
     <!-- AWS configuration properties -->
     <fester.s3.region>us-east-1</fester.s3.region>
     <fester.s3.bucket>iiif-fester</fester.s3.bucket>
@@ -264,6 +267,14 @@
     <testResources>
       <testResource>
         <directory>src/test/resources</directory>
+        <filtering>true</filtering>
+      </testResource>
+      <!-- We can also override the default logging configuration with a file in our root project directory -->
+      <testResource>
+        <directory>${basedir}</directory>
+        <includes>
+          <include>logback-test.xml</include>
+        </includes>
         <filtering>true</filtering>
       </testResource>
     </testResources>

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -3,6 +3,9 @@
   <timestamp key="byDay" datePattern="yyyy-MM-dd" />
 
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+      <level>${testLogLevel}</level>
+    </filter>
     <encoder>
       <pattern>[%level] %logger{45}:%X{line} | %msg%n</pattern>
     </encoder>
@@ -10,10 +13,10 @@
 
   <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
     <file>/var/log/fester/fester-${byDay}.log</file>
-      <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-        <fileNamePattern>/var/log/fester/fester.%d{yyyy-MM-dd}.log</fileNamePattern>
-        <maxHistory>30</maxHistory>
-        <totalSizeCap>2GB</totalSizeCap>
+    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+      <fileNamePattern>/var/log/fester/fester.%d{yyyy-MM-dd}.log</fileNamePattern>
+      <maxHistory>30</maxHistory>
+      <totalSizeCap>2GB</totalSizeCap>
     </rollingPolicy>
     <encoder>
       <pattern>[%level] %logger{45}:%X{line} | %msg%n</pattern>
@@ -22,16 +25,23 @@
 
   <logger name="io.netty" level="ERROR" additivity="false">
     <appender-ref ref="STDOUT" />
+    <appender-ref ref="FILEOUT" />
   </logger>
   <logger name="io.vertx" level="ERROR" additivity="false">
     <appender-ref ref="STDOUT" />
-  </logger>
-  <logger name="edu.ucla.library.iiif.fester" level="DEBUG" additivity="false">
-    <appender-ref ref="STDOUT" />
+    <appender-ref ref="FILEOUT" />
   </logger>
 
+  <!-- Loggers for our application -->
+  <logger name="edu.ucla.library.iiif.fester" level="DEBUG" additivity="false">
+    <appender-ref ref="STDOUT" />
+    <appender-ref ref="FILEOUT" />
+  </logger>
+
+  <!-- Default logging level for everything else -->
   <root level="INFO">
     <appender-ref ref="STDOUT" />
+    <appender-ref ref="FILEOUT" />
   </root>
 
 </configuration>

--- a/src/test/java/edu/ucla/library/iiif/fester/handlers/AbstractFesterHandlerTest.java
+++ b/src/test/java/edu/ucla/library/iiif/fester/handlers/AbstractFesterHandlerTest.java
@@ -21,6 +21,7 @@ import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import info.freelibrary.util.Logger;
 import info.freelibrary.util.LoggerFactory;
 
+import ch.qos.logback.classic.Level;
 import edu.ucla.library.iiif.fester.Config;
 import edu.ucla.library.iiif.fester.Constants;
 import edu.ucla.library.iiif.fester.MessageCodes;
@@ -46,10 +47,10 @@ abstract class AbstractFesterHandlerTest {
 
     protected static final File MANIFEST_FILE = new File("src/test/resources/json/ark%3A%2F21198%2Fzz0009gv8j.json");
 
-    protected static final File COLLECTION_FILE = new File("src/test/resources/json/ark%3A%2F21198%2Fzz0009gsq9.json");
+    protected static final File COLLECTION_FILE = new File(
+            "src/test/resources/json/ark%3A%2F21198%2Fzz0009gsq9.json");
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(AbstractFesterHandlerTest.class,
-            Constants.MESSAGES);
+    private static final Logger LOGGER = LoggerFactory.getLogger(AbstractFesterHandlerTest.class, Constants.MESSAGES);
 
     protected Vertx myVertx;
 
@@ -118,6 +119,24 @@ abstract class AbstractFesterHandlerTest {
         }
 
         myVertx.close(aContext.asyncAssertSuccess());
+    }
+
+    /**
+     * Set the log level of the supplied logger. This is really something that should bubble back up into the logging
+     * facade library.
+     *
+     * @param aLogClass A logger for which to set the level
+     * @param aLogLevel A new log level
+     * @return The logger's previous log level
+     */
+    protected Level setLogLevel(final Class aLogClass, final Level aLogLevel) {
+        final ch.qos.logback.classic.Logger logger = (ch.qos.logback.classic.Logger) LoggerFactory.getLogger(
+                aLogClass, Constants.MESSAGES).getLoggerImpl();
+        final Level level = logger.getEffectiveLevel();
+
+        logger.setLevel(aLogLevel);
+
+        return level;
     }
 
     /**

--- a/src/test/java/edu/ucla/library/iiif/fester/handlers/GetCollectionHandlerTest.java
+++ b/src/test/java/edu/ucla/library/iiif/fester/handlers/GetCollectionHandlerTest.java
@@ -10,6 +10,7 @@ import info.freelibrary.util.Logger;
 import info.freelibrary.util.LoggerFactory;
 import info.freelibrary.util.StringUtils;
 
+import ch.qos.logback.classic.Level;
 import edu.ucla.library.iiif.fester.Config;
 import edu.ucla.library.iiif.fester.Constants;
 import edu.ucla.library.iiif.fester.HTTP;
@@ -75,9 +76,12 @@ public class GetCollectionHandlerTest extends AbstractFesterHandlerTest {
         final Async asyncTask = aContext.async();
         final int port = aContext.get(Config.HTTP_PORT);
         final String missingPath = "/collections/missingIdentifier";
+        final Level logLevel = setLogLevel(GetCollectionHandler.class, Level.OFF);
 
         myVertx.createHttpClient().getNow(port, Constants.UNSPECIFIED_HOST, missingPath, response -> {
             final int statusCode = response.statusCode();
+
+            setLogLevel(GetCollectionHandler.class, logLevel); // Turn logger back on after expected error
 
             if (response.statusCode() != HTTP.NOT_FOUND) {
                 aContext.fail(LOGGER.getMessage(MessageCodes.MFS_004, HTTP.NOT_FOUND, statusCode));

--- a/src/test/java/edu/ucla/library/iiif/fester/handlers/PutCollectionHandlerTest.java
+++ b/src/test/java/edu/ucla/library/iiif/fester/handlers/PutCollectionHandlerTest.java
@@ -14,6 +14,7 @@ import com.amazonaws.SdkClientException;
 import info.freelibrary.util.Logger;
 import info.freelibrary.util.LoggerFactory;
 
+import ch.qos.logback.classic.Level;
 import edu.ucla.library.iiif.fester.Config;
 import edu.ucla.library.iiif.fester.Constants;
 import edu.ucla.library.iiif.fester.HTTP;
@@ -122,6 +123,7 @@ public class PutCollectionHandlerTest extends AbstractFesterHandlerTest {
         final int port = aContext.get(Config.HTTP_PORT);
         final String requestPath = IDUtils.getResourceURIPath(myPutCollectionS3Key);
         final RequestOptions requestOpts = new RequestOptions();
+        final Level logLevel = setLogLevel(GetCollectionHandler.class, Level.OFF);
 
         LOGGER.debug(MessageCodes.MFS_016, requestPath);
 
@@ -138,6 +140,8 @@ public class PutCollectionHandlerTest extends AbstractFesterHandlerTest {
                     myVertx.createHttpClient().getNow(port, Constants.UNSPECIFIED_HOST, requestPath, getResponse -> {
                         final int getStatusCode = getResponse.statusCode();
 
+                        setLogLevel(GetCollectionHandler.class, logLevel); // Turn logger back on after expected error
+
                         if (getStatusCode == HTTP.NOT_FOUND) {
                             if (!asyncTask.isCompleted()) {
                                 asyncTask.complete();
@@ -148,6 +152,7 @@ public class PutCollectionHandlerTest extends AbstractFesterHandlerTest {
                             aContext.fail(LOGGER.getMessage(MessageCodes.MFS_010, getStatusCode));
                         }
                     });
+
                     break;
                 default:
                     aContext.fail(LOGGER.getMessage(MessageCodes.MFS_019, manifestPath, putStatusCode));
@@ -170,6 +175,7 @@ public class PutCollectionHandlerTest extends AbstractFesterHandlerTest {
         final int port = aContext.get(Config.HTTP_PORT);
         final String requestPath = IDUtils.getResourceURIPath(myPutCollectionS3Key);
         final RequestOptions requestOpts = new RequestOptions();
+        final Level logLevel = setLogLevel(GetCollectionHandler.class, Level.OFF);
 
         LOGGER.debug(MessageCodes.MFS_016, requestPath);
 
@@ -185,6 +191,8 @@ public class PutCollectionHandlerTest extends AbstractFesterHandlerTest {
                     // Send a GET request to the same path to make sure PUT failed
                     myVertx.createHttpClient().getNow(port, Constants.UNSPECIFIED_HOST, requestPath, getResponse -> {
                         final int getStatusCode = getResponse.statusCode();
+
+                        setLogLevel(GetCollectionHandler.class, logLevel); // Turn logger back on after expected error
 
                         if (getStatusCode == HTTP.NOT_FOUND) {
                             if (!asyncTask.isCompleted()) {

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -3,14 +3,17 @@
   <timestamp key="byDay" datePattern="yyyy-MM-dd" />
   
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+      <level>${testLogLevel}</level>
+    </filter>
     <encoder>
       <pattern>[%level] %logger{45}:%X{line} | %msg%n</pattern>
     </encoder>
   </appender>
 
-  <appender name="FILE" class="ch.qos.logback.core.FileAppender">
+  <appender name="FILEOUT" class="ch.qos.logback.core.FileAppender">
     <file>target/${project.artifactId}-${byDay}.log</file>
-    <append>false</append>
+    <append>true</append>
     <encoder>
       <pattern>[%level] %logger{45}:%X{line} | %msg%n</pattern>
     </encoder>
@@ -18,33 +21,45 @@
 
   <logger name="io.netty" level="ERROR" additivity="false">
     <appender-ref ref="STDOUT" />
+    <appender-ref ref="FILEOUT" />
   </logger>
   <logger name="io.vertx" level="ERROR" additivity="false">
     <appender-ref ref="STDOUT" />
+    <appender-ref ref="FILEOUT" />
   </logger>
+
+  <!-- Loggers for our application -->
   <logger name="edu.ucla.library.iiif.fester" level="DEBUG" additivity="false">
     <appender-ref ref="STDOUT" />
+    <appender-ref ref="FILEOUT" />
   </logger>
 
   <!-- Loggers for the testcontainers.org tool -->
   <logger name="org.testcontainers.utility.RegistryAuthLocator" level="ERROR">
     <appender-ref ref="STDOUT" />
+    <appender-ref ref="FILEOUT" />
   </logger>
   <logger name="org.testcontainers.dockerclient.DockerClientProviderStrategy" level="WARN">
     <appender-ref ref="STDOUT" />
+    <appender-ref ref="FILEOUT" />
   </logger>
   <logger name="org.testcontainers.dockerclient.EnvironmentAndSystemPropertyClientProviderStrategy" level="WARN">
     <appender-ref ref="STDOUT" />
+    <appender-ref ref="FILEOUT" />
   </logger>
   <logger name="org.testcontainers.utility.ResourceReaper" level="ERROR">
     <appender-ref ref="STDOUT" />
+    <appender-ref ref="FILEOUT" />
   </logger>
   <logger name="🐳 [alpine/socat:latest]" level="WARN">
     <appender-ref ref="STDOUT" />
+    <appender-ref ref="FILEOUT" />
   </logger>
 
+  <!-- Default logging level for everything else -->
   <root level="INFO">
     <appender-ref ref="STDOUT" />
+    <appender-ref ref="FILEOUT" />
   </root>
 
 </configuration>


### PR DESCRIPTION
* Set test logging to a sane level (i.e., ERROR instead of DEBUG)
* Allow overriding default test stdout logging level with Maven build property (via command line or settings.xml file)
* Create mechanism to override `src/test/resources/logback-test.xml` with `logback-test.xml` file in project's root directory (and add that file to `.gitignore`) for even more control over logging levels
* Turn off error logging on tests that are supposed to test failures (in these cases, the ERROR logs are false positives)
* Update README

Fixes IIIF-784 (log to file) and IIIF-778 (have more control over logging levels)