### PR TITLE
Update IIIF host default in CSV upload form

### DIFF
--- a/src/main/webroot/upload/csv/index.html
+++ b/src/main/webroot/upload/csv/index.html
@@ -43,10 +43,10 @@
               <label for="csv-file">File to upload:</label> <input type="file" name="csv-file" id="csv-file">
             </div>
             <div class="form-group">
-              <label for="iiif-host">IIIF Host:</label> <input type="text" value="https://iiif.library.ucla.edu"
+              <label for="iiif-host">IIIF Host:</label> <input type="text" value="https://iiif.library.ucla.edu/iiif/2"
                 name="iiif-host" id="iiif-host" onfocus="this.value=''" />
-              <div class="infotext">Use the default IIIF URL (https://iiif.library.ucla.edu) or enter the base URL
-                for a different IIIF server.</div>
+              <div class="infotext">Use the default IIIF URL (i.e., https://iiif.library.ucla.edu/iiif/2) or enter the
+                base URL for a different IIIF server.</div>
             </div>
             <div class="form-group">
               <input type="submit" value="Upload" name="submit">


### PR DESCRIPTION
Update CSV upload form's default IIIF host URL to include the `/iiif/2` Cantaloupe path.