### PR TITLE
[IIIF-867] slight return

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,7 @@
     <fester.s3.secret_key>YOUR_SECRET_KEY</fester.s3.secret_key>
 
     <!-- Don't touch below unless you are using something other than S3 -->
-    <fester.s3.endpoint>s3.amazonaws.com</fester.s3.endpoint>
+    <fester.s3.endpoint>https://s3.amazonaws.com</fester.s3.endpoint>
 
     <!-- The IIIF base URL (including service prefix) -->
     <iiif.base.url>https://iiif.library.ucla.edu/iiif/2</iiif.base.url>

--- a/pom.xml
+++ b/pom.xml
@@ -808,6 +808,7 @@
                   <exclude>info.freelibrary:freelib-utils</exclude>
                   <exclude>info.freelibrary:jiiify-presentation</exclude>
                   <exclude>info.freelibrary:vertx-pairtree</exclude>
+                  <exclude>info.freelibrary:vertx-super-s3</exclude>
                   <exclude>io.netty:netty-buffer</exclude>
                   <exclude>io.netty:netty-codec-dns</exclude>
                   <exclude>io.netty:netty-codec-http2</exclude>
@@ -897,7 +898,7 @@
                   <exclude>org.yaml:snakeyaml</exclude>
                   <exclude>se.sawano.java:alphanumeric-comparator</exclude>
                   <exclude>software.amazon.ion:ion-java</exclude>
-                  <exclude>info.freelibrary:vertx-super-s3</exclude>
+                  <exclude>uk.co.lucasweb:aws-v4-signer-java</exclude>
                 </excludes>
               </artifactSet>
               <outputFile>${project.build.directory}/build-artifact/${project.artifactId}-${project.version}.jar</outputFile>

--- a/src/main/docker/configs/fester.properties.default
+++ b/src/main/docker/configs/fester.properties.default
@@ -18,6 +18,6 @@ FESTER_S3_BUCKET=fester
 FESTER_S3_ACCESS_KEY=changeme
 FESTER_S3_SECRET_KEY=changeme
 FESTER_S3_REGION=us-west-2
-FESTER_S3_ENDPOINT=s3.amazonaws.com
+FESTER_S3_ENDPOINT=https://s3.amazonaws.com
 
 IIIF_BASE_URL=https://iiif.library.ucla.edu/iiif/2

--- a/src/main/java/edu/ucla/library/iiif/fester/Constants.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/Constants.java
@@ -19,7 +19,7 @@ public final class Constants {
     /**
      * The default S3 endpoint.
      */
-    public static final String S3_ENDPOINT = "s3.amazonaws.com";
+    public static final String S3_ENDPOINT = "https://s3.amazonaws.com";
 
     /**
      * The message header key associated with the Fester operation (HTTP request) that caused the message send.
@@ -118,8 +118,8 @@ public final class Constants {
     public static final String NO_REWRITE_URLS = "no-rewrite-urls";
 
     /**
-     * A unique random placeholder URL that prefixes all IIIF Presentation API resource URLs in all manifests at rest in
-     * S3. It gets replaced with Constants.URL on each GET request.
+     * A unique random placeholder URL that prefixes all IIIF Presentation API resource URLs in all manifests at rest
+     * in S3. It gets replaced with Constants.URL on each GET request.
      */
     public static final String URL_PLACEHOLDER = "http://b1dbe4a0-443c-479f-bf0a-25c352df0d8f.iiif.library.ucla.edu";
 

--- a/src/main/java/edu/ucla/library/iiif/fester/handlers/AbstractFesterHandler.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/handlers/AbstractFesterHandler.java
@@ -57,14 +57,16 @@ abstract class AbstractFesterHandler implements Handler<RoutingContext> {
                 // Check to see that we're not overriding the default S3 endpoint
                 if (endpoint == null || Constants.S3_ENDPOINT.equals(endpoint)) {
                     httpOpts.setDefaultHost(s3Region.getServiceEndpoint("s3"));
+                    LOGGER.debug(MessageCodes.MFS_034, httpOpts.getDefaultHost(), "default");
                 } else {
                     final URI s3URI = URI.create(endpoint);
 
                     httpOpts.setDefaultHost(s3URI.getHost());
                     httpOpts.setDefaultPort(s3URI.getPort());
-                }
 
-                LOGGER.debug(MessageCodes.MFS_034, httpOpts.getDefaultHost() + ':' + httpOpts.getDefaultPort());
+                    LOGGER.debug(MessageCodes.MFS_034, httpOpts.getDefaultHost() + ':' + httpOpts.getDefaultPort(),
+                            "supplied");
+                }
 
                 myS3Client = new S3Client(aVertx, s3AccessKey, s3SecretKey, httpOpts);
             } else {

--- a/src/main/java/edu/ucla/library/iiif/fester/handlers/AbstractFesterHandler.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/handlers/AbstractFesterHandler.java
@@ -1,7 +1,7 @@
 
 package edu.ucla.library.iiif.fester.handlers;
 
-import java.net.URI;
+import java.net.MalformedURLException;
 
 import com.amazonaws.regions.Region;
 import com.amazonaws.regions.RegionUtils;
@@ -18,7 +18,6 @@ import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.eventbus.DeliveryOptions;
 import io.vertx.core.eventbus.Message;
-import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.RoutingContext;
 
@@ -51,24 +50,24 @@ abstract class AbstractFesterHandler implements Handler<RoutingContext> {
             LOGGER.debug(MessageCodes.MFS_003, s3RegionName);
 
             if (s3Region != null) {
-                final HttpClientOptions httpOpts = new HttpClientOptions();
                 final String endpoint = aConfig.getString(Config.S3_ENDPOINT);
 
-                // Check to see that we're not overriding the default S3 endpoint
-                if (endpoint == null || Constants.S3_ENDPOINT.equals(endpoint)) {
-                    httpOpts.setDefaultHost(s3Region.getServiceEndpoint("s3"));
-                    LOGGER.debug(MessageCodes.MFS_034, httpOpts.getDefaultHost(), "default");
-                } else {
-                    final URI s3URI = URI.create(endpoint);
+                try {
+                    // Check to see that we're not overriding the default S3 endpoint
+                    if (endpoint == null || Constants.S3_ENDPOINT.equals(endpoint)) {
+                        final String regionEndpoint = RegionUtils.getRegion(s3RegionName).getServiceEndpoint("s3");
 
-                    httpOpts.setDefaultHost(s3URI.getHost());
-                    httpOpts.setDefaultPort(s3URI.getPort());
+                        LOGGER.debug(MessageCodes.MFS_034, regionEndpoint, "default");
+                        myS3Client = new S3Client(aVertx, s3AccessKey, s3SecretKey, "https://" + regionEndpoint);
+                    } else {
+                        LOGGER.debug(MessageCodes.MFS_034, endpoint, "supplied");
+                        myS3Client = new S3Client(aVertx, s3AccessKey, s3SecretKey, endpoint);
+                    }
 
-                    LOGGER.debug(MessageCodes.MFS_034, httpOpts.getDefaultHost() + ':' + httpOpts.getDefaultPort(),
-                            "supplied");
+                    myS3Client.useV2Signature(true);
+                } catch (final MalformedURLException details) {
+                    throw new IllegalArgumentException(details);
                 }
-
-                myS3Client = new S3Client(aVertx, s3AccessKey, s3SecretKey, httpOpts);
             } else {
                 myS3Client = new S3Client(aVertx, s3AccessKey, s3SecretKey);
             }

--- a/src/main/java/edu/ucla/library/iiif/fester/handlers/DeleteManifestHandler.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/handlers/DeleteManifestHandler.java
@@ -65,13 +65,13 @@ public class DeleteManifestHandler extends AbstractFesterHandler {
 
                     break;
                 default:
-                    final String genericErrorMessage = LOGGER.getMessage(MessageCodes.MFS_013, manifestID);
+                    final String errorMessage = LOGGER.getMessage(MessageCodes.MFS_013, statusCode, manifestID);
 
-                    LOGGER.warn(genericErrorMessage);
+                    LOGGER.warn(errorMessage);
 
                     response.setStatusCode(statusCode);
                     response.putHeader(Constants.CONTENT_TYPE, Constants.PLAIN_TEXT_TYPE);
-                    response.end(genericErrorMessage);
+                    response.end(errorMessage);
             }
         });
     }

--- a/src/main/java/edu/ucla/library/iiif/fester/verticles/S3BucketVerticle.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/verticles/S3BucketVerticle.java
@@ -67,7 +67,7 @@ public class S3BucketVerticle extends AbstractFesterVerticle {
             if (endpoint == null || Constants.S3_ENDPOINT.equals(endpoint)) {
                 httpOptions.setDefaultHost(RegionUtils.getRegion(s3RegionName).getServiceEndpoint("s3"));
 
-                LOGGER.debug(MessageCodes.MFS_034, httpOptions.getDefaultHost());
+                LOGGER.debug(MessageCodes.MFS_034, httpOptions.getDefaultHost(), "default");
             } else {
                 final URI s3URI = URI.create(endpoint);
 
@@ -75,7 +75,8 @@ public class S3BucketVerticle extends AbstractFesterVerticle {
                 httpOptions.setDefaultHost(s3URI.getHost());
                 httpOptions.setDefaultPort(s3URI.getPort());
 
-                LOGGER.debug(MessageCodes.MFS_034, httpOptions.getDefaultHost() + ':' + httpOptions.getDefaultPort());
+                LOGGER.debug(MessageCodes.MFS_034, httpOptions.getDefaultHost() + ':' + httpOptions.getDefaultPort(),
+                        "supplied");
             }
 
             myS3Client = new S3Client(getVertx(), s3AccessKey, s3SecretKey, httpOptions);
@@ -84,6 +85,7 @@ public class S3BucketVerticle extends AbstractFesterVerticle {
             // Trace is only for developer use; don't turn on when running on a server
             LOGGER.trace(MessageCodes.MFS_046, s3AccessKey, s3SecretKey);
             LOGGER.debug(MessageCodes.MFS_047, s3RegionName);
+            LOGGER.debug(MessageCodes.MFS_132, myS3Bucket);
         }
 
         getJsonConsumer().handler(message -> {

--- a/src/main/resources/fester_messages.xml
+++ b/src/main/resources/fester_messages.xml
@@ -47,7 +47,7 @@
   <entry key="MFS-031">Fester service is unavailable</entry>
   <entry key="MFS-032">Dockerfile with variables populated: {}</entry>
   <entry key="MFS-033">Found manifest '{}' does not match expected manifest '{}'</entry>
-  <entry key="MFS-034">S3 endpoint to be used: {}</entry>
+  <entry key="MFS-034">S3 endpoint to be used: {} [{}]</entry>
   <entry key="MFS-035">Unable to DELETE manifest '{}'</entry>
   <entry key="MFS-036">Manifest '{}' found when it should have been deleted</entry>
   <entry key="MFS-037">Not processed. The submission is missing a CSV file.</entry>
@@ -145,7 +145,7 @@
   <entry key="MFS-129">Checking S3 collection object: {}</entry>
   <entry key="MFS-130">Reset collection manifest key to: {}</entry>
   <entry key="MFS-131">Failed to upload all the work manifests: {}</entry>
-  <entry key="MFS-132"></entry>
+  <entry key="MFS-132">Configured to use AWS S3 bucket: {}</entry>
   <entry key="MFS-133">Getting '{}' from Fester's S3 bucket: {}</entry>
   <entry key="MFS-134">Uploaded CSV file '{}' still exists on disk {} ms after the handler sent the response</entry>
   <entry key="MFS-135">Regular expression '{}' does not match '{}'</entry>


### PR DESCRIPTION
The previous PR didn't completely fix the issue. There is also an upstream bug with the v4 signature generation. This works around that.

* Update endpoint references
* Fallback to v2 signing because there is a bug with v4 signing and S3 regions in the upstream library
* Simplify some of the S3Client construction (the upsteam library does more parsing of endpoint now)
* Add additional debug logging