### PR TITLE
Update default S3 endpoint to include protocol

### DIFF
--- a/src/main/docker/configs/fester.properties.default
+++ b/src/main/docker/configs/fester.properties.default
@@ -18,6 +18,6 @@ FESTER_S3_BUCKET=fester
 FESTER_S3_ACCESS_KEY=changeme
 FESTER_S3_SECRET_KEY=changeme
 FESTER_S3_REGION=us-west-2
-FESTER_S3_ENDPOINT=s3.amazonaws.com
+FESTER_S3_ENDPOINT=https://s3.amazonaws.com
 
 IIIF_BASE_URL=https://iiif.library.ucla.edu/iiif/2


### PR DESCRIPTION
Update default value for S3 endpoint in the Fester config file. It must include the protocol now, not just the host name.