### PR TITLE
Update POM for Codacy integration fix

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,5 @@
+#
+# This file contains a list of project codeowners
+#
+
+* @UCLALibrary/services-team-reviewers

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,6 @@
     <deploy.plugin.version>2.8.2</deploy.plugin.version>
     <netty.epoll.version>4.1.37.Final</netty.epoll.version>
     <vertx.plugin.version>1.0.18</vertx.plugin.version>
-    <codacy.plugin.version>1.0.2</codacy.plugin.version>
     <xml.maven.plugin.version>1.0.2</xml.maven.plugin.version>
     <docker.maven.plugin.version>0.33.0</docker.maven.plugin.version>
 
@@ -569,13 +568,6 @@
         </executions>
       </plugin>
 
-      <!-- Codacy runs automated code reviews and code analytics -->
-      <plugin>
-        <groupId>com.gavinmogan</groupId>
-        <artifactId>codacy-maven-plugin</artifactId>
-        <version>${codacy.plugin.version}</version>
-      </plugin>
-
       <!-- Maven dependency helps freelib-resources copy files into the project -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -636,8 +628,7 @@
           </systemPropertyVariables>
           <argLine>${jacoco.agent.arg}</argLine>
           <skipTests>${skipUTs}</skipTests>
-          <forkCount>0</forkCount><!-- Multiple forks result in multiple containers -->
-          <useSystemClassLoader>false</useSystemClassLoader> <!-- Override parent project setting -->
+          <forkCount>1</forkCount><!-- Multiple forks result in multiple containers -->
         </configuration>
         <executions>
           <execution>
@@ -1185,6 +1176,6 @@
   <parent>
     <artifactId>freelib-parent</artifactId>
     <groupId>info.freelibrary</groupId>
-    <version>3.8.6</version>
+    <version>4.0.0</version>
   </parent>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,10 @@
     <jiiify.presentation.version>0.3.1</jiiify.presentation.version>
     <alphanumeric-comparator.version>1.4.1</alphanumeric-comparator.version>
 
+    <!-- Exclusions/Replacements -->
+    <snakeyaml.version>1.26</snakeyaml.version>
+    <commons.codec.version>1.14</commons.codec.version>
+
     <!-- Versions of tools used for testing -->
     <jsoup.version>1.13.1</jsoup.version>
     <aws.sdk.version>1.11.830</aws.sdk.version>
@@ -193,9 +197,20 @@
 
     <!-- OpenAPI for Vert.x - https://vertx.io/docs/vertx-web-api-contract/java/ -->
     <dependency>
+      <groupId>org.yaml</groupId>
+      <artifactId>snakeyaml</artifactId>
+      <version>${snakeyaml.version}</version>
+    </dependency>
+    <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-web-api-contract</artifactId>
       <version>${vertx.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.yaml</groupId>
+          <artifactId>snakeyaml</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <!-- Below is a dependency that needs updating due to security issue (may be able to remove in future) -->
     <dependency>
@@ -236,9 +251,20 @@
       <version>${commons.lang.version}</version>
     </dependency>
     <dependency>
+      <groupId>commons-codec</groupId>
+      <artifactId>commons-codec</artifactId>
+      <version>${commons.codec.version}</version>
+    </dependency>
+    <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-s3</artifactId>
       <version>${aws.sdk.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-codec</groupId>
+          <artifactId>commons-codec</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>se.sawano.java</groupId>

--- a/src/test/java/edu/ucla/library/iiif/fester/fit/PagesManifestFT.java
+++ b/src/test/java/edu/ucla/library/iiif/fester/fit/PagesManifestFT.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -23,6 +24,7 @@ import io.vertx.core.Promise;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.Timeout;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.ext.web.multipart.MultipartForm;
@@ -45,6 +47,10 @@ public class PagesManifestFT extends BaseFesterFT {
         "works/ark:/21198/zz000wrh7t.json" };
 
     private static final int[] CANVAS_COUNTS = new int[] { 42, 26, 46, 39, 36 };
+
+    /* Slower systems may have trouble finishing within the default timeout */
+    @Rule
+    public Timeout myTimeoutRule = Timeout.seconds(3600);
 
     /**
      * Sets up testing environment.


### PR DESCRIPTION
* Update POM/parent project
* Remove obsolete Codacy configuration (it's done by the parent POM/project now)
* Change to running tests in a single fork instead of the same process so that the JaCoCo plugin will run
* Add CODEOWNERS file so we'll get auto-added as reviewers on PRs