### PR TITLE
[IIIF-800] Add 404 to manifest delete endpoint in spec

### DIFF
--- a/src/main/resources/fester.yaml
+++ b/src/main/resources/fester.yaml
@@ -200,6 +200,13 @@ paths:
           description: Deleted the manifest at the supplied ID
         '403':
           description: Forbidden
+        '404':
+          description: Not found
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: The manifest 'FakeManifest' could not be found
         '500':
           description: Internal server error
     parameters:


### PR DESCRIPTION
We apparently missed including a 404 response in the delete manifest endpoint in the OpenAPI spec. We implemented it in the handler and have a test for it, but no documentation in the spec. This ticket adds it to the spec/documentation.