### PR TITLE
[IIIF-697] Improve error handling in IDUtils

### DIFF
--- a/src/main/java/edu/ucla/library/iiif/fester/MalformedPathException.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/MalformedPathException.java
@@ -1,0 +1,124 @@
+
+package edu.ucla.library.iiif.fester;
+
+import java.util.Locale;
+
+import info.freelibrary.util.I18nRuntimeException;
+
+/**
+ * A runtime exception thrown when a path is incorrectly constructed.
+ */
+public class MalformedPathException extends I18nRuntimeException {
+
+    /**
+     * The <code>serialVersionUID</code> for MalformedPathException.
+     */
+    private static final long serialVersionUID = 3817178883041384608L;
+
+    /**
+     * Creates a new path structure exception.
+     */
+    public MalformedPathException() {
+    }
+
+    /**
+     * Creates a new path structure exception from the supplied parent exception.
+     *
+     * @param aCause An underlying cause of the exception
+     */
+    public MalformedPathException(final Throwable aCause) {
+        super(aCause);
+    }
+
+    /**
+     * Creates a new path structure exception from the supplied exception message (or message key).
+     *
+     * @param aMessageKey An exception message (or message key)
+     */
+    public MalformedPathException(final String aMessageKey) {
+        super(Constants.MESSAGES, aMessageKey);
+    }
+
+    /**
+     * Creates a new path structure exception from the supplied exception message (or message key) and locale.
+     *
+     * @param aLocale A locale
+     * @param aMessageKey An exception message (or message key)
+     */
+    public MalformedPathException(final Locale aLocale, final String aMessageKey) {
+        super(aLocale, Constants.MESSAGES, aMessageKey);
+    }
+
+    /**
+     * Creates a new path structure exception from the supplied exception message (or message key) and additional
+     * details.
+     *
+     * @param aMessageKey An exception message (or message key)
+     * @param aVarargs Additional details about the exception
+     */
+    public MalformedPathException(final String aMessageKey, final Object... aVarargs) {
+        super(Constants.MESSAGES, aMessageKey, aVarargs);
+    }
+
+    /**
+     * Creates a new path structure exception from the supplied exception message (or message key) and parent
+     * exception.
+     *
+     * @param aCause An underlying exception
+     * @param aMessageKey An exception message (or message key)
+     */
+    public MalformedPathException(final Throwable aCause, final String aMessageKey) {
+        super(aCause, Constants.MESSAGES, aMessageKey);
+    }
+
+    /**
+     * Creates a new path structure exception from the supplied exception message (or message key), locale, and
+     * additional details.
+     *
+     * @param aLocale A locale
+     * @param aMessageKey An exception message (or message key)
+     * @param aVarargs Additional details about the exception
+     */
+    public MalformedPathException(final Locale aLocale, final String aMessageKey, final Object... aVarargs) {
+        super(aLocale, Constants.MESSAGES, aMessageKey, aVarargs);
+    }
+
+    /**
+     * Creates a new path structure exception from the supplied exception message (or message key), locale, and parent
+     * exception.
+     *
+     * @param aCause An underlying exception
+     * @param aLocale A locale
+     * @param aMessageKey An exception message (or message key)
+     */
+    public MalformedPathException(final Throwable aCause, final Locale aLocale, final String aMessageKey) {
+        super(aCause, aLocale, Constants.MESSAGES, aMessageKey);
+    }
+
+    /**
+     * Creates a new path structure exception from the supplied exception message (or message key), parent exception,
+     * and additional details.
+     *
+     * @param aCause An underlying exception
+     * @param aMessageKey An exception message (or message key)
+     * @param aVarargs Additional details about the exception
+     */
+    public MalformedPathException(final Throwable aCause, final String aMessageKey, final Object... aVarargs) {
+        super(aCause, Constants.MESSAGES, aMessageKey, aVarargs);
+    }
+
+    /**
+     * Creates a new path structure exception from the supplied exception message (or message key), locale, and parent
+     * exception.
+     *
+     * @param aCause An underlying exception
+     * @param aLocale A locale
+     * @param aMessageKey An exception message (or message key)
+     * @param aVarargs Additional details about the exception
+     */
+    public MalformedPathException(final Throwable aCause, final Locale aLocale, final String aMessageKey,
+            final Object... aVarargs) {
+        super(aCause, aLocale, Constants.MESSAGES, aMessageKey, aVarargs);
+    }
+
+}

--- a/src/main/java/edu/ucla/library/iiif/fester/utils/IDUtils.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/utils/IDUtils.java
@@ -196,7 +196,7 @@ public final class IDUtils {
      * @deprecated Gets an S3 key for a work, with an extension to append if the identifier doesn't have it already.
      *             TODO: remove in 1.0.0
      * @param aID The ID (ARK) of the work
-     * @param aExt The extension to append if the id)entifier doesn't have it already
+     * @param aExt The extension to append if the identifier doesn't have it already
      * @return An S3 key
      */
     @Deprecated

--- a/src/main/java/edu/ucla/library/iiif/fester/utils/IDUtils.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/utils/IDUtils.java
@@ -12,8 +12,11 @@ import java.util.Set;
 
 import org.apache.commons.lang3.RandomStringUtils;
 
-import edu.ucla.library.iiif.fester.Constants;
 import info.freelibrary.util.FileUtils;
+
+import edu.ucla.library.iiif.fester.Constants;
+import edu.ucla.library.iiif.fester.MalformedPathException;
+import edu.ucla.library.iiif.fester.MessageCodes;
 
 /**
  * A utilities class for working with IDs.
@@ -83,17 +86,21 @@ public final class IDUtils {
      *
      * @param aS3Key The S3 key for the IIIF resource
      * @return A IIIF resource URI path
+     * @throws MalformedPathException If the supplied S3 key doesn't start with {@link Constants.WORK_S3_KEY_PREFIX}
+     *         or {@link Constants.COLLECTION_S3_KEY_PREFIX}
      */
-    public static String getResourceURIPath(final String aS3Key) {
+    public static String getResourceURIPath(final String aS3Key) throws MalformedPathException {
         final String encodedID = URLEncoder.encode(getResourceID(aS3Key), StandardCharsets.UTF_8);
         final String path;
 
-        if (aS3Key.contains(Constants.COLLECTION_S3_KEY_PREFIX)) {
+        checkPrefixValidity(aS3Key);
+
+        if (aS3Key.startsWith(Constants.COLLECTION_S3_KEY_PREFIX)) {
             path = Constants.COLLECTION_URI_PATH_PREFIX + encodedID;
-        } else {
-            // TODO: check (aS3Key.contains(Constants.WORK_S3_KEY_PREFIX))
+        } else { // it starts with Constants.WORK_S3_KEY_PREFIX
             path = Constants.SLASH + encodedID + Constants.MANIFEST_URI_PATH_SUFFIX;
         }
+
         return path;
     }
 
@@ -102,15 +109,20 @@ public final class IDUtils {
      *
      * @param aS3Key The S3 key for the IIIF resource
      * @return An ID (ARK)
+     * @throws MalformedPathException If the supplied S3 key doesn't start with {@link Constants.WORK_S3_KEY_PREFIX}
+     *         or {@link Constants.COLLECTION_S3_KEY_PREFIX}
      */
-    public static String getResourceID(final String aS3Key) {
+    public static String getResourceID(final String aS3Key) throws MalformedPathException {
         final String s3KeyPrefix;
-        if (aS3Key.contains(Constants.COLLECTION_S3_KEY_PREFIX)) {
+
+        checkPrefixValidity(aS3Key);
+
+        if (aS3Key.startsWith(Constants.COLLECTION_S3_KEY_PREFIX)) {
             s3KeyPrefix = Constants.COLLECTION_S3_KEY_PREFIX;
-        } else {
-            // TODO: check (aS3Key.contains(Constants.WORK_S3_KEY_PREFIX))
+        } else { // it starts with Constants.WORK_S3_KEY_PREFIX
             s3KeyPrefix = Constants.WORK_S3_KEY_PREFIX;
         }
+
         return FileUtils.stripExt(aS3Key.substring(s3KeyPrefix.length()));
     }
 
@@ -129,8 +141,10 @@ public final class IDUtils {
      *
      * @param aURI The URI of the IIIF resource
      * @return An S3 key
+     * @throws MalformedPathException If the supplied URI doesn't contain {@link Constants.MANIFEST_URI_PATH_SUFFIX}
+     *         or {@link Constants.COLLECTION_URI_PATH_PREFIX}
      */
-    public static String getResourceS3Key(final URI aURI) {
+    public static String getResourceS3Key(final URI aURI) throws MalformedPathException {
         final String path = aURI.getPath();
         final String encodedID;
         final String uriPathPrefix;
@@ -142,16 +156,20 @@ public final class IDUtils {
             uriPathPrefix = Constants.COLLECTION_URI_PATH_PREFIX;
             s3KeyPrefix = Constants.COLLECTION_S3_KEY_PREFIX;
             endIndex = path.length();
-        } else {
-            // TODO: check (path.contains(Constants.MANIFEST_URI_PATH_SUFFIX))
+        } else if (path.contains(Constants.MANIFEST_URI_PATH_SUFFIX)) {
             uriPathPrefix = Constants.SLASH;
             s3KeyPrefix = Constants.WORK_S3_KEY_PREFIX;
             endIndex = path.length() - Constants.MANIFEST_URI_PATH_SUFFIX.length();
+        } else {
+            throw new MalformedPathException(MessageCodes.MFS_143, aURI, Constants.MANIFEST_URI_PATH_SUFFIX,
+                    Constants.COLLECTION_URI_PATH_PREFIX);
         }
+
         encodedID = path.substring(uriPathPrefix.length(), endIndex);
 
-        // Add any prefix and a .json extension
-        return s3KeyPrefix + URLDecoder.decode(encodedID, StandardCharsets.UTF_8) + Constants.DOT + Constants.JSON_EXT;
+        // Concatenate prefix, ID, and a ".json" extension
+        return s3KeyPrefix + URLDecoder.decode(encodedID, StandardCharsets.UTF_8) + Constants.DOT +
+                Constants.JSON_EXT;
     }
 
     /**
@@ -161,16 +179,24 @@ public final class IDUtils {
      * @return An S3 key
      */
     public static String getWorkS3Key(final String aID) {
+        final String jsonExtension = Constants.DOT + Constants.JSON_EXT;
+
+        if (aID.startsWith(Constants.WORK_S3_KEY_PREFIX)) {
+            throw new MalformedPathException(MessageCodes.MFS_144, aID);
+        }
+
+        if (aID.endsWith(jsonExtension)) {
+            throw new MalformedPathException(MessageCodes.MFS_145, aID);
+        }
+
         return Constants.WORK_S3_KEY_PREFIX + aID + Constants.DOT + Constants.JSON_EXT;
     }
 
     /**
      * @deprecated Gets an S3 key for a work, with an extension to append if the identifier doesn't have it already.
-     *
-     * TODO: remove in 1.0.0
-     *
+     *             TODO: remove in 1.0.0
      * @param aID The ID (ARK) of the work
-     * @param aExt The extension to append if the identifier doesn't have it already
+     * @param aExt The extension to append if the id)entifier doesn't have it already
      * @return An S3 key
      */
     @Deprecated
@@ -189,6 +215,29 @@ public final class IDUtils {
      * @return An S3 key
      */
     public static String getCollectionS3Key(final String aID) {
-        return Constants.COLLECTION_S3_KEY_PREFIX + aID + Constants.DOT + Constants.JSON_EXT;
+        final String jsonExtension = Constants.DOT + Constants.JSON_EXT;
+
+        if (aID.startsWith(Constants.COLLECTION_S3_KEY_PREFIX)) {
+            throw new MalformedPathException(MessageCodes.MFS_144, aID);
+        }
+
+        if (aID.endsWith(jsonExtension)) {
+            throw new MalformedPathException(MessageCodes.MFS_145, aID);
+        }
+
+        return Constants.COLLECTION_S3_KEY_PREFIX + aID + jsonExtension;
+    }
+
+    /**
+     * Checks for a valid S3 key path prefix.
+     *
+     * @param aS3Key An S3 key
+     */
+    private static void checkPrefixValidity(final String aS3Key) {
+        if (!aS3Key.startsWith(Constants.COLLECTION_S3_KEY_PREFIX) && !aS3Key.startsWith(
+                Constants.WORK_S3_KEY_PREFIX)) {
+            throw new MalformedPathException(MessageCodes.MFS_142, aS3Key, Constants.WORK_S3_KEY_PREFIX,
+                    Constants.COLLECTION_S3_KEY_PREFIX);
+        }
     }
 }

--- a/src/main/java/edu/ucla/library/iiif/fester/verticles/S3BucketVerticle.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/verticles/S3BucketVerticle.java
@@ -148,6 +148,7 @@ public class S3BucketVerticle extends AbstractFesterVerticle {
 
         LOGGER.debug(MessageCodes.MFS_051, aManifest, myS3Bucket);
         LOGGER.debug(MessageCodes.MFS_128, manifestID);
+
         if (!aS3Key.equals(derivedManifestS3Key)) {
             LOGGER.warn(MessageCodes.MFS_138, aS3Key, derivedManifestS3Key);
         }

--- a/src/main/resources/fester_messages.xml
+++ b/src/main/resources/fester_messages.xml
@@ -144,4 +144,9 @@
   <entry key="MFS-139">'{}' unable to handle message '{}': unknown action '{}'</entry>
   <entry key="MFS-140">Manifest '{}' not found when it should have been put</entry>
   <entry key="MFS-141">Manifest '{}' found when it should not have been put</entry>
+  <entry key="MFS-142">S3 key '{}' does not start with required prefixes: {} or {}</entry>
+  <entry key="MFS-143">URI path '{}' does not contain a required subpath: {} or {}</entry>
+  <entry key="MFS-144">S3 key already starts with the prefix to be added: {}</entry>
+  <entry key="MFS-145">S3 key already ends with .json extension: {}</entry>
+  <entry key="MFS-146"></entry>
 </properties>

--- a/src/test/java/edu/ucla/library/iiif/fester/utils/IDUtilsTest.java
+++ b/src/test/java/edu/ucla/library/iiif/fester/utils/IDUtilsTest.java
@@ -5,8 +5,13 @@ import static org.junit.Assert.assertEquals;
 
 import java.net.URI;
 import java.util.List;
+import java.util.UUID;
 
+import org.junit.Before;
 import org.junit.Test;
+
+import edu.ucla.library.iiif.fester.Constants;
+import edu.ucla.library.iiif.fester.MalformedPathException;
 
 /**
  * Tests of IDUtils.
@@ -23,7 +28,6 @@ public class IDUtilsTest {
 
     private static final String WORK_MANIFEST_S3_KEY = "works/ark:/21198/zz000bjfsv.json";
 
-
     private static final String COLLECTION_MANIFEST_ID = "ark:/21198/zz0009gss9";
 
     private static final String COLLECTION_MANIFEST_URI_PATH = "/collections/ark%3A%2F21198%2Fzz0009gss9";
@@ -31,6 +35,16 @@ public class IDUtilsTest {
     private static final String COLLECTION_MANIFEST_URI = FAKE_HOST + COLLECTION_MANIFEST_URI_PATH;
 
     private static final String COLLECTION_MANIFEST_S3_KEY = "collections/ark:/21198/zz0009gss9.json";
+
+    private String myTestID;
+
+    /**
+     * Create a fake ID for testing.
+     */
+    @Before
+    public final void setUp() {
+        myTestID = UUID.randomUUID().toString();
+    }
 
     /**
      * Tests getIDs().
@@ -68,8 +82,7 @@ public class IDUtilsTest {
      */
     @Test
     public final void testGetLastPartStringWithoutSlashes() {
-        final String id = "YadaYadaYada";
-        assertEquals(id, IDUtils.getLastPart(id));
+        assertEquals(myTestID, IDUtils.getLastPart(myTestID));
     }
 
     /**
@@ -77,10 +90,7 @@ public class IDUtilsTest {
      */
     @Test
     public final void testGetResourceURIWork() {
-        final String expected = WORK_MANIFEST_URI;
-        final String found = IDUtils.getResourceURI(FAKE_HOST, WORK_MANIFEST_S3_KEY).toString();
-
-        assertEquals(expected, found);
+        assertEquals(WORK_MANIFEST_URI, IDUtils.getResourceURI(FAKE_HOST, WORK_MANIFEST_S3_KEY).toString());
     }
 
     /**
@@ -88,11 +98,8 @@ public class IDUtilsTest {
      */
     @Test
     public final void testGetResourceURICollection() {
-        final String expected = COLLECTION_MANIFEST_URI;
-        final String found = IDUtils.getResourceURI(FAKE_HOST, COLLECTION_MANIFEST_S3_KEY)
-                .toString();
-
-        assertEquals(expected, found);
+        assertEquals(COLLECTION_MANIFEST_URI, IDUtils.getResourceURI(FAKE_HOST, COLLECTION_MANIFEST_S3_KEY)
+                .toString());
     }
 
     /**
@@ -100,10 +107,7 @@ public class IDUtilsTest {
      */
     @Test
     public final void testGetResourceURIPathWork() {
-        final String expected = WORK_MANIFEST_URI_PATH;
-        final String found = IDUtils.getResourceURIPath(WORK_MANIFEST_S3_KEY);
-
-        assertEquals(expected, found);
+        assertEquals(WORK_MANIFEST_URI_PATH, IDUtils.getResourceURIPath(WORK_MANIFEST_S3_KEY));
     }
 
     /**
@@ -111,10 +115,15 @@ public class IDUtilsTest {
      */
     @Test
     public final void testGetResourceURIPathCollection() {
-        final String expected = COLLECTION_MANIFEST_URI_PATH;
-        final String found = IDUtils.getResourceURIPath(COLLECTION_MANIFEST_S3_KEY);
+        assertEquals(COLLECTION_MANIFEST_URI_PATH, IDUtils.getResourceURIPath(COLLECTION_MANIFEST_S3_KEY));
+    }
 
-        assertEquals(expected, found);
+    /**
+     * Tests that getResourceURIPath() doesn't accept things without the required paths.
+     */
+    @Test(expected = MalformedPathException.class)
+    public final void testGetResourceURIPathInvalid() {
+        IDUtils.getResourceURIPath(myTestID);
     }
 
     /**
@@ -122,10 +131,7 @@ public class IDUtilsTest {
      */
     @Test
     public final void testGetResourceS3KeyWork() {
-        final String expected = WORK_MANIFEST_S3_KEY;
-        final String found = IDUtils.getResourceS3Key(URI.create(WORK_MANIFEST_URI));
-
-        assertEquals(expected, found);
+        assertEquals(WORK_MANIFEST_S3_KEY, IDUtils.getResourceS3Key(URI.create(WORK_MANIFEST_URI)));
     }
 
     /**
@@ -133,10 +139,31 @@ public class IDUtilsTest {
      */
     @Test
     public final void testGetResourceS3KeyCollection() {
-        final String expected = COLLECTION_MANIFEST_S3_KEY;
-        final String found = IDUtils.getResourceS3Key(URI.create(COLLECTION_MANIFEST_URI));
+        assertEquals(COLLECTION_MANIFEST_S3_KEY, IDUtils.getResourceS3Key(URI.create(COLLECTION_MANIFEST_URI)));
+    }
 
-        assertEquals(expected, found);
+    /**
+     * Tests getResourceS3Key() method to make sure it doesn't accept keys that are invalid.
+     */
+    @Test(expected = MalformedPathException.class)
+    public final void testGetResourceS3KeyInvalid() {
+        IDUtils.getResourceS3Key(URI.create(myTestID));
+    }
+
+    /**
+     * Tests the check on pre-existing collection S3 key prefixes.
+     */
+    @Test(expected = MalformedPathException.class)
+    public final void testGetResourceS3KeyPrefixed() {
+        IDUtils.getResourceS3Key(URI.create(Constants.COLLECTION_S3_KEY_PREFIX + myTestID));
+    }
+
+    /**
+     * Tests the check on pre-existing collection S3 key extensions.
+     */
+    @Test(expected = MalformedPathException.class)
+    public final void testGetResourceS3KeyExtension() {
+        IDUtils.getResourceS3Key(URI.create(myTestID + Constants.DOT + Constants.JSON_EXT));
     }
 
     /**
@@ -144,10 +171,7 @@ public class IDUtilsTest {
      */
     @Test
     public final void testGetResourceIDWorkURI() {
-        final String expected = WORK_MANIFEST_ID;
-        final String found = IDUtils.getResourceID(URI.create(WORK_MANIFEST_URI));
-
-        assertEquals(expected, found);
+        assertEquals(WORK_MANIFEST_ID, IDUtils.getResourceID(URI.create(WORK_MANIFEST_URI)));
     }
 
     /**
@@ -155,10 +179,15 @@ public class IDUtilsTest {
      */
     @Test
     public final void testGetResourceIDCollectionURI() {
-        final String expected = COLLECTION_MANIFEST_ID;
-        final String found = IDUtils.getResourceID(URI.create(COLLECTION_MANIFEST_URI));
+        assertEquals(COLLECTION_MANIFEST_ID, IDUtils.getResourceID(URI.create(COLLECTION_MANIFEST_URI)));
+    }
 
-        assertEquals(expected, found);
+    /**
+     * Tests getResourceID() method to make sure it doesn't except invalid URIs.
+     */
+    @Test(expected = MalformedPathException.class)
+    public final void testGetResourceIDInvalidURI() {
+        IDUtils.getResourceID(URI.create(myTestID));
     }
 
     /**
@@ -166,10 +195,7 @@ public class IDUtilsTest {
      */
     @Test
     public final void testGetResourceIDWorkS3Key() {
-        final String expected = WORK_MANIFEST_ID;
-        final String found = IDUtils.getResourceID(WORK_MANIFEST_S3_KEY);
-
-        assertEquals(expected, found);
+        assertEquals(WORK_MANIFEST_ID, IDUtils.getResourceID(WORK_MANIFEST_S3_KEY));
     }
 
     /**
@@ -177,10 +203,15 @@ public class IDUtilsTest {
      */
     @Test
     public final void testGetResourceIDCollectionS3Key() {
-        final String expected = COLLECTION_MANIFEST_ID;
-        final String found = IDUtils.getResourceID(COLLECTION_MANIFEST_S3_KEY);
+        assertEquals(COLLECTION_MANIFEST_ID, IDUtils.getResourceID(COLLECTION_MANIFEST_S3_KEY));
+    }
 
-        assertEquals(expected, found);
+    /**
+     * Tests to make sure getResourceID() doesn't accept invalid keys.
+     */
+    @Test(expected = MalformedPathException.class)
+    public final void testGetResourceIDInvalidKey() {
+        IDUtils.getResourceID(myTestID);
     }
 
     /**
@@ -188,10 +219,23 @@ public class IDUtilsTest {
      */
     @Test
     public final void testGetWorkS3Key() {
-        final String expected = WORK_MANIFEST_S3_KEY;
-        final String found = IDUtils.getWorkS3Key(WORK_MANIFEST_ID);
+        assertEquals(WORK_MANIFEST_S3_KEY, IDUtils.getWorkS3Key(WORK_MANIFEST_ID));
+    }
 
-        assertEquals(expected, found);
+    /**
+     * Tests S3 key mapping when the key already has the prefix to be added.
+     */
+    @Test(expected = MalformedPathException.class)
+    public final void testGetWorkS3KeyPrefix() {
+        IDUtils.getWorkS3Key(Constants.WORK_S3_KEY_PREFIX + WORK_MANIFEST_ID);
+    }
+
+    /**
+     * Tests S3 key mapping when the key already has the extension to be added.
+     */
+    @Test(expected = MalformedPathException.class)
+    public final void testGetWorkS3KeyExt() {
+        IDUtils.getWorkS3Key(WORK_MANIFEST_ID + Constants.DOT + Constants.JSON_EXT);
     }
 
     /**
@@ -199,9 +243,6 @@ public class IDUtilsTest {
      */
     @Test
     public final void testGetCollectionS3Key() {
-        final String expected = COLLECTION_MANIFEST_S3_KEY;
-        final String found = IDUtils.getCollectionS3Key(COLLECTION_MANIFEST_ID);
-
-        assertEquals(expected, found);
+        assertEquals(COLLECTION_MANIFEST_S3_KEY, IDUtils.getCollectionS3Key(COLLECTION_MANIFEST_ID));
     }
 }


### PR DESCRIPTION
* Create new runtime exception for path (s3 or URI) problems
* Catch more possible (bad) variations in ID values
* Add new tests for those error checks
* Refactor tests for brevity

This PR is going to have conflicts with the one that removed the deprecated method from IDUtils, I fear.