### PR TITLE
[IIIF-782] Enable debugging of application code running in a container

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,40 +76,82 @@ Once run, the service can be verified/accessed at [http://localhost:8888/fester/
 
 ## Debugging with Eclipse IDE
 
-You can run a development instance of Fester with debugging turned on by typing the following within the project root:
+There are two ways to debug Fester:
 
-    mvn -Pdebug test
-Development instances are configured to accept remote debugger connections on port `5555`.
+- **Debugging the tests.** This enables stepping through test suite code as well as the application code as runs according to the test suite.
+- **Debugging a running instance.** This enables stepping through the application code as it runs according to a developer's interaction with the HTTP API.
 
-To debug Fester with [Eclipse IDE](https://www.eclipse.org/eclipseide/):
+The following setup instructions were tested with [Eclipse IDE](https://www.eclipse.org/eclipseide/) 4.14.0 (2019-12).
 
-1. Create a new run configuration
+### Debugging the tests
+
+From within Eclipse:
+
+1. Create a new debug configuration
+    - In the top-level menu, select *Run* > *Debug Configurations...*
+    - In the pop-up window:
+        - Create a new configuration of type *Remote Java Application*
+        - Set *Name* to something like `Fester (JDWP server for containerized instances created by test suite)`
+        - In the *Connect* tab:
+            - Set *Project* to the Fester project directory
+            - Set *Connection Type* to `Standard (Socket Listen)`
+            - Set *Port* to `5556`
+            - Set *Connection limit* to `16`
+            - Check *Allow termination of remote VM* (optional)
+2. Create another debug configuration *
+    - In the top-level menu, select *Run* > *Debug Configurations...*
+    - In the pop-up window:
+        - Create a new configuration of type *Maven Build*
+        - Set *Name* to something like `Fester (debug test suite)`
+        - In the *Main* tab:
+            - Set *Base directory* to the Fester project directory
+            - Set *Goals* to `integration-test`
+            - Set *Profiles* to `debug`
+            - Set *User settings* to the path to a `settings.xml` that contains your AWS S3 credentials
+3. Run the debug configuration created in Step 1 **
+4. Run the debug configuration created in Step 2 **
+
+_* As an alternative to step 2 (and 4), run the following from the command line (after completing steps 1 and 3):_
+
+    mvn -Pdebug integration-test
+
+_** If you're doing this for the first time, you may need to bring back the pop-up window where you created the configuration in order to invoke it. Otherwise, you can use toolbar buttons, or hotkeys <kbd>Ctrl</kbd> <kbd>F11</kbd> (Run) or <kbd>F11</kbd> (Debug)._
+
+### Debugging a running instance
+
+This procedure will start an instance of Fester with port `5555` open for incoming JDWP connections.
+
+From within Eclipse:
+
+1. Create a new run configuration ***
     - In the top-level menu, select *Run* > *Run Configurations...*
     - In the pop-up window:
         - Create a new configuration of type *Maven Build*
-        - Set *Name* to something like `Fester (development mode)`
+        - Set *Name* to something like `Fester (debugging mode)`
         - In the *Main* tab:
             - Set *Base directory* to the Fester project directory
             - Set *Goals* to `test`
-            - Set *Profiles* to `live`
+            - Set *Profiles* to `runDebug`
             - Set *User settings* to the path to a `settings.xml` that contains your AWS S3 credentials
 2. Create a new debug configuration
     - In the top-level menu, select *Run* > *Debug Configurations...*
     - In the pop-up window:
         - Create a new configuration of type *Remote Java Application*
-        - Set *Name* to something like `Fester (socket attach)`
+        - Set *Name* to something like `Fester (JDWP client)`
         - In the *Connect* tab:
             - Set *Project* to the Fester project directory
             - Set *Connection Type* to `Standard (Socket Attach)`
             - Set *Host* to `localhost`
             - Set *Port* to `5555`
             - Check *Allow termination of remote VM* (optional)
-3. Run the new run configuration created in Step 1 *
-4. Run the new debug configuration created in Step 2 *
+3. Run the new run configuration created in Step 1
+4. Run the new debug configuration created in Step 2
 
-_* If you're doing this for the first time, you may need to bring back the pop-up window where you created the configuration in order to invoke it. Otherwise, you can use toolbar buttons, or hotkeys <kbd>Ctrl</kbd> <kbd>F11</kbd> (Run) or <kbd>F11</kbd> (Debug)._
+_*** As an alternative to step 1 (and 3), run the following from the command line:_
 
-Tested with Eclipse IDE 4.14.0 (2019-12).
+    mvn -PrunDebug test
+
+_and then proceed with steps 2 and 4._
 
 ## Load Testing
 

--- a/README.md
+++ b/README.md
@@ -78,8 +78,8 @@ Once run, the service can be verified/accessed at [http://localhost:8888/fester/
 
 There are two ways to debug Fester:
 
-- **Debugging the tests.** This enables stepping through test suite code as well as the application code as runs according to the test suite.
-- **Debugging a running instance.** This enables stepping through the application code as it runs according to a developer's interaction with the HTTP API.
+- **Debugging the tests.** This enables the developer to step through both the test and application code as the test suite runs.
+- **Debugging a running instance.** This enables the developer to step through the application code as they interact with the HTTP API.
 
 The following setup instructions were tested with [Eclipse IDE](https://www.eclipse.org/eclipseide/) 4.14.0 (2019-12).
 

--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,15 @@
 
     <!-- The port Fester listens on -->
     <fester.http.port>8888</fester.http.port>
+
+    <!-- The port a debugger may attach to when Fester is running in debug mode -->
     <fester.debug.port>5555</fester.debug.port>
+
+    <!-- The port a debugger may listen on to debug a containerized Fester instance -->
+    <jdwp.host.port>5556</jdwp.host.port>
+
+    <!-- The JDWP configuration for debugging a containerized Fester instance; see "debug" profile -->
+    <jdwp.client.config />
 
     <!-- The Docker registry user and password used for publishing images -->
     <docker.registry.username />
@@ -608,6 +616,8 @@
                 <fester.s3.bucket>${fester.s3.bucket}</fester.s3.bucket>
                 <fester.container.tag>${project.artifactId}:${project.version}</fester.container.tag>
                 <feature.flags>https://iiif-manifest-store.s3.amazonaws.com/fester-features-off.conf</feature.flags>
+                <jdwp.host.port>${jdwp.host.port}</jdwp.host.port>
+                <jdwp.client.config>${jdwp.client.config}</jdwp.client.config>
               </systemPropertyVariables>
             </configuration>
           </execution>
@@ -634,6 +644,8 @@
                 <fester.s3.bucket>${fester.s3.bucket}</fester.s3.bucket>
                 <fester.container.tag>${project.artifactId}:${project.version}</fester.container.tag>
                 <feature.flags>https://iiif-manifest-store.s3.amazonaws.com/fester-features-on.conf</feature.flags>
+                <jdwp.host.port>${jdwp.host.port}</jdwp.host.port>
+                <jdwp.client.config>${jdwp.client.config}</jdwp.client.config>
               </systemPropertyVariables>
             </configuration>
           </execution>
@@ -658,6 +670,8 @@
                 <fester.logs.output>${seeLogsFT}</fester.logs.output>
                 <fester.s3.bucket>${fester.s3.bucket}</fester.s3.bucket>
                 <fester.container.tag>${docker.registry.account}${project.artifactId}:${project.version}</fester.container.tag>
+                <jdwp.host.port>${jdwp.host.port}</jdwp.host.port>
+                <jdwp.client.config>${jdwp.client.config}</jdwp.client.config>
               </systemPropertyVariables>
             </configuration>
           </execution>
@@ -686,6 +700,8 @@
                 <fester.s3.secret_key>${fester.s3.secret_key}</fester.s3.secret_key>
                 <fester.s3.endpoint>${fester.s3.endpoint}</fester.s3.endpoint>
                 <fester.container.tag>${docker.registry.account}${project.artifactId}:${project.version}</fester.container.tag>
+                <jdwp.host.port>${jdwp.host.port}</jdwp.host.port>
+                <jdwp.client.config>${jdwp.client.config}</jdwp.client.config>
               </systemPropertyVariables>
             </configuration>
           </execution>
@@ -933,6 +949,13 @@
     </profile>
     <profile>
       <id>debug</id>
+      <properties>
+        <forkCount>0</forkCount>
+        <jdwp.client.config>-agentlib:jdwp=transport=dt_socket,address=host.testcontainers.internal:${jdwp.host.port},suspend=n</jdwp.client.config>
+      </properties>
+    </profile>
+    <profile>
+      <id>runDebug</id>
       <properties>
         <maven.test.skip>true</maven.test.skip>
         <jacoco.skip>true</jacoco.skip>

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -35,6 +35,7 @@ USER ${project.artifactId}
 ENTRYPOINT ["docker-entrypoint.sh"]
 ENV CACHE_DIR="-Dvertx.cacheDirBase=/tmp"
 ENV CONFIG_FILE="-Dvertx-config-path=/etc/${project.artifactId}/${project.artifactId}.properties"
+ENV JAVA_TOOL_OPTIONS="${jdwp.client.config}"
 ENV JAR_PATH="/usr/local/${project.artifactId}/${project.artifactId}-${project.version}.jar"
 CMD ["sh", "-c", "java $CACHE_DIR $CONFIG_FILE -Xmx2g -jar $JAR_PATH"]
 

--- a/src/main/java/edu/ucla/library/iiif/fester/Config.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/Config.java
@@ -39,6 +39,9 @@ public final class Config {
     /* A feature flags configuration for the Docker container */
     public static final String FEATURE_FLAGS = "feature.flags";
 
+    /* The port a debugger may listen on to debug a containerized Fester instance */
+    public static final String JDWP_HOST_PORT = "jdwp.host.port";
+
     /**
      * Private constructor for the Constants class.
      */

--- a/src/test/java/edu/ucla/library/iiif/fester/utils/ContainerUtils.java
+++ b/src/test/java/edu/ucla/library/iiif/fester/utils/ContainerUtils.java
@@ -7,6 +7,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 
+import org.testcontainers.Testcontainers;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.localstack.LocalStackContainer;
@@ -53,10 +54,16 @@ public final class ContainerUtils {
                 secretKey, toEnv(Config.S3_REGION), region, toEnv(Config.S3_ENDPOINT), endpoint, toEnv(
                         Config.HTTP_PORT), Integer.toString(aConfig.getContainerPort()), toEnv(Config.S3_BUCKET),
                 bucket, featureFlags, featureFlagsURL);
+        final String jdwpHostPort = System.getProperty(Config.JDWP_HOST_PORT);
 
         // Check to see if we want to output our Fester container logs when we run; the default is "no"
         if (Boolean.parseBoolean(System.getProperty(Config.LOGS_ON, Boolean.FALSE.toString()))) {
             container.withLogConsumer(new Slf4jLogConsumer(LoggerFactory.getLogger(aConfig.getContainerName())));
+        }
+
+        if (!"".equals(jdwpHostPort)) {
+            // Allow our container to attach to a JDWP server running on the host machine
+            Testcontainers.exposeHostPorts(Integer.parseInt(jdwpHostPort));
         }
 
         container.withExposedPorts(aConfig.getContainerPort()).withEnv(envMap).withNetwork(NETWORK).start();


### PR DESCRIPTION
To test, set a few breakpoints in the application code and in the test suite code (particularly an FT, FfT, or IT), and then follow the setup instructions in the README to run the debugger and verify that execution suspends at the breakpoints.

Note that the `debug` Maven profile is now used for debugging the test suite, and `runDebug` is for running a Fester instance in "debug" mode.