### PR TITLE
[IIIF-843] Update manifest serialization order

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
     <freelib.utils.version>1.0.2</freelib.utils.version>
     <freelib.maven.version>0.0.3</freelib.maven.version>
     <vertx.super.s3.version>1.3.3</vertx.super.s3.version>
-    <jiiify.presentation.version>0.3.0</jiiify.presentation.version>
+    <jiiify.presentation.version>0.3.1</jiiify.presentation.version>
     <alphanumeric-comparator.version>1.4.1</alphanumeric-comparator.version>
 
     <!-- Versions of tools used for testing -->


### PR DESCRIPTION
This pulls in changes made in the upstream library. Those changes can be seen at:

https://github.com/ksclarke/jiiify-presentation/commit/5c4939c2fc391ae5e4ba18df2b43564bf09e7a79

They include: 1) updating the jiiify-presentation parent project version, 2) updating Javadocs that the new parent project Checkstyle rules said needed to be updated, 3) updating the project's pmd-rules configuration, and 3) specifying an order of manifest properties that should be used on serialization. A simple test is included to confirm that viewingHint and viewingDirection's serialization orders have been fixed and existing test fixtures were updated as well.