### PR TITLE
Reformat festerize README.md

### DIFF
--- a/src/main/scripts/festerize/README.md
+++ b/src/main/scripts/festerize/README.md
@@ -8,7 +8,8 @@ First, ensure that you have Bash, cURL, Python 3 and Pip installed on your syste
 
 When that's done, run the following command in your shell to install the latest release of Festerize:
 
-    bash <(curl -sSL https://raw.githubusercontent.com/UCLALibrary/fester/master/src/main/scripts/festerize/install.sh)
+    bash <(curl -sSL \
+      https://raw.githubusercontent.com/UCLALibrary/fester/master/src/main/scripts/festerize/install.sh)
 
 ## Usage
 


### PR DESCRIPTION
A small reformat to prevent the install command from being hidden by the README code scroller.