### PR TITLE
[IIIF-863] Improve "manifest not found" error message

### DIFF
--- a/src/main/java/edu/ucla/library/iiif/fester/ManifestNotFoundException.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/ManifestNotFoundException.java
@@ -1,0 +1,25 @@
+package edu.ucla.library.iiif.fester;
+
+import info.freelibrary.util.I18nException;
+
+/**
+ * An exception thrown when a collection or manifest can't be found.
+ */
+public class ManifestNotFoundException extends I18nException {
+
+    /**
+     * The <code>serialVersionUID</code> for a ManifestNotFoundException.
+     */
+    private static final long serialVersionUID = -278145895817091916L;
+
+    /**
+     * Creates a new manifest not found exception.
+     *
+     * @param aCause The throwable that caused the exception
+     * @param aMessageCode A message code
+     * @param aDetails Additional details about the exception
+     */
+    public ManifestNotFoundException(final Throwable aCause, final String aMessageCode, final Object... aDetails) {
+        super(aCause, Constants.MESSAGES, aMessageCode, aDetails);
+    }
+}

--- a/src/main/java/edu/ucla/library/iiif/fester/verticles/ManifestVerticle.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/verticles/ManifestVerticle.java
@@ -331,7 +331,7 @@ public class ManifestVerticle extends AbstractFesterVerticle {
                             final String errorMessage = LOGGER.getMessage(MessageCodes.MFS_146,
                                     aCollDoc ? "collection" : "work", aID);
                             lockRequest.result().release();
-                            aPromise.fail(new Throwable(errorMessage));
+                            aPromise.fail(new Exception(errorMessage, handler.cause()));
                         }
                     });
                 } catch (final NullPointerException | IndexOutOfBoundsException details) {

--- a/src/main/java/edu/ucla/library/iiif/fester/verticles/ManifestVerticle.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/verticles/ManifestVerticle.java
@@ -329,7 +329,7 @@ public class ManifestVerticle extends AbstractFesterVerticle {
                             aPromise.complete(new LockedManifest(manifest, aCollDoc, lock));
                         } else {
                             final String errorMessage = LOGGER.getMessage(MessageCodes.MFS_146,
-                                    (aCollDoc ? "collection" : "work"), aID);
+                                    aCollDoc ? "collection" : "work", aID);
                             lockRequest.result().release();
                             aPromise.fail(new Throwable(errorMessage));
                         }

--- a/src/main/java/edu/ucla/library/iiif/fester/verticles/ManifestVerticle.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/verticles/ManifestVerticle.java
@@ -328,8 +328,10 @@ public class ManifestVerticle extends AbstractFesterVerticle {
 
                             aPromise.complete(new LockedManifest(manifest, aCollDoc, lock));
                         } else {
+                            final String errorMessage = LOGGER.getMessage(MessageCodes.MFS_146,
+                                    (aCollDoc ? "collection" : "work"), aID);
                             lockRequest.result().release();
-                            aPromise.fail(handler.cause());
+                            aPromise.fail(new Throwable(errorMessage));
                         }
                     });
                 } catch (final NullPointerException | IndexOutOfBoundsException details) {

--- a/src/main/java/edu/ucla/library/iiif/fester/verticles/ManifestVerticle.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/verticles/ManifestVerticle.java
@@ -45,6 +45,7 @@ import edu.ucla.library.iiif.fester.HTTP;
 import edu.ucla.library.iiif.fester.ImageInfoLookup;
 import edu.ucla.library.iiif.fester.ImageNotFoundException;
 import edu.ucla.library.iiif.fester.LockedManifest;
+import edu.ucla.library.iiif.fester.ManifestNotFoundException;
 import edu.ucla.library.iiif.fester.MessageCodes;
 import edu.ucla.library.iiif.fester.Op;
 import edu.ucla.library.iiif.fester.utils.IDUtils;
@@ -328,10 +329,9 @@ public class ManifestVerticle extends AbstractFesterVerticle {
 
                             aPromise.complete(new LockedManifest(manifest, aCollDoc, lock));
                         } else {
-                            final String errorMessage = LOGGER.getMessage(MessageCodes.MFS_146,
-                                    aCollDoc ? "collection" : "work", aID);
                             lockRequest.result().release();
-                            aPromise.fail(new Exception(errorMessage, handler.cause()));
+                            aPromise.fail(new ManifestNotFoundException(handler.cause(), MessageCodes.MFS_146,
+                                    aCollDoc ? "collection" : "work", aID));
                         }
                     });
                 } catch (final NullPointerException | IndexOutOfBoundsException details) {

--- a/src/main/resources/fester_messages.xml
+++ b/src/main/resources/fester_messages.xml
@@ -159,5 +159,5 @@
   <entry key="MFS-143">URI path '{}' does not contain a required subpath: {} or {}</entry>
   <entry key="MFS-144">S3 key already starts with the prefix to be added: {}</entry>
   <entry key="MFS-145">S3 key already ends with .json extension: {}</entry>
-  <entry key="MFS-146"></entry>
+  <entry key="MFS-146">Could not find {} manifest '{}' to update</entry>
 </properties>

--- a/src/main/scripts/festerize/festerize.py
+++ b/src/main/scripts/festerize/festerize.py
@@ -7,6 +7,7 @@ import pathlib
 import random
 import sys
 
+from bs4 import BeautifulSoup
 import click
 import requests
 
@@ -71,7 +72,7 @@ def cli(src, server, endpoint, out, iiifhost, loglevel):
             r = requests.post(request_url, files=files, data=payload)
 
             # Handle the response.
-            if r.status_code == 201 :
+            if r.status_code == 201:
                 # Send an awesome message to the user.
                 border_char = extra_satisfaction[random.randint(0, len(extra_satisfaction) - 1)]
                 border_length = 2 + (20 + len(csv_filename)) // 2
@@ -84,10 +85,10 @@ def cli(src, server, endpoint, out, iiifhost, loglevel):
                 out_file = click.open_file(os.path.join(out, csv_filename), 'wb')
                 out_file.write(r.content)
             else:
-                error_msg = 'Failed to upload {}: {}'.format(csv_filename, r.status_code)
+                error_cause = BeautifulSoup(r.text, features='html.parser').find(id='error-message').string
+                error_msg = 'Failed to upload {}: {} (HTTP {})'.format(csv_filename, error_cause, r.status_code)
                 click.echo(error_msg)
                 logging.error(error_msg)
-                logging.error(r.text)
                 logging.error('--------------------------------------------')
         else:
             error_msg = 'File {} is not a CSV, skipping'.format(csv_filename)

--- a/src/main/scripts/festerize/setup.py
+++ b/src/main/scripts/festerize/setup.py
@@ -7,6 +7,7 @@ setup (
     version='0.1',
     py_modules=['festerize'],
     install_requires=[
+        'beautifulsoup4',
         'click',
         'requests'
     ],

--- a/src/main/webroot/error.html
+++ b/src/main/webroot/error.html
@@ -33,7 +33,7 @@
 
   <div class="container-fluid">
     <h1 id="csv-upload-title">Error</h1>
-    <p>{}</p>
+    <p id="error-message">{}</p>
   </div>
 
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>

--- a/src/test/java/edu/ucla/library/iiif/fester/fit/PostCsvFIT.java
+++ b/src/test/java/edu/ucla/library/iiif/fester/fit/PostCsvFIT.java
@@ -53,6 +53,8 @@ public class PostCsvFIT {
 
     private static final File WORKS_CSV_NO_COLLECTION = new File(DIR, "csv/hathaway/batch2/works.csv");
 
+    private static final String HATHAWAY_COLLECTION_ARK = "ark:/21198/zz0009gsq9";
+
     private static final File HATHAWAY_COLLECTION_MANIFEST = new File(DIR, "json/ark%3A%2F21198%2Fzz0009gsq9.json");
 
     private static final File BLANK_LINE_CSV = new File(DIR, "csv/blankline.csv");
@@ -224,7 +226,7 @@ public class PostCsvFIT {
             final Async asyncTask = aContext.async();
 
             // Put a collection manifest in Fester
-            myS3Client.putObject(BUCKET, IDUtils.getCollectionS3Key("ark:/21198/zz0009gsq9"),
+            myS3Client.putObject(BUCKET, IDUtils.getCollectionS3Key(HATHAWAY_COLLECTION_ARK),
                     HATHAWAY_COLLECTION_MANIFEST);
 
             postCSV(WORKS_CSV_NO_COLLECTION, post -> {
@@ -280,10 +282,12 @@ public class PostCsvFIT {
             postCSV(WORKS_CSV_NO_COLLECTION, post -> {
                 if (post.succeeded()) {
                     final HttpResponse<Buffer> response = post.result();
+                    final String expectedErrorMessage = LOGGER.getMessage(MessageCodes.MFS_103,
+                            LOGGER.getMessage(MessageCodes.MFS_146, "collection", HATHAWAY_COLLECTION_ARK));
 
                     aContext.assertEquals(response.statusCode(), HTTP.INTERNAL_SERVER_ERROR);
                     aContext.assertEquals(response.getHeader(Constants.CONTENT_TYPE), Constants.HTML_MEDIA_TYPE);
-                    aContext.assertTrue(response.bodyAsString().contains("Manifest generation failed: Not Found"));
+                    aContext.assertTrue(response.bodyAsString().contains(expectedErrorMessage));
 
                     if (!asyncTask.isCompleted()) {
                         asyncTask.complete();


### PR DESCRIPTION
- if `getLockedManifest` fails to retrieve a manifest, send the ARK and the manifest type back to the client
- assign an id to the error message HTML tag
- on the client running `festerize`, only log the error message, not the entire HTML response