### PR TITLE
[IIIF-869] Move V2 manifest work into its own verticle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,8 @@ buildNumber.properties
 .mvn/timing.properties
 .editorconfig
 .checkstyle
-src/main/tools
+src/main/tools/eclipse
+src/main/tools/travis
 src/main/generated
 src/main/jbake/
 logback-test.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ services: docker
 branches:
   only:
   - main
+  - version-fester
 
 jobs:
   include:

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,5 @@
+#
+# This file contains a list of project codeowners
+#
+
+* @UCLALibrary/services-team-reviewers

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Fester &nbsp;[![Build Status](https://api.travis-ci.com/uclalibrary/fester.svg?branch=master)](https://travis-ci.com/uclalibrary/fester) [![Known Vulnerabilities](https://snyk.io/test/github/uclalibrary/fester/badge.svg)](https://snyk.io/test/github/uclalibrary/fester)
+# Fester &nbsp;[![Build Status](https://api.travis-ci.com/uclalibrary/fester.svg?branch=main)](https://travis-ci.com/uclalibrary/fester) [![Known Vulnerabilities](https://snyk.io/test/github/uclalibrary/fester/badge.svg)](https://snyk.io/test/github/uclalibrary/fester)
 
 A microservice for facilitating the creation, storage, and retrieval of IIIF manifests and collections.
 

--- a/pom.xml
+++ b/pom.xml
@@ -75,10 +75,10 @@
     <slf4j.ext.version>1.7.26</slf4j.ext.version>
     <jcl.over.slf4j.version>1.7.30</jcl.over.slf4j.version>
     <commons.lang.version>3.9</commons.lang.version>
-    <freelib.utils.version>1.0.2</freelib.utils.version>
-    <freelib.maven.version>0.0.3</freelib.maven.version>
+    <freelib.utils.version>1.1.0</freelib.utils.version>
+    <freelib.maven.version>0.1.0</freelib.maven.version>
     <vertx.super.s3.version>1.3.3</vertx.super.s3.version>
-    <jiiify.presentation.version>0.3.1</jiiify.presentation.version>
+    <jiiify.presentation.version>v2-0.4.0</jiiify.presentation.version>
     <alphanumeric-comparator.version>1.4.1</alphanumeric-comparator.version>
 
     <!-- Versions of tools used for testing -->
@@ -1159,6 +1159,6 @@
   <parent>
     <artifactId>freelib-parent</artifactId>
     <groupId>info.freelibrary</groupId>
-    <version>3.8.6</version>
+    <version>4.0.0</version>
   </parent>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
     <deploy.plugin.version>2.8.2</deploy.plugin.version>
     <netty.epoll.version>4.1.37.Final</netty.epoll.version>
     <vertx.plugin.version>1.0.18</vertx.plugin.version>
-    <codacy.plugin.version>1.0.2</codacy.plugin.version>
+    <codacy.plugin.version>1.2.0</codacy.plugin.version>
     <xml.maven.plugin.version>1.0.2</xml.maven.plugin.version>
     <docker.maven.plugin.version>0.33.0</docker.maven.plugin.version>
 

--- a/src/main/java/edu/ucla/library/iiif/fester/Constants.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/Constants.java
@@ -219,6 +219,16 @@ public final class Constants {
     public static final String ID = "@id";
 
     /**
+     * The collection type of resource.
+     */
+    public static final String COLLECTION = "collection";
+
+    /**
+     * The manifest type of resource.
+     */
+    public static final String MANIFEST = "work";
+
+    /**
      * Version 2 of the IIIF presentation API.
      */
     public static final String IIIF_API_V2 = "v2";

--- a/src/main/java/edu/ucla/library/iiif/fester/Constants.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/Constants.java
@@ -118,6 +118,11 @@ public final class Constants {
     public static final String IIIF_HOST = "iiif-host";
 
     /**
+     * The name of the IIIF presentation version parameter.
+     */
+    public static final String IIIF_API_VERSION = "iiif-version";
+
+    /**
      * Used as a message header when the sender wants the manifest returned from S3 without resource URLs re-written.
      */
     public static final String NO_REWRITE_URLS = "no-rewrite-urls";
@@ -179,6 +184,26 @@ public final class Constants {
     public static final String MANIFEST_CONTENT = "manifest-content";
 
     /**
+     * Collection content, stored as a JSON object.
+     */
+    public static final String COLLECTION_CONTENT = "collection-content";
+
+    /**
+     * Manifest pages, stored in list form.
+     */
+    public static final String MANIFEST_PAGES = "manifest-pages";
+
+    /**
+     * The placeholder image property name.
+     */
+    public static final String PLACEHOLDER_IMAGE = "placeholder-image";
+
+    /**
+     * CSV headers, stored as a JSON object.
+     */
+    public static final String CSV_HEADERS = "csv-headers";
+
+    /**
      * The POST parameter for uploading a CSV file.
      */
     public static final String CSV_FILE = "csv-file";
@@ -189,19 +214,19 @@ public final class Constants {
     public static final String VERTICLE_MAP = "fester-verticles";
 
     /**
-     * The ID property in a manifest (collection or work).
+     * The ID property in a collection or manifest.
      */
     public static final String ID = "@id";
 
     /**
-     * The label that should be displayed along with the repository name in the manifest metadata.
+     * Version 2 of the IIIF presentation API.
      */
-    public static final String REPOSITORY_NAME_METADATA_LABEL = "Repository";
+    public static final String IIIF_API_V2 = "v2";
 
     /**
-     * The label that should be displayed along with the rights contact in the manifest metadata.
+     * Version 3 of the IIIF presentation API.
      */
-    public static final String RIGHTS_CONTACT_METADATA_LABEL = "Rights contact";
+    public static final String IIIF_API_V3 = "v3";
 
     /**
      * Private constructor for Constants class.

--- a/src/main/java/edu/ucla/library/iiif/fester/CsvHeaders.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/CsvHeaders.java
@@ -1,6 +1,13 @@
 
 package edu.ucla.library.iiif.fester;
 
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonSetter;
+
+import io.vertx.core.json.Json;
+import io.vertx.core.json.JsonObject;
+
 /**
  * The CSV file's headers.
  */
@@ -119,10 +126,18 @@ public class CsvHeaders {
     }
 
     /**
+     * A constructor used by Jackson for deserialization.
+     */
+    @SuppressWarnings("unused")
+    private CsvHeaders() {
+    }
+
+    /**
      * Gets the Item ARK index position.
      *
      * @return The Item ARK index position
      */
+    @JsonGetter
     public int getItemArkIndex() {
         return myItemArkIndex;
     }
@@ -133,6 +148,7 @@ public class CsvHeaders {
      * @param aItemArkIndex The position of the Item ARK header
      * @return This CSV headers
      */
+    @JsonSetter
     public CsvHeaders setItemArkIndex(final int aItemArkIndex) {
         myItemArkIndex = aItemArkIndex;
         return this;
@@ -152,6 +168,7 @@ public class CsvHeaders {
      *
      * @return The image access URL index position
      */
+    @JsonGetter
     public int getImageAccessUrlIndex() {
         return myImageAccessUrlIndex;
     }
@@ -162,6 +179,7 @@ public class CsvHeaders {
      * @param aImageAccessUrlIndex The position of the image access URL header
      * @return This CSV headers
      */
+    @JsonSetter
     public CsvHeaders setImageAccessUrlIndex(final int aImageAccessUrlIndex) {
         myImageAccessUrlIndex = aImageAccessUrlIndex;
         return this;
@@ -181,6 +199,7 @@ public class CsvHeaders {
      *
      * @return The Parent ARK index position
      */
+    @JsonGetter
     public int getParentArkIndex() {
         return myParentArkIndex;
     }
@@ -191,6 +210,7 @@ public class CsvHeaders {
      * @param aParentArkIndex The index position of the Parent ARK
      * @return This CSV headers
      */
+    @JsonSetter
     public CsvHeaders setParentArkIndex(final int aParentArkIndex) {
         myParentArkIndex = aParentArkIndex;
         return this;
@@ -210,6 +230,7 @@ public class CsvHeaders {
      *
      * @return The Title index position
      */
+    @JsonGetter
     public int getTitleIndex() {
         return myTitleIndex;
     }
@@ -220,6 +241,7 @@ public class CsvHeaders {
      * @param aTitleIndex The index position of the Title
      * @return This CSV headers
      */
+    @JsonSetter
     public CsvHeaders setTitleIndex(final int aTitleIndex) {
         myTitleIndex = aTitleIndex;
         return this;
@@ -239,6 +261,7 @@ public class CsvHeaders {
      *
      * @return The index position of the Object Type
      */
+    @JsonGetter
     public int getObjectTypeIndex() {
         return myObjectTypeIndex;
     }
@@ -249,6 +272,7 @@ public class CsvHeaders {
      * @param aObjectTypeIndex The index position of the Object Type
      * @return This CSV headers
      */
+    @JsonSetter
     public CsvHeaders setObjectTypeIndex(final int aObjectTypeIndex) {
         myObjectTypeIndex = aObjectTypeIndex;
         return this;
@@ -268,6 +292,7 @@ public class CsvHeaders {
      *
      * @return The index position of the File Name
      */
+    @JsonGetter
     public int getFileNameIndex() {
         return myFileNameIndex;
     }
@@ -278,6 +303,7 @@ public class CsvHeaders {
      * @param aFileNameIndex The index position of the File Name
      * @return This CSV headers
      */
+    @JsonSetter
     public CsvHeaders setFileNameIndex(final int aFileNameIndex) {
         myFileNameIndex = aFileNameIndex;
         return this;
@@ -293,23 +319,25 @@ public class CsvHeaders {
     }
 
     /**
+     * Gets the Item Sequence header position.
+     *
+     * @return The item sequence header position
+     */
+    @JsonGetter
+    public int getItemSequenceIndex() {
+        return myItemSequenceIndex;
+    }
+
+    /**
      * Sets the Item Sequence index position.
      *
      * @param aItemSequenceIndex
      * @return This CSV headers
      */
+    @JsonSetter
     public CsvHeaders setItemSequenceIndex(final int aItemSequenceIndex) {
         myItemSequenceIndex = aItemSequenceIndex;
         return this;
-    }
-
-    /**
-     * Gets the Item Sequence header position.
-     *
-     * @return The item sequence header position
-     */
-    public int getItemSequenceIndex() {
-        return myItemSequenceIndex;
     }
 
     /**
@@ -326,6 +354,7 @@ public class CsvHeaders {
      *
      * @return The viewingHint index position
      */
+    @JsonGetter
     public int getViewingHintIndex() {
         return myViewingHintIndex;
     }
@@ -336,6 +365,7 @@ public class CsvHeaders {
      * @param aViewingHintIndex The position of the viewingHint header
      * @return This CSV headers
      */
+    @JsonSetter
     public CsvHeaders setViewingHintIndex(final int aViewingHintIndex) {
         myViewingHintIndex = aViewingHintIndex;
         return this;
@@ -355,6 +385,7 @@ public class CsvHeaders {
      *
      * @return The viewingDirection index position
      */
+    @JsonGetter
     public int getViewingDirectionIndex() {
         return myViewingDirectionIndex;
     }
@@ -365,6 +396,7 @@ public class CsvHeaders {
      * @param aViewingDirectionIndex The position of the viewingDirection header
      * @return This CSV headers
      */
+    @JsonSetter
     public CsvHeaders setViewingDirectionIndex(final int aViewingDirectionIndex) {
         myViewingDirectionIndex = aViewingDirectionIndex;
         return this;
@@ -384,6 +416,7 @@ public class CsvHeaders {
      *
      * @return The repository name index position
      */
+    @JsonGetter
     public int getRepositoryNameIndex() {
         return myRepositoryNameIndex;
     }
@@ -394,6 +427,7 @@ public class CsvHeaders {
      * @param aRepositoryNameIndex The position of the repository name header
      * @return This CSV headers
      */
+    @JsonSetter
     public CsvHeaders setRepositoryNameIndex(final int aRepositoryNameIndex) {
         myRepositoryNameIndex = aRepositoryNameIndex;
         return this;
@@ -413,6 +447,7 @@ public class CsvHeaders {
      *
      * @return The local rights statement index position
      */
+    @JsonGetter
     public int getLocalRightsStatementIndex() {
         return myLocalRightsStatementIndex;
     }
@@ -423,6 +458,7 @@ public class CsvHeaders {
      * @param aLocalRightsStatementIndex The position of the local rights statement header
      * @return This CSV headers
      */
+    @JsonSetter
     public CsvHeaders setLocalRightsStatementIndex(final int aLocalRightsStatementIndex) {
         myLocalRightsStatementIndex = aLocalRightsStatementIndex;
         return this;
@@ -442,6 +478,7 @@ public class CsvHeaders {
      *
      * @return The rights contact index position
      */
+    @JsonGetter
     public int getRightsContactIndex() {
         return myRightsContactIndex;
     }
@@ -452,6 +489,7 @@ public class CsvHeaders {
      * @param aRightsContactIndex The position of the rights contact header
      * @return This CSV headers
      */
+    @JsonSetter
     public CsvHeaders setRightsContactIndex(final int aRightsContactIndex) {
         myRightsContactIndex = aRightsContactIndex;
         return this;
@@ -464,5 +502,41 @@ public class CsvHeaders {
      */
     public boolean hasRightsContactIndex() {
         return myRightsContactIndex != -1;
+    }
+
+    /**
+     * Returns a JsonObject of the Manifest.
+     *
+     * @return A JsonObject of the Manifest
+     */
+    public JsonObject toJSON() {
+        return JsonObject.mapFrom(this);
+    }
+
+    @Override
+    public String toString() {
+        return toJSON().encodePrettily();
+    }
+
+    /**
+     * Returns a CsvHeaders from its JSON representation.
+     *
+     * @param aJsonObject A CSV headers object in JSON form
+     * @return The CSV headers
+     */
+    @JsonIgnore
+    public static CsvHeaders fromJSON(final JsonObject aJsonObject) {
+        return Json.decodeValue(aJsonObject.toString(), CsvHeaders.class);
+    }
+
+    /**
+     * Returns a CsvHeaders from its JSON representation.
+     *
+     * @param aJsonString A CSV headers object in string form
+     * @return The CSV headers
+     */
+    @JsonIgnore
+    public static CsvHeaders fromString(final String aJsonString) {
+        return fromJSON(new JsonObject(aJsonString));
     }
 }

--- a/src/main/java/edu/ucla/library/iiif/fester/CsvMetadata.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/CsvMetadata.java
@@ -7,18 +7,16 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 
-import info.freelibrary.iiif.presentation.Collection;
-
 /**
  * Processed metadata from a supplied CSV file.
  */
 public class CsvMetadata {
 
-    private final Map<String, List<Collection.Manifest>> myWorksMap;
-
-    private final List<String[]> myWorksList;
+    private final Map<String, List<String[]>> myWorksMap;
 
     private final Map<String, List<String[]>> myPagesMap;
+
+    private final List<String[]> myWorksList;
 
     /**
      * Creates a CSV metadata object.
@@ -27,7 +25,7 @@ public class CsvMetadata {
      * @param aWorksList A list of works metadata
      * @param aPagesMap A map of pages metadata
      */
-    public CsvMetadata(final Map<String, List<Collection.Manifest>> aWorksMap, final List<String[]> aWorksList,
+    public CsvMetadata(final Map<String, List<String[]>> aWorksMap, final List<String[]> aWorksList,
             final Map<String, List<String[]>> aPagesMap) {
         myWorksMap = aWorksMap;
         myWorksList = aWorksList;
@@ -39,7 +37,7 @@ public class CsvMetadata {
      *
      * @return The metadata for the works stored in a collection document
      */
-    public Map<String, List<Collection.Manifest>> getWorksMap() {
+    public Map<String, List<String[]>> getWorksMap() {
         return myWorksMap;
     }
 

--- a/src/main/java/edu/ucla/library/iiif/fester/CsvParser.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/CsvParser.java
@@ -23,9 +23,6 @@ import com.opencsv.CSVIterator;
 import com.opencsv.CSVReader;
 import com.opencsv.exceptions.CsvException;
 
-import info.freelibrary.iiif.presentation.Collection;
-import info.freelibrary.iiif.presentation.properties.Attribution;
-import info.freelibrary.iiif.presentation.properties.Metadata;
 import info.freelibrary.util.Logger;
 import info.freelibrary.util.LoggerFactory;
 import info.freelibrary.util.StringUtils;
@@ -41,13 +38,13 @@ public class CsvParser {
 
     private static final Pattern EOL_PATTERN = Pattern.compile(".*\\R");
 
-    private final Map<String, List<Collection.Manifest>> myWorksMap = new HashMap<>();
+    private final Map<String, List<String[]>> myWorksMap = new HashMap<>();
 
     private final Map<String, List<String[]>> myPagesMap = new LinkedHashMap<>();
 
     private final List<String[]> myWorksList = new ArrayList<>();
 
-    private Collection myCollection;
+    private String[] myCollectionData;
 
     private CsvHeaders myCsvHeaders;
 
@@ -59,12 +56,9 @@ public class CsvParser {
     }
 
     /**
-     * Parses the CSV file at the supplied path. This is not thread-safe.
-     *
-     * Optional CSV columns:
-     *
-     *   IIIF Access URL, Item Sequence (if the CSV contains no page rows), viewingHint, viewingDirection,
-     *   Name.repository, Rights.statementLocal, Rights.servicesContact,
+     * Parses the CSV file at the supplied path. This is not thread-safe. Optional CSV columns: IIIF Access URL, Item
+     * Sequence (if the CSV contains no page rows), viewingHint, viewingDirection, Name.repository,
+     * Rights.statementLocal, Rights.servicesContact,
      *
      * @param aPath A path to a CSV file
      * @throws IOException If there is trouble reading or writing data
@@ -113,15 +107,12 @@ public class CsvParser {
             }
 
             for (final String[] row : rows) {
-                final ObjectType objectType;
-
                 checkForEOLs(row);
                 trimValues(row);
-                objectType = getObjectType(row);
 
-                switch (objectType) {
+                switch (getObjectType(row)) {
                     case COLLECTION: {
-                        myCollection = getCollection(row);
+                        extractCollectionMetadata(row);
                         break;
                     }
                     case WORK: {
@@ -139,6 +130,7 @@ public class CsvParser {
                         break;
                     }
                 }
+
                 rowsRead += 1;
             }
 
@@ -155,8 +147,8 @@ public class CsvParser {
      *
      * @return An optional collection
      */
-    public Optional<Collection> getCollection() {
-        return Optional.ofNullable(myCollection);
+    public Optional<String[]> getCsvCollection() {
+        return Optional.ofNullable(myCollectionData);
     }
 
     /**
@@ -181,14 +173,32 @@ public class CsvParser {
      * Reset the CSV parser.
      */
     private CsvParser reset() {
+        myCollectionData = null;
+        myCsvHeaders = null;
+
         myWorksList.clear();
         myPagesMap.clear();
         myWorksMap.clear();
 
-        myCsvHeaders = null;
-        myCollection = null;
-
         return this;
+    }
+
+    /**
+     * Extracts the collection metadata, checking that required properties are there.
+     *
+     * @param aRow The row of collection metadata
+     * @throws CsvParsingException If there is trouble parsing the data
+     */
+    private void extractCollectionMetadata(final String[] aRow) throws CsvParsingException {
+        if (getMetadata(aRow[myCsvHeaders.getItemArkIndex()]).isPresent()) {
+            if (getMetadata(aRow[myCsvHeaders.getTitleIndex()]).isEmpty()) {
+                throw new CsvParsingException(MessageCodes.MFS_104);
+            }
+
+            myCollectionData = aRow;
+        } else {
+            throw new CsvParsingException(MessageCodes.MFS_106);
+        }
     }
 
     /**
@@ -211,7 +221,7 @@ public class CsvParser {
         if (workIdOpt.isPresent() && labelOpt.isPresent()) {
             final String workID = workIdOpt.get();
             final URI uri = IDUtils.getResourceURI(Constants.URL_PLACEHOLDER, IDUtils.getWorkS3Key(workID));
-            final Collection.Manifest manifest = new Collection.Manifest(uri.toString(), labelOpt.get());
+            final String[] workData = new String[] { uri.toString(), labelOpt.get() };
 
             if (LOGGER.isDebugEnabled()) {
                 LOGGER.debug(MessageCodes.MFS_119, workID, parentIdOpt.orElse(Constants.EMPTY));
@@ -221,12 +231,12 @@ public class CsvParser {
                 final String parentID = parentIdOpt.get();
 
                 if (myWorksMap.containsKey(parentID)) {
-                    myWorksMap.get(parentID).add(manifest);
+                    myWorksMap.get(parentID).add(workData);
                 } else {
-                    final List<Collection.Manifest> manifests = new ArrayList<>();
+                    final List<String[]> worksData = new ArrayList<>();
 
-                    manifests.add(manifest);
-                    myWorksMap.put(parentID, manifests);
+                    worksData.add(workData);
+                    myWorksMap.put(parentID, worksData);
                 }
             } else {
                 throw new CsvParsingException(MessageCodes.MFS_107);
@@ -261,67 +271,6 @@ public class CsvParser {
         } else {
             throw new CsvParsingException(MessageCodes.MFS_121);
         }
-    }
-
-    /**
-     * Get the collection object from the collection row.
-     *
-     * @param aRow A row of collection metadata
-     * @param aHeaders A CSV headers object
-     * @return A collection
-     */
-    private Collection getCollection(final String[] aRow) throws CsvParsingException {
-        final Optional<String> id = getMetadata(aRow[myCsvHeaders.getItemArkIndex()]);
-        final Collection collection;
-
-        if (id.isPresent()) {
-            final URI uri = IDUtils.getResourceURI(Constants.URL_PLACEHOLDER, IDUtils.getCollectionS3Key(id.get()));
-            final Optional<String> label = getMetadata(aRow[myCsvHeaders.getTitleIndex()]);
-            final Metadata metadata = new Metadata();
-
-            if (label.isEmpty()) {
-                throw new CsvParsingException(MessageCodes.MFS_104);
-            }
-
-            collection = new Collection(uri.toString(), label.get());
-
-            // Add optional properties
-            if (myCsvHeaders.hasRepositoryNameIndex()) {
-                final Optional<String> repoName = getMetadata(aRow[myCsvHeaders.getRepositoryNameIndex()]);
-
-                if (repoName.isPresent()) {
-                    metadata.add(Constants.REPOSITORY_NAME_METADATA_LABEL, repoName.get());
-                }
-            }
-
-            if (myCsvHeaders.hasLocalRightsStatementIndex()) {
-                final Optional<String> rights = getMetadata(aRow[myCsvHeaders.getLocalRightsStatementIndex()]);
-
-                if (rights.isPresent()) {
-                    collection.setAttribution(new Attribution(rights.get()));
-                }
-            }
-
-            if (myCsvHeaders.hasRightsContactIndex()) {
-                final Optional<String> contract = getMetadata(aRow[myCsvHeaders.getRightsContactIndex()]);
-
-                if (contract.isPresent()) {
-                    metadata.add(Constants.RIGHTS_CONTACT_METADATA_LABEL, contract.get());
-                }
-            }
-
-            if (metadata.getEntries().size() > 0) {
-                collection.setMetadata(metadata);
-            }
-
-            return collection;
-        } else {
-            throw new CsvParsingException(MessageCodes.MFS_106);
-        }
-    }
-
-    private Optional<String> getMetadata(final String aRowColumnValue) {
-        return Optional.ofNullable(StringUtils.trimToNull(aRowColumnValue));
     }
 
     /**
@@ -360,8 +309,8 @@ public class CsvParser {
      *
      * @param aRow A row from the metadata CSV
      * @return The object type
-     * @throws CsvParsingException If object type isn't included in the CSV headers, or the object type index is out of
-     * bounds of the CSV row, or the metadata contains an unknown object type
+     * @throws CsvParsingException If object type isn't included in the CSV headers, or the object type index is out
+     *         of bounds of the CSV row, or the metadata contains an unknown object type
      */
     private ObjectType getObjectType(final String[] aRow) throws CsvParsingException {
         if (myCsvHeaders.hasObjectTypeIndex()) {
@@ -395,8 +344,8 @@ public class CsvParser {
      *
      * @param aCsvRows A list of rows from the metadata CSV
      * @return The set of object types
-     * @throws CsvParsingException If object type isn't included in the CSV headers, or the object type index is out of
-     * bounds of the CSV row, or the metadata contains an unknown object type
+     * @throws CsvParsingException If object type isn't included in the CSV headers, or the object type index is out
+     *         of bounds of the CSV row, or the metadata contains an unknown object type
      */
     private Set<ObjectType> getObjectTypes(final List<String[]> aCsvRows) throws CsvParsingException {
         final Set<ObjectType> objectTypes = EnumSet.noneOf(ObjectType.class);
@@ -404,6 +353,11 @@ public class CsvParser {
         for (final String[] row : aCsvRows) {
             objectTypes.add(getObjectType(row));
         }
+
         return objectTypes;
+    }
+
+    private Optional<String> getMetadata(final String aRowColumnValue) {
+        return Optional.ofNullable(StringUtils.trimToNull(aRowColumnValue));
     }
 }

--- a/src/main/java/edu/ucla/library/iiif/fester/CsvParser.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/CsvParser.java
@@ -61,10 +61,10 @@ public class CsvParser {
      * Rights.statementLocal, Rights.servicesContact,
      *
      * @param aPath A path to a CSV file
+     * @return This CSV parser
      * @throws IOException If there is trouble reading or writing data
      * @throws CsvException If there is trouble reading the CSV data
      * @throws CsvParsingException If there is trouble parsing the CSV data
-     * @return This CSV parser
      */
     public CsvParser parse(final Path aPath) throws IOException, CsvException, CsvParsingException {
         reset();

--- a/src/main/java/edu/ucla/library/iiif/fester/LockedManifest.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/LockedManifest.java
@@ -1,9 +1,6 @@
 
 package edu.ucla.library.iiif.fester;
 
-import info.freelibrary.iiif.presentation.Collection;
-import info.freelibrary.iiif.presentation.Manifest;
-
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.shareddata.Lock;
 
@@ -23,7 +20,7 @@ public class LockedManifest {
      *
      * @param aManifest A manifest in JSON form
      * @param aCollection A collection document
-     * @param aLock A Vertx lock
+     * @param aLock A Vert.x lock
      */
     public LockedManifest(final JsonObject aManifest, final boolean aCollection, final Lock aLock) {
         myManifestIsCollection = aCollection;
@@ -32,7 +29,7 @@ public class LockedManifest {
     }
 
     /**
-     * Gets whether this is a collection (or a work).
+     * Gets whether this is a collection document.
      *
      * @return True if the manifest is for a collection
      */
@@ -41,21 +38,21 @@ public class LockedManifest {
     }
 
     /**
-     * Gets the manifest content as a work manifest object.
+     * Return the JSON encoded manifest.
      *
-     * @return The manifest's contents
+     * @return The JSON representation of a IIIF presentation manifest
      */
-    public Manifest getWork() {
-        return Manifest.fromJSON(myManifest);
+    public JsonObject toJSON() {
+        return myManifest;
     }
 
     /**
-     * Gets the manifest content as a Collection object.
+     * Gets whether this is a work manifest.
      *
-     * @return The manifest's contents
+     * @return True if the manifest is for a work
      */
-    public Collection getCollection() {
-        return Collection.fromJSON(myManifest);
+    public boolean isWork() {
+        return !myManifestIsCollection;
     }
 
     /**

--- a/src/main/java/edu/ucla/library/iiif/fester/MetadataLabels.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/MetadataLabels.java
@@ -1,0 +1,23 @@
+
+package edu.ucla.library.iiif.fester;
+
+/**
+ * Constants for manifest metadata.
+ */
+public final class MetadataLabels {
+
+    /**
+     * The label that should be displayed along with the repository name in the manifest metadata.
+     */
+    public static final String REPOSITORY_NAME = "Repository";
+
+    /**
+     * The label that should be displayed along with the rights contact in the manifest metadata.
+     */
+    public static final String RIGHTS_CONTACT = "Rights contact";
+
+    // Private constructor for constants class
+    private MetadataLabels() {
+    }
+
+}

--- a/src/main/java/edu/ucla/library/iiif/fester/Op.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/Op.java
@@ -1,28 +1,64 @@
 
 package edu.ucla.library.iiif.fester;
 
+/**
+ * Constants representing API operations.
+ */
 public final class Op {
 
+    /**
+     * Get the status of Fester.
+     */
     public static final String GET_STATUS = "getStatus";
 
+    /**
+     * Get a manifest from Fester.
+     */
     public static final String GET_MANIFEST = "getManifest";
 
+    /**
+     * Put a manifest into Fester.
+     */
     public static final String PUT_MANIFEST = "putManifest";
 
+    /**
+     * Delete a manifest from Fester.
+     */
     public static final String DELETE_MANIFEST = "deleteManifest";
 
+    /**
+     * Get a collection from Fester.
+     */
     public static final String GET_COLLECTION = "getCollection";
 
+    /**
+     * Put a collection into Fester.
+     */
     public static final String PUT_COLLECTION = "putCollection";
 
+    /**
+     * Delete a collection from Fester.
+     */
     public static final String DELETE_COLLECTION = "deleteCollection";
 
+    /**
+     * Post a CSV file to Fester for processing of its contents.
+     */
     public static final String POST_CSV = "postCSV";
 
+    /**
+     * A successful operation.
+     */
     public static final String SUCCESS = "success";
 
+    /**
+     * An operation that needs to be retried.
+     */
     public static final String RETRY = "retry";
 
+    /**
+     * A failed operation.
+     */
     public static final String FAILURE = "failure";
 
     private Op() {

--- a/src/main/java/edu/ucla/library/iiif/fester/handlers/MissingMediaTypeException.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/handlers/MissingMediaTypeException.java
@@ -7,7 +7,7 @@ import edu.ucla.library.iiif.fester.Constants;
 import edu.ucla.library.iiif.fester.MessageCodes;
 
 /**
- * Exception thrown when a request is missing a required media-type
+ * Exception thrown when a request is missing a required media-type.
  */
 public class MissingMediaTypeException extends I18nException {
 

--- a/src/main/java/edu/ucla/library/iiif/fester/handlers/PostCsvHandler.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/handlers/PostCsvHandler.java
@@ -175,7 +175,7 @@ public class PostCsvHandler extends AbstractFesterHandler {
         LOGGER.error(aThrowable, LOGGER.getMessage(MessageCodes.MFS_103, error));
 
         aResponse.setStatusCode(aStatusCode);
-        aResponse.setStatusMessage(error.replaceAll(Constants.EOL_REGEX, ""));
+        aResponse.setStatusMessage(error.replaceAll(Constants.EOL_REGEX, Constants.EMPTY));
         aResponse.putHeader(Constants.CONTENT_TYPE, Constants.HTML_MEDIA_TYPE);
         aResponse.end(StringUtils.format(myExceptionPage, body));
     }

--- a/src/main/java/edu/ucla/library/iiif/fester/handlers/PostCsvHandler.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/handlers/PostCsvHandler.java
@@ -88,9 +88,8 @@ public class PostCsvHandler extends AbstractFesterHandler {
             response.setStatusMessage(errorMessage);
             response.putHeader(Constants.CONTENT_TYPE, Constants.HTML_MEDIA_TYPE);
             response.end(StringUtils.format(myExceptionPage, errorMessage));
-        } else if (festerizeUserAgentMatcher.matches()
-                && !festerizeUserAgentMatcher.group("version").equals(myFesterizeVersion)) {
-            // Festerize version mismatch
+        } else if (festerizeUserAgentMatcher.matches() && !festerizeUserAgentMatcher.group("version").equals(
+                myFesterizeVersion)) { // Festerize version mismatch
             errorMessage = LOGGER.getMessage(MessageCodes.MFS_147, myFesterizeVersion);
 
             response.setStatusCode(HTTP.BAD_REQUEST);
@@ -104,10 +103,13 @@ public class PostCsvHandler extends AbstractFesterHandler {
             final JsonObject message = new JsonObject();
             final DeliveryOptions options = new DeliveryOptions();
             final String iiifHost = StringUtils.trimToNull(request.getFormAttribute(Constants.IIIF_HOST));
+            final String iiifVersion = StringUtils.trimToNull(request.getFormAttribute(Constants.IIIF_API_VERSION));
 
             // Store the information that the manifest generator will need
             message.put(Constants.CSV_FILE_NAME, fileName);
             message.put(Constants.CSV_FILE_PATH, filePath);
+            // For now, our default IIIF API version is v2... TODO: make this a configuration option?
+            message.put(Constants.IIIF_API_VERSION, iiifVersion == null ? Constants.IIIF_API_V2 : iiifVersion);
             options.addHeader(Constants.ACTION, Op.POST_CSV);
 
             if (iiifHost != null) {
@@ -123,6 +125,7 @@ public class PostCsvHandler extends AbstractFesterHandler {
                     returnError(response, error.failureCode(), error);
                 }
             });
+
         }
     }
 

--- a/src/main/java/edu/ucla/library/iiif/fester/handlers/package-info.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/handlers/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Handlers used by the Fester application to handle incoming API requests.
+ */
+
+package edu.ucla.library.iiif.fester.handlers;

--- a/src/main/java/edu/ucla/library/iiif/fester/handlers/package-info.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/handlers/package-info.java
@@ -3,3 +3,4 @@
  */
 
 package edu.ucla.library.iiif.fester.handlers;
+

--- a/src/main/java/edu/ucla/library/iiif/fester/package-info.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Basic classes for the Fester application.
+ */
+
+package edu.ucla.library.iiif.fester;

--- a/src/main/java/edu/ucla/library/iiif/fester/package-info.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/package-info.java
@@ -3,3 +3,4 @@
  */
 
 package edu.ucla.library.iiif.fester;
+

--- a/src/main/java/edu/ucla/library/iiif/fester/utils/V2ManifestLabelComparator.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/utils/V2ManifestLabelComparator.java
@@ -1,16 +1,17 @@
+
 package edu.ucla.library.iiif.fester.utils;
 
 import java.util.Comparator;
-import info.freelibrary.iiif.presentation.Collection;
+
+import info.freelibrary.iiif.presentation.v2.Collection;
+
 import se.sawano.java.text.AlphanumericComparator;
 
 /**
- * Comparator for sorting manifests alpha-numerically based on their label.
- *
- * Note that this comparison is based on the assumption that all work manifests embedded in a collection manifest have
- * exactly one label.
+ * Comparator for sorting manifests alpha-numerically based on their label. Note that this comparison is based on the
+ * assumption that all work manifests embedded in a collection manifest have exactly one label.
  */
-public class ManifestLabelComparator implements Comparator<Collection.Manifest> {
+public class V2ManifestLabelComparator implements Comparator<Collection.Manifest> {
 
     private final AlphanumericComparator myComparator = new AlphanumericComparator();
 
@@ -21,4 +22,5 @@ public class ManifestLabelComparator implements Comparator<Collection.Manifest> 
 
         return myComparator.compare(firstLabel, secondLabel);
     }
+
 }

--- a/src/main/java/edu/ucla/library/iiif/fester/utils/V3ManifestLabelComparator.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/utils/V3ManifestLabelComparator.java
@@ -1,0 +1,28 @@
+
+package edu.ucla.library.iiif.fester.utils;
+
+import java.util.Comparator;
+
+import info.freelibrary.iiif.presentation.v2.Collection;
+
+import se.sawano.java.text.AlphanumericComparator;
+
+/**
+ * Comparator for sorting manifests alpha-numerically based on their label. Note that this comparison is based on the
+ * assumption that all work manifests embedded in a collection manifest have exactly one label.
+ * <p>
+ * FIXME: Use the v3 Collection.Manifest
+ */
+public class V3ManifestLabelComparator implements Comparator<Collection.Manifest> {
+
+    private final AlphanumericComparator myComparator = new AlphanumericComparator();
+
+    @Override
+    public int compare(final Collection.Manifest aFirstManifest, final Collection.Manifest aSecondManifest) {
+        final String firstLabel = aFirstManifest.getLabel().getValues().get(0).getValue();
+        final String secondLabel = aSecondManifest.getLabel().getValues().get(0).getValue();
+
+        return myComparator.compare(firstLabel, secondLabel);
+    }
+
+}

--- a/src/main/java/edu/ucla/library/iiif/fester/utils/package-info.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/utils/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Utility classes for the Fester application.
+ */
+
+package edu.ucla.library.iiif.fester.utils;

--- a/src/main/java/edu/ucla/library/iiif/fester/utils/package-info.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/utils/package-info.java
@@ -3,3 +3,4 @@
  */
 
 package edu.ucla.library.iiif.fester.utils;
+

--- a/src/main/java/edu/ucla/library/iiif/fester/verticles/MainVerticle.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/verticles/MainVerticle.java
@@ -140,7 +140,6 @@ public class MainVerticle extends AbstractVerticle {
      */
     private Future<Void> deployVerticle(final String aVerticleName, final DeploymentOptions aOptions,
             final Promise<Void> aPromise) {
-        LOGGER.debug("Deploying {}", aVerticleName);
         vertx.deployVerticle(aVerticleName, aOptions, response -> {
             try {
                 final String verticleName = Class.forName(aVerticleName).getSimpleName();

--- a/src/main/java/edu/ucla/library/iiif/fester/verticles/MainVerticle.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/verticles/MainVerticle.java
@@ -105,15 +105,19 @@ public class MainVerticle extends AbstractVerticle {
      * @param aPromise A startup promise
      */
     private void startVerticles(final JsonObject aConfig, final Promise<Void> aPromise) {
+        @SuppressWarnings("rawtypes")
+        final List<Future> futures = new ArrayList<>();
         final DeploymentOptions uploaderOptions = new DeploymentOptions();
         final DeploymentOptions manifestorOptions = new DeploymentOptions();
-        final List<Future> futures = new ArrayList<>();
+        final int cores = Runtime.getRuntime().availableProcessors();
 
         uploaderOptions.setConfig(aConfig);
         manifestorOptions.setWorker(true).setWorkerPoolName(ManifestVerticle.class.getSimpleName());
-        manifestorOptions.setWorkerPoolSize(1).setConfig(aConfig);
+        manifestorOptions.setWorkerPoolSize(cores > 2 ? cores - 2 : 1).setConfig(aConfig);
 
         // Start up any necessary Fester verticles
+        futures.add(deployVerticle(V2ManifestVerticle.class.getName(), manifestorOptions, Promise.promise()));
+        futures.add(deployVerticle(V3ManifestVerticle.class.getName(), manifestorOptions, Promise.promise()));
         futures.add(deployVerticle(ManifestVerticle.class.getName(), manifestorOptions, Promise.promise()));
         futures.add(deployVerticle(S3BucketVerticle.class.getName(), uploaderOptions, Promise.promise()));
 
@@ -136,6 +140,7 @@ public class MainVerticle extends AbstractVerticle {
      */
     private Future<Void> deployVerticle(final String aVerticleName, final DeploymentOptions aOptions,
             final Promise<Void> aPromise) {
+        LOGGER.debug("Deploying {}", aVerticleName);
         vertx.deployVerticle(aVerticleName, aOptions, response -> {
             try {
                 final String verticleName = Class.forName(aVerticleName).getSimpleName();

--- a/src/main/java/edu/ucla/library/iiif/fester/verticles/ManifestVerticle.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/verticles/ManifestVerticle.java
@@ -2,39 +2,22 @@
 package edu.ucla.library.iiif.fester.verticles;
 
 import java.io.IOException;
-import java.net.URI;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
-import java.util.SortedSet;
-import java.util.TreeSet;
-import java.util.stream.Collectors;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.opencsv.exceptions.CsvException;
 
 import info.freelibrary.util.Logger;
 import info.freelibrary.util.LoggerFactory;
 import info.freelibrary.util.StringUtils;
-
-import info.freelibrary.iiif.presentation.Canvas;
-import info.freelibrary.iiif.presentation.Collection;
-import info.freelibrary.iiif.presentation.ImageContent;
-import info.freelibrary.iiif.presentation.ImageResource;
-import info.freelibrary.iiif.presentation.Manifest;
-import info.freelibrary.iiif.presentation.Sequence;
-import info.freelibrary.iiif.presentation.properties.Attribution;
-import info.freelibrary.iiif.presentation.properties.Metadata;
-import info.freelibrary.iiif.presentation.properties.ViewingDirection;
-import info.freelibrary.iiif.presentation.properties.ViewingHint;
-import info.freelibrary.iiif.presentation.services.ImageInfoService;
 
 import edu.ucla.library.iiif.fester.Config;
 import edu.ucla.library.iiif.fester.Constants;
@@ -43,52 +26,45 @@ import edu.ucla.library.iiif.fester.CsvMetadata;
 import edu.ucla.library.iiif.fester.CsvParser;
 import edu.ucla.library.iiif.fester.CsvParsingException;
 import edu.ucla.library.iiif.fester.HTTP;
-import edu.ucla.library.iiif.fester.ImageInfoLookup;
-import edu.ucla.library.iiif.fester.ImageNotFoundException;
 import edu.ucla.library.iiif.fester.LockedManifest;
 import edu.ucla.library.iiif.fester.ManifestNotFoundException;
 import edu.ucla.library.iiif.fester.MessageCodes;
 import edu.ucla.library.iiif.fester.Op;
-import edu.ucla.library.iiif.fester.utils.IDUtils;
-import edu.ucla.library.iiif.fester.utils.ItemSequenceComparator;
-import edu.ucla.library.iiif.fester.utils.ManifestLabelComparator;
-
 import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.eventbus.DeliveryOptions;
 import io.vertx.core.eventbus.Message;
+import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.shareddata.Lock;
 import io.vertx.core.shareddata.SharedData;
 
 /**
- * A creator of manifests (collection and work).
+ * A verticle to parse the incoming CSV data and hand the request off to the appropriate manifester.
  */
 public class ManifestVerticle extends AbstractFesterVerticle {
 
+    public static final String UPDATE_PAGES = "update-pages";
+
+    public static final String ADD_PAGES = "add-pages";
+
+    public static final String UPDATE_COLLECTION = "update-collection";
+
+    public static final String CREATE_COLLECTION = "create-collection";
+
+    public static final String CREATE_WORK = "create-work";
+
     private static final Logger LOGGER = LoggerFactory.getLogger(ManifestVerticle.class, Constants.MESSAGES);
 
-    private static final String SEQUENCE_URI = "{}/{}/manifest/sequence/normal";
-
-    private static final String CANVAS_URI = "{}/{}/manifest/canvas/{}";
-
-    private static final String ANNOTATION_URI = "{}/{}/annotation/{}";
-
-    private static final String SIMPLE_URI = "{}/{}";
-
-    private static final String DEFAULT_THUMBNAIL_URI = "/full/{},/0/default.jpg";
-
-    private static final int DEFAULT_THUMBNAIL_SIZE = 600;
-
-    private static final String MANIFEST_URI = "{}/{}/manifest";
+    private static final long TIMEOUT = Long.MAX_VALUE; // A temporary over the top setting for image lookups
 
     private String myPlaceholderImage;
 
     private String myImageHost;
 
     /**
-     * Starts the collection manifester.
+     * Starts a verticle to handle manifest creation requests.
      */
     @Override
     public void start(final Promise<Void> aPromise) {
@@ -97,44 +73,63 @@ public class ManifestVerticle extends AbstractFesterVerticle {
         }
 
         if (myPlaceholderImage == null) {
-            myPlaceholderImage = StringUtils.trimToNull(config().getString(Config.PLACEHOLDER_IMAGE));
+            myPlaceholderImage = StringUtils.trimTo(config().getString(Config.PLACEHOLDER_IMAGE), Constants.EMPTY);
         }
 
         getJsonConsumer().handler(message -> {
-            final JsonObject messageBody = message.body();
+            final JsonObject body = message.body();
             final String action = message.headers().get(Constants.ACTION);
 
             if (Op.POST_CSV.equals(action)) {
-                final Path filePath = Paths.get(messageBody.getString(Constants.CSV_FILE_PATH));
-                final Optional<String> imageHost = Optional.ofNullable(messageBody.getString(Constants.IIIF_HOST));
+                final Path filePath = Paths.get(body.getString(Constants.CSV_FILE_PATH));
+                final Optional<String> optImageHost = Optional.ofNullable(body.getString(Constants.IIIF_HOST));
+                final String iiifVersion = body.getString(Constants.IIIF_API_VERSION);
+                final String imageHost = optImageHost.orElse(myImageHost);
 
                 try {
                     final CsvParser csvParser = new CsvParser().parse(filePath);
-                    final Optional<Collection> collection = csvParser.getCollection();
+                    final Optional<String[]> csvCollection = csvParser.getCsvCollection();
                     final CsvHeaders csvHeaders = csvParser.getCsvHeaders();
                     final CsvMetadata csvMetadata = csvParser.getCsvMetadata();
 
                     // If we have a collection record in the CSV we're processing, create a collection manifest
-                    if (collection.isPresent()) {
-                        LOGGER.debug(MessageCodes.MFS_122, filePath, collection);
-                        buildCollectionManifest(collection.get(), csvHeaders, csvMetadata, imageHost, message);
+                    if (csvCollection.isPresent()) {
+                        final Promise<Void> promise = Promise.promise();
+
+                        // On completion of creating the collection doc, check to see if works need to be added
+                        promise.future().onComplete(creation -> {
+                            if (creation.succeeded()) {
+                                createWorks(csvHeaders, csvMetadata, imageHost, iiifVersion, message);
+                            } else {
+                                final Throwable throwable = creation.cause();
+                                final String log = LOGGER.getMessage(MessageCodes.MFS_125, throwable.getMessage());
+
+                                LOGGER.error(throwable, log);
+                                message.fail(HTTP.INTERNAL_SERVER_ERROR, log);
+                            }
+                        });
+
+                        createCollection(promise, csvCollection.get(), csvHeaders, csvMetadata, iiifVersion);
                     } else if (csvMetadata.hasWorks()) {
                         final Optional<String> id = csvMetadata.getCollectionID(csvHeaders.getParentArkIndex());
 
                         LOGGER.debug(MessageCodes.MFS_043, filePath);
-                        updateWorks(id.get(), csvHeaders, csvMetadata, imageHost, message);
+                        updateWorks(id.get(), csvHeaders, csvMetadata, imageHost, iiifVersion, message);
                     } else if (csvMetadata.hasPages()) {
-                        final Iterator<Entry<String, List<String[]>>> iterator = csvMetadata.getPageIterator();
+                        @SuppressWarnings("rawtypes")
                         final List<Future> futures = new ArrayList<>();
+                        final Iterator<Entry<String, List<String[]>>> iterator = csvMetadata.getPageIterator();
 
                         LOGGER.debug(MessageCodes.MFS_069, filePath);
 
                         while (iterator.hasNext()) {
                             final Entry<String, List<String[]>> pageEntry = iterator.next();
                             final List<String[]> pagesList = pageEntry.getValue();
+                            final Promise<Void> promise = Promise.promise();
                             final String workID = pageEntry.getKey();
 
-                            futures.add(updatePages(workID, csvHeaders, pagesList, imageHost, Promise.promise()));
+                            futures.add(promise.future());
+                            updatePages(promise, workID, csvHeaders, pagesList, imageHost, iiifVersion);
                         }
 
                         CompositeFuture.all(futures).onComplete(handler -> {
@@ -173,57 +168,89 @@ public class ManifestVerticle extends AbstractFesterVerticle {
     }
 
     /**
+     * Creates a collection manifest.
+     *
+     * @param aPromise A promise of future work to be done
+     * @param aCollection A collection ID and label
+     * @param aCsvHeaders Headers from a CSV file
+     * @param aCsvMetadata Metadata from a CSV file
+     */
+    private void createCollection(final Promise<Void> aPromise, final String[] aCsvCollection,
+            final CsvHeaders aCsvHeaders, final CsvMetadata aCsvMetadata, final String aApiVersion)
+            throws CsvParsingException {
+        final String collectionID = aCsvCollection[aCsvHeaders.getItemArkIndex()];
+        final List<String[]> csvWorks = aCsvMetadata.getWorksMap().get(collectionID);
+        final DeliveryOptions options = new DeliveryOptions();
+        final ObjectMapper mapper = new ObjectMapper();
+        final JsonObject message = new JsonObject();
+
+        try {
+            options.addHeader(Constants.ACTION, ManifestVerticle.CREATE_COLLECTION);
+            message.put(Constants.COLLECTION_CONTENT, new JsonArray(mapper.writeValueAsString(aCsvCollection)));
+            message.put(Constants.COLLECTION_NAME, collectionID);
+            message.put(Constants.CSV_HEADERS, aCsvHeaders.toJSON());
+
+            if (csvWorks != null) {
+                message.put(Constants.MANIFEST_CONTENT, mapper.writeValueAsString(csvWorks));
+            } else {
+                LOGGER.debug(MessageCodes.MFS_118, collectionID);
+            }
+
+            LOGGER.debug(MessageCodes.MFS_122, collectionID);
+
+            sendMessage(getManifestVerticleName(aApiVersion), message, options, collectionCreation -> {
+                if (collectionCreation.succeeded()) {
+                    aPromise.complete();
+                } else {
+                    aPromise.fail(collectionCreation.cause());
+                }
+            });
+        } catch (final JsonProcessingException details) {
+            aPromise.fail(details);
+        }
+    }
+
+    /**
      * Update work manifest pages with data from an uploaded CSV.
      *
      * @param aWorkID A work ID
      * @param aPagesList A list of pages
      * @param aMessage A message
      */
-    private Future<Void> updatePages(final String aWorkID, final CsvHeaders aCsvHeaders,
-            final List<String[]> aPagesList, final Optional<String> aImageHost, final Promise<Void> aPromise) {
+    private void updatePages(final Promise<Void> aPromise, final String aWorkID, final CsvHeaders aCsvHeaders,
+            final List<String[]> aPagesList, final String aImageHost, final String aApiVersion) {
         final Promise<LockedManifest> promise = Promise.promise();
-        final String encodedWorkID = URLEncoder.encode(aWorkID, StandardCharsets.UTF_8);
 
         promise.future().onComplete(handler -> {
             if (handler.succeeded()) {
                 final LockedManifest lockedManifest = handler.result();
-                final Manifest manifest = lockedManifest.getWork();
-                final List<Sequence> sequences = manifest.getSequences();
-                final Sequence sequence;
-                final JsonObject message = new JsonObject();
                 final DeliveryOptions options = new DeliveryOptions();
+                final ObjectMapper mapper = new ObjectMapper();
+                final JsonObject message = new JsonObject();
 
-                // If the work doesn't already have any sequences, create one for it
-                if (sequences.size() == 0) {
-                    final String seqID = StringUtils.format(SEQUENCE_URI, Constants.URL_PLACEHOLDER, encodedWorkID);
-
-                    sequence = new Sequence().setID(seqID);
-                    manifest.addSequence(sequence);
-                } else {
-                    // For now we're just dealing with single sequence works
-                    sequence = sequences.get(0);
-                }
-
-                sequence.getCanvases().clear(); // overwrite whatever is on the manifest already
-                aPagesList.sort(new ItemSequenceComparator(aCsvHeaders.getItemSequenceIndex()));
+                options.addHeader(Constants.ACTION, ManifestVerticle.UPDATE_PAGES);
+                message.put(Constants.MANIFEST_ID, aWorkID);
+                message.put(Constants.PLACEHOLDER_IMAGE, myPlaceholderImage);
+                message.put(Constants.MANIFEST_CONTENT, lockedManifest.toJSON());
+                message.put(Constants.CSV_HEADERS, aCsvHeaders.toJSON());
+                message.put(Constants.IIIF_HOST, aImageHost);
 
                 try {
-                    addPages(aCsvHeaders, aPagesList, sequence, aImageHost, encodedWorkID);
+                    message.put(Constants.MANIFEST_PAGES, new JsonArray(mapper.writeValueAsString(aPagesList)));
 
-                    message.put(Constants.MANIFEST_ID, aWorkID).put(Constants.DATA, manifest.toJSON());
-                    options.addHeader(Constants.ACTION, Op.PUT_MANIFEST);
-
-                    sendMessage(S3BucketVerticle.class.getName(), message, options, send -> {
-                        if (send.succeeded()) {
+                    // Override default timeout because we look up image dimensions as a part of this process
+                    sendMessage(getManifestVerticleName(aApiVersion), message, options, TIMEOUT, update -> {
+                        if (update.succeeded()) {
                             aPromise.complete();
                         } else {
-                            aPromise.fail(send.cause());
+                            aPromise.fail(update.cause());
                         }
+
+                        lockedManifest.release();
                     });
-                } catch (final IOException details) {
-                    aPromise.fail(details);
-                } finally {
+                } catch (JsonProcessingException details) {
                     lockedManifest.release();
+                    aPromise.fail(details);
                 }
             } else {
                 aPromise.fail(handler.cause());
@@ -231,7 +258,6 @@ public class ManifestVerticle extends AbstractFesterVerticle {
         });
 
         getLockedManifest(aWorkID, false, promise);
-        return aPromise.future();
     }
 
     /**
@@ -244,30 +270,36 @@ public class ManifestVerticle extends AbstractFesterVerticle {
      * @param aMessage A message
      */
     private void updateWorks(final String aCollectionID, final CsvHeaders aCsvHeaders, final CsvMetadata aCsvMetadata,
-            final Optional<String> aImageHost, final Message<JsonObject> aMessage) {
+            final String aImageHost, final String aApiVersion, final Message<JsonObject> aMessage) {
         final Promise<LockedManifest> promise = Promise.promise();
 
         // If we were able to get a lock on the manifest, update it with our new works
         promise.future().onComplete(handler -> {
             if (handler.succeeded()) {
+                final Map<String, List<String[]>> worksMap = aCsvMetadata.getWorksMap();
                 final LockedManifest lockedManifest = handler.result();
-                final Collection collectionToUpdate = lockedManifest.getCollection();
-                final JsonObject manifestJSON = updateCollection(collectionToUpdate, aCsvMetadata.getWorksMap());
-                final JsonObject message = new JsonObject();
                 final DeliveryOptions options = new DeliveryOptions();
+                final ObjectMapper mapper = new ObjectMapper();
+                final JsonObject message = new JsonObject();
 
-                message.put(Constants.COLLECTION_NAME, aCollectionID).put(Constants.DATA, manifestJSON);
-                options.addHeader(Constants.ACTION, Op.PUT_COLLECTION);
+                try {
+                    options.addHeader(Constants.ACTION, ManifestVerticle.UPDATE_COLLECTION);
+                    message.put(Constants.COLLECTION_CONTENT, lockedManifest.toJSON());
+                    message.put(Constants.COLLECTION_NAME, aCollectionID);
+                    message.put(Constants.MANIFEST_CONTENT, new JsonObject(mapper.writeValueAsString(worksMap)));
 
-                sendMessage(S3BucketVerticle.class.getName(), message, options, update -> {
-                    lockedManifest.release();
+                    sendMessage(getManifestVerticleName(aApiVersion), message, options, collectionUpdate -> {
+                        lockedManifest.release();
 
-                    if (update.succeeded()) {
-                        processWorks(aCsvHeaders, aCsvMetadata, aImageHost, aMessage);
-                    } else {
-                        aMessage.fail(HTTP.INTERNAL_SERVER_ERROR, update.cause().getMessage());
-                    }
-                });
+                        if (collectionUpdate.succeeded()) {
+                            createWorks(aCsvHeaders, aCsvMetadata, aImageHost, aApiVersion, aMessage);
+                        } else {
+                            aMessage.fail(HTTP.INTERNAL_SERVER_ERROR, collectionUpdate.cause().getMessage());
+                        }
+                    });
+                } catch (final JsonProcessingException details) {
+                    aMessage.fail(HTTP.INTERNAL_SERVER_ERROR, details.getMessage());
+                }
             } else {
                 aMessage.fail(HTTP.INTERNAL_SERVER_ERROR, handler.cause().getMessage());
             }
@@ -276,35 +308,55 @@ public class ManifestVerticle extends AbstractFesterVerticle {
         getLockedManifest(aCollectionID, true, promise);
     }
 
-    /**
-     * Update a collection with new works.
-     *
-     * @param aCollection A collection to be updated
-     * @return The updated collection
-     */
-    @SuppressWarnings("checkstyle:indentation")
-    private JsonObject updateCollection(final Collection aCollection,
-            final Map<String, List<Collection.Manifest>> aWorksMap) {
+    private void createWorks(final CsvHeaders aCsvHeaders, final CsvMetadata aCsvMetadata, final String aImageHost,
+            final String aApiVersion, final Message<JsonObject> aMessage) {
+        final Map<String, List<String[]>> aPagesMap = aCsvMetadata.getPagesMap();
+        final List<String[]> aWorksDataList = aCsvMetadata.getWorksList();
+        final DeliveryOptions options = new DeliveryOptions();
+        final ObjectMapper mapper = new ObjectMapper();
+        @SuppressWarnings("rawtypes")
+        final List<Future> futures = new ArrayList<>();
 
-        // Keep track of the manifests we want to add to, or update on, the IIIF collection
-        final Map<URI, Collection.Manifest> manifestMap = new HashMap<>();
-        final SortedSet<Collection.Manifest> sortedManifestSet = new TreeSet<>(new ManifestLabelComparator());
+        options.addHeader(Constants.ACTION, ManifestVerticle.CREATE_WORK);
 
-        // First, add the old manifests to the map
-        manifestMap.putAll(aCollection.getManifests().stream().collect(Collectors.toMap(Collection.Manifest::getID,
-                collection -> collection)));
+        // Cycle through the works creating a manifest for each
+        aWorksDataList.forEach(worksData -> {
+            final Promise<Void> promise = Promise.promise();
+            final JsonObject message = new JsonObject();
 
-        // Next, add the new manifests to the map, replacing any that already exist
-        manifestMap.putAll(aWorksMap.get(IDUtils.getResourceID(aCollection.getID())).stream().collect(Collectors.toMap(
-                Collection.Manifest::getID, collection -> collection)));
+            futures.add(promise.future());
 
-        // Update the manifest list with the manifests in the map, ordered by their label
-        sortedManifestSet.addAll(manifestMap.values());
+            try {
+                message.put(Constants.CSV_HEADERS, aCsvHeaders.toJSON());
+                message.put(Constants.MANIFEST_PAGES, new JsonObject(mapper.writeValueAsString(aPagesMap)));
+                message.put(Constants.MANIFEST_CONTENT, new JsonArray(mapper.writeValueAsString(worksData)));
+                message.put(Constants.IIIF_HOST, aImageHost);
 
-        aCollection.getManifests().clear();
-        aCollection.getManifests().addAll(sortedManifestSet);
+                // This is the call that looks up all the image dimensions; we need to bump default timeout
+                sendMessage(getManifestVerticleName(aApiVersion), message, options, TIMEOUT, workCreation -> {
+                    if (workCreation.succeeded()) {
+                        promise.complete();
+                    } else {
+                        promise.fail(workCreation.cause());
+                    }
+                });
+            } catch (final JsonProcessingException details) {
+                promise.fail(details);
+            }
+        });
 
-        return aCollection.toJSON();
+        // Keep track of our progress and fail our promise if we don't succeed
+        CompositeFuture.all(futures).onComplete(handler -> {
+            if (handler.succeeded()) {
+                aMessage.reply(LOGGER.getMessage(MessageCodes.MFS_126));
+            } else {
+                final Throwable cause = handler.cause();
+                final String message = LOGGER.getMessage(MessageCodes.MFS_131, cause.getMessage());
+
+                LOGGER.error(cause, message);
+                aMessage.fail(HTTP.INTERNAL_SERVER_ERROR, message);
+            }
+        });
     }
 
     /**
@@ -341,8 +393,8 @@ public class ManifestVerticle extends AbstractFesterVerticle {
                             aPromise.complete(new LockedManifest(manifest, aCollDoc, lock));
                         } else {
                             lockRequest.result().release();
-                            aPromise.fail(new ManifestNotFoundException(handler.cause(), MessageCodes.MFS_146, aCollDoc
-                                    ? "collection" : "work", aID));
+                            aPromise.fail(new ManifestNotFoundException(handler.cause(), MessageCodes.MFS_146,
+                                    aCollDoc ? "collection" : "work", aID));
                         }
                     });
                 } catch (final NullPointerException | IndexOutOfBoundsException details) {
@@ -359,275 +411,16 @@ public class ManifestVerticle extends AbstractFesterVerticle {
     }
 
     /**
-     * Builds the collection manifest.
+     * Gets a manifest verticle for the supplied version, falling back to v2 if the supplied version isn't recognized.
      *
-     * @param aCollection A collection
-     * @param aCsvHeaders Headers from a CSV file
-     * @param aCsvMetadata Metadata from a CSV file
-     * @param aMessage The verticle response message
+     * @param aApiVersion A version of the IIIF presentation specification
+     * @return The name of the manifest verticle that would handle requests for the supplied API version
      */
-    private void buildCollectionManifest(final Collection aCollection, final CsvHeaders aCsvHeaders,
-            final CsvMetadata aCsvMetadata, final Optional<String> aImageHost, final Message<JsonObject> aMessage) {
-        final List<Collection.Manifest> manifestList = aCollection.getManifests(); // Empty list
-        final String collectionID = IDUtils.getResourceID(aCollection.getID());
-        final List<Collection.Manifest> manifests = aCsvMetadata.getWorksMap().get(collectionID);
-        final Promise<Void> promise = Promise.promise();
-        final JsonObject message = new JsonObject();
-        final DeliveryOptions options = new DeliveryOptions();
-
-        // If we have work manifests, add them to the collection manifest
-        if (manifests != null) {
-            manifestList.addAll(manifests);
+    private String getManifestVerticleName(final String aApiVersion) {
+        if (Constants.IIIF_API_V3.equals(aApiVersion)) {
+            return V3ManifestVerticle.class.getName();
         } else {
-            LOGGER.warn(MessageCodes.MFS_118, collectionID);
-        }
-
-        message.put(Constants.COLLECTION_NAME, collectionID).put(Constants.DATA, aCollection.toJSON());
-        options.addHeader(Constants.ACTION, Op.PUT_COLLECTION);
-
-        // Create a handler to handle generating work manifests after the collection manage has been uploaded
-        promise.future().onComplete(handler -> {
-            if (handler.succeeded()) {
-                processWorks(aCsvHeaders, aCsvMetadata, aImageHost, aMessage);
-            } else {
-                final String failMessage = handler.cause().getMessage();
-
-                LOGGER.error(MessageCodes.MFS_125, failMessage);
-                aMessage.fail(HTTP.INTERNAL_SERVER_ERROR, failMessage);
-            }
-        });
-
-        // Send collection manifest to S3
-        sendMessage(S3BucketVerticle.class.getName(), message, options, send -> {
-            if (send.succeeded()) {
-                promise.complete();
-            } else {
-                promise.fail(send.cause());
-            }
-        });
-    }
-
-    private void processWorks(final CsvHeaders aHeaders, final CsvMetadata aCsvMetadata,
-            final Optional<String> aImageHost, final Message<JsonObject> aMessage) {
-        final Map<String, List<String[]>> aPagesMap = aCsvMetadata.getPagesMap();
-        final List<String[]> aWorksDataList = aCsvMetadata.getWorksList();
-        final Iterator<String[]> iterator = aWorksDataList.iterator();
-        final List<Future> futures = new ArrayList<>();
-
-        // Request each work manifest be created
-        while (iterator.hasNext()) {
-            futures.add(buildWorkManifest(aHeaders, iterator.next(), aPagesMap, aImageHost, Promise.promise()));
-        }
-
-        // Keep track of our progress and fail our promise if we don't succeed
-        CompositeFuture.all(futures).onComplete(handler -> {
-            if (handler.succeeded()) {
-                aMessage.reply(LOGGER.getMessage(MessageCodes.MFS_126));
-            } else {
-                final Throwable cause = handler.cause();
-                final String message = LOGGER.getMessage(MessageCodes.MFS_131, cause.getMessage());
-
-                LOGGER.error(cause, message);
-                aMessage.fail(HTTP.INTERNAL_SERVER_ERROR, message);
-            }
-        });
-    }
-
-    /**
-     * Build an individual work manifest.
-     *
-     * @param aCsvHeaders The CSV headers
-     * @param aWork A metadata array representing the work
-     * @param aPages A list of pages
-     * @param aPromise A promise we'll create the work manifest
-     * @return The future result of our promise
-     */
-    private Future buildWorkManifest(final CsvHeaders aCsvHeaders, final String[] aWork,
-            final Map<String, List<String[]>> aPages, final Optional<String> aImageHost, final Promise<Void> aPromise) {
-        final String workID = aWork[aCsvHeaders.getItemArkIndex()];
-        final String urlEncodedWorkID = URLEncoder.encode(workID, StandardCharsets.UTF_8);
-        final String workLabel = aWork[aCsvHeaders.getTitleIndex()];
-        final Metadata metadata = new Metadata();
-        final String manifestID = StringUtils.format(MANIFEST_URI, Constants.URL_PLACEHOLDER, urlEncodedWorkID);
-        final Manifest manifest = new Manifest(manifestID, workLabel);
-        final String sequenceID = StringUtils.format(SEQUENCE_URI, Constants.URL_PLACEHOLDER, urlEncodedWorkID);
-        final Sequence sequence = new Sequence().setID(sequenceID);
-        final JsonObject message = new JsonObject();
-        final DeliveryOptions options = new DeliveryOptions();
-
-        try {
-            // Add optional properties
-            if (aCsvHeaders.hasViewingDirectionIndex()) {
-                final String viewingDirection = StringUtils.trimToNull(aWork[aCsvHeaders.getViewingDirectionIndex()]);
-
-                if (viewingDirection != null) {
-                    manifest.setViewingDirection(ViewingDirection.fromString(viewingDirection));
-                }
-            }
-
-            if (aCsvHeaders.hasViewingHintIndex()) {
-                final String viewingHint = StringUtils.trimToNull(aWork[aCsvHeaders.getViewingHintIndex()]);
-
-                if (viewingHint != null) {
-                    manifest.setViewingHint(new ViewingHint(viewingHint));
-                }
-            }
-
-            if (aCsvHeaders.hasRepositoryNameIndex()) {
-                final String repositoryName = StringUtils.trimToNull(aWork[aCsvHeaders.getRepositoryNameIndex()]);
-
-                if (repositoryName != null) {
-                    metadata.add(Constants.REPOSITORY_NAME_METADATA_LABEL, repositoryName);
-                }
-            }
-
-            if (aCsvHeaders.hasLocalRightsStatementIndex()) {
-                final String localRightsStatement = StringUtils.trimToNull(aWork[aCsvHeaders
-                        .getLocalRightsStatementIndex()]);
-
-                if (localRightsStatement != null) {
-                    manifest.setAttribution(new Attribution(localRightsStatement));
-                }
-            }
-
-            if (aCsvHeaders.hasRightsContactIndex()) {
-                final String rightsContact = StringUtils.trimToNull(aWork[aCsvHeaders.getRightsContactIndex()]);
-
-                if (rightsContact != null) {
-                    metadata.add(Constants.RIGHTS_CONTACT_METADATA_LABEL, rightsContact);
-                }
-            }
-
-            if (metadata.getEntries().size() > 0) {
-                manifest.setMetadata(metadata);
-            }
-
-            // Check first for pages, then if the work itself is an image
-            if (aPages.containsKey(workID)) {
-                final List<String[]> pageList = aPages.get(workID);
-
-                manifest.addSequence(sequence);
-                pageList.sort(new ItemSequenceComparator(aCsvHeaders.getItemSequenceIndex()));
-
-                addPages(aCsvHeaders, pageList, sequence, aImageHost, urlEncodedWorkID);
-            } else if (aCsvHeaders.hasImageAccessUrlIndex()) {
-                final String accessURL = StringUtils.trimToNull(aWork[aCsvHeaders.getImageAccessUrlIndex()]);
-
-                if (accessURL != null) {
-                    final List<String[]> pageList = new ArrayList<>(1);
-
-                    pageList.add(aWork);
-                    manifest.addSequence(sequence);
-
-                    addPages(aCsvHeaders, pageList, sequence, aImageHost, urlEncodedWorkID);
-                }
-            }
-
-            message.put(Constants.MANIFEST_ID, workID).put(Constants.DATA, manifest.toJSON());
-            options.addHeader(Constants.ACTION, Op.PUT_MANIFEST);
-
-            sendMessage(S3BucketVerticle.class.getName(), message, options, send -> {
-                if (send.succeeded()) {
-                    aPromise.complete();
-                } else {
-                    aPromise.fail(send.cause());
-                }
-            });
-        } catch (final IllegalArgumentException details) {
-            LOGGER.warn(MessageCodes.MFS_074, workID, details.getMessage());
-            aPromise.fail(details);
-        } catch (final IOException details) {
-            aPromise.fail(details);
-        }
-
-        // Return our promise's future result
-        return aPromise.future();
-    }
-
-    /**
-     * Adds pages to a sequence from a work manifest.
-     *
-     * @param aCsvHeaders A CSV headers
-     * @param aPageList A list of pages to add
-     * @param aSequence A sequence to add pages to
-     * @param aImageHost An image host for image links
-     * @param aWorkID A URL encoded work ID
-     * @throws IOException If there is trouble adding a page
-     */
-    private void addPages(final CsvHeaders aCsvHeaders, final List<String[]> aPageList, final Sequence aSequence,
-            final Optional<String> aImageHost, final String aWorkID) throws IOException {
-        final Iterator<String[]> iterator = aPageList.iterator();
-        final String imageHost = aImageHost.orElse(myImageHost);
-
-        while (iterator.hasNext()) {
-            final String[] columns = iterator.next();
-            final String pageID = columns[aCsvHeaders.getItemArkIndex()];
-            final String idPart = IDUtils.getLastPart(pageID); // We're just copying Samvera here
-            final String encodedPageID = URLEncoder.encode(pageID, StandardCharsets.UTF_8);
-            final String pageLabel = columns[aCsvHeaders.getTitleIndex()];
-            final String canvasID = StringUtils.format(CANVAS_URI, Constants.URL_PLACEHOLDER, aWorkID, idPart);
-            final String pageURI = StringUtils.format(SIMPLE_URI, imageHost, encodedPageID);
-            final String annotationURI = StringUtils.format(ANNOTATION_URI, Constants.URL_PLACEHOLDER, aWorkID, idPart);
-
-            String resourceURI = pageURI + StringUtils.format(DEFAULT_THUMBNAIL_URI, DEFAULT_THUMBNAIL_SIZE);
-            ImageResource imageResource = new ImageResource(resourceURI, new ImageInfoService(pageURI));
-            ImageContent imageContent;
-            Canvas canvas;
-
-            try {
-                final ImageInfoLookup infoLookup = new ImageInfoLookup(pageURI);
-                final int width = infoLookup.getWidth();
-                final int height = infoLookup.getHeight();
-
-                // Create a canvas using the width and height of the related image
-                canvas = new Canvas(canvasID, pageLabel, width, height);
-                imageContent = new ImageContent(annotationURI, canvas);
-                imageContent.addResource(imageResource);
-                canvas.addImageContent(imageContent);
-            } catch (final ImageNotFoundException details) {
-                LOGGER.info(MessageCodes.MFS_078, pageID);
-
-                if (myPlaceholderImage != null) {
-                    try {
-                        final ImageInfoLookup placeholderLookup = new ImageInfoLookup(myPlaceholderImage);
-                        final int width = placeholderLookup.getWidth();
-                        final int height = placeholderLookup.getHeight();
-                        final int size = width >= DEFAULT_THUMBNAIL_SIZE ? DEFAULT_THUMBNAIL_SIZE : width;
-
-                        // If placeholder image found, use its URL for image resource and service
-                        resourceURI = myPlaceholderImage + StringUtils.format(DEFAULT_THUMBNAIL_URI, size);
-                        imageResource = new ImageResource(resourceURI, new ImageInfoService(myPlaceholderImage));
-
-                        // Create a canvas using the width and height of the placeholder image
-                        canvas = new Canvas(canvasID, pageLabel, width, height);
-                        imageContent = new ImageContent(annotationURI, canvas);
-                        imageContent.addResource(imageResource);
-                        canvas.addImageContent(imageContent);
-                    } catch (final ImageNotFoundException additionalDetails) {
-                        // We couldn't find the placeholder image so we create an empty canvas
-                        canvas = new Canvas(canvasID, pageLabel, 0, 0);
-                        LOGGER.error(additionalDetails, additionalDetails.getMessage());
-
-                        // No image content added to canvas when we couldn't find any
-                    }
-                } else {
-                    // We couldn't find the placeholder image so we create an empty canvas
-                    canvas = new Canvas(canvasID, pageLabel, 0, 0);
-                    LOGGER.info(MessageCodes.MFS_099, pageID);
-
-                    // No image content added to canvas when we couldn't find any
-                }
-            }
-
-            if (aCsvHeaders.hasViewingHintIndex()) {
-                final String viewingHint = StringUtils.trimToNull(columns[aCsvHeaders.getViewingHintIndex()]);
-
-                if (viewingHint != null) {
-                    canvas.setViewingHint(new ViewingHint(viewingHint));
-                }
-            }
-
-            aSequence.addCanvas(canvas);
+            return V2ManifestVerticle.class.getName();
         }
     }
 }

--- a/src/main/java/edu/ucla/library/iiif/fester/verticles/ManifestVerticle.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/verticles/ManifestVerticle.java
@@ -45,14 +45,29 @@ import io.vertx.core.shareddata.SharedData;
  */
 public class ManifestVerticle extends AbstractFesterVerticle {
 
+    /**
+     * An action value that indicates pages should be updated.
+     */
     public static final String UPDATE_PAGES = "update-pages";
 
+    /**
+     * An action value that indicates pages should be added.
+     */
     public static final String ADD_PAGES = "add-pages";
 
+    /**
+     * An action value that indicates a collection should be updated.
+     */
     public static final String UPDATE_COLLECTION = "update-collection";
 
+    /**
+     * An action value that indicates a collection should be created.
+     */
     public static final String CREATE_COLLECTION = "create-collection";
 
+    /**
+     * An action value that indicates a new work should be created.
+     */
     public static final String CREATE_WORK = "create-work";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ManifestVerticle.class, Constants.MESSAGES);
@@ -204,7 +219,7 @@ public class ManifestVerticle extends AbstractFesterVerticle {
     }
 
     /**
-     * Update work manifest pages with data from an uploaded CSV.
+     * Updates work manifest pages with data from an uploaded CSV.
      *
      * @param aWorkID A work ID
      * @param aPagesList A list of pages
@@ -254,7 +269,7 @@ public class ManifestVerticle extends AbstractFesterVerticle {
     }
 
     /**
-     * Update the works associated with a supplied collection.
+     * Updates the works associated with a supplied collection.
      *
      * @param aCollectionID A collection ID
      * @param aCsvHeaders Headers from the supplied CSV file
@@ -301,6 +316,15 @@ public class ManifestVerticle extends AbstractFesterVerticle {
         getLockedManifest(aCollectionID, true, promise);
     }
 
+    /**
+     * Creates manifest records for the supplied works.
+     *
+     * @param aCsvHeaders Headers from the CSV file
+     * @param aCsvMetadata Metadata from the supplied CSV file
+     * @param aImageHost The URL of the IIIF image server
+     * @param aApiVersion The version of the IIIF Presentation API being requested
+     * @param aMessage The event queue message
+     */
     private void createWorks(final CsvHeaders aCsvHeaders, final CsvMetadata aCsvMetadata, final String aImageHost,
             final String aApiVersion, final Message<JsonObject> aMessage) {
         final Map<String, List<String[]>> aPagesMap = aCsvMetadata.getPagesMap();

--- a/src/main/java/edu/ucla/library/iiif/fester/verticles/S3BucketVerticle.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/verticles/S3BucketVerticle.java
@@ -82,36 +82,35 @@ public class S3BucketVerticle extends AbstractFesterVerticle {
         }
 
         getJsonConsumer().handler(message -> {
-            final JsonObject msg = message.body();
-            final String manifestID;
-            final JsonObject manifest;
+            final JsonObject messageBody = message.body();
             final String action = message.headers().get(Constants.ACTION);
+            final JsonObject manifest;
+            final String manifestID;
 
             switch (action) {
                 case Op.GET_MANIFEST:
-                    manifestID = msg.getString(Constants.MANIFEST_ID);
+                    manifestID = messageBody.getString(Constants.MANIFEST_ID);
                     LOGGER.debug(MessageCodes.MFS_133, manifestID, myS3Bucket);
                     get(IDUtils.getWorkS3Key(manifestID), message);
                     break;
                 case Op.PUT_MANIFEST:
-                    manifestID = msg.getString(Constants.MANIFEST_ID);
-                    manifest = msg.getJsonObject(Constants.DATA);
+                    manifestID = messageBody.getString(Constants.MANIFEST_ID);
+                    manifest = messageBody.getJsonObject(Constants.DATA);
                     put(IDUtils.getWorkS3Key(manifestID), manifest, message);
                     break;
                 case Op.GET_COLLECTION:
-                    manifestID = msg.getString(Constants.COLLECTION_NAME);
+                    manifestID = messageBody.getString(Constants.COLLECTION_NAME);
                     LOGGER.debug(MessageCodes.MFS_133, manifestID, myS3Bucket);
                     get(IDUtils.getCollectionS3Key(manifestID), message);
                     break;
                 case Op.PUT_COLLECTION:
-                    manifestID = msg.getString(Constants.COLLECTION_NAME);
-                    manifest = msg.getJsonObject(Constants.DATA);
+                    manifestID = messageBody.getString(Constants.COLLECTION_NAME);
+                    manifest = messageBody.getJsonObject(Constants.DATA);
                     put(IDUtils.getCollectionS3Key(manifestID), manifest, message);
                     break;
                 default:
-                    final String errorMessage = StringUtils.format(MessageCodes.MFS_139, getClass().toString(),
-                            message.toString(), action);
-                    message.fail(CodeUtils.getInt(MessageCodes.MFS_139), errorMessage);
+                    message.fail(CodeUtils.getInt(MessageCodes.MFS_139), StringUtils.format(MessageCodes.MFS_139,
+                            getClass().toString(), message.toString(), action));
             }
         });
 

--- a/src/main/java/edu/ucla/library/iiif/fester/verticles/V2ManifestVerticle.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/verticles/V2ManifestVerticle.java
@@ -1,0 +1,445 @@
+
+package edu.ucla.library.iiif.fester.verticles;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import info.freelibrary.iiif.presentation.v2.Canvas;
+import info.freelibrary.iiif.presentation.v2.Collection;
+import info.freelibrary.iiif.presentation.v2.ImageContent;
+import info.freelibrary.iiif.presentation.v2.ImageResource;
+import info.freelibrary.iiif.presentation.v2.Manifest;
+import info.freelibrary.iiif.presentation.v2.Sequence;
+import info.freelibrary.iiif.presentation.v2.properties.Attribution;
+import info.freelibrary.iiif.presentation.v2.properties.Label;
+import info.freelibrary.iiif.presentation.v2.properties.Metadata;
+import info.freelibrary.iiif.presentation.v2.properties.ViewingDirection;
+import info.freelibrary.iiif.presentation.v2.properties.ViewingHint;
+import info.freelibrary.iiif.presentation.v2.services.ImageInfoService;
+import info.freelibrary.util.Logger;
+import info.freelibrary.util.LoggerFactory;
+import info.freelibrary.util.StringUtils;
+
+import edu.ucla.library.iiif.fester.Constants;
+import edu.ucla.library.iiif.fester.CsvHeaders;
+import edu.ucla.library.iiif.fester.HTTP;
+import edu.ucla.library.iiif.fester.ImageInfoLookup;
+import edu.ucla.library.iiif.fester.ImageNotFoundException;
+import edu.ucla.library.iiif.fester.MessageCodes;
+import edu.ucla.library.iiif.fester.MetadataLabels;
+import edu.ucla.library.iiif.fester.Op;
+import edu.ucla.library.iiif.fester.utils.CodeUtils;
+import edu.ucla.library.iiif.fester.utils.IDUtils;
+import edu.ucla.library.iiif.fester.utils.ItemSequenceComparator;
+import edu.ucla.library.iiif.fester.utils.V2ManifestLabelComparator;
+import io.vertx.core.Promise;
+import io.vertx.core.eventbus.DeliveryOptions;
+import io.vertx.core.eventbus.Message;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+/**
+ * A verticle that updates pages on a version 2 presentation manifest.
+ */
+public class V2ManifestVerticle extends AbstractFesterVerticle {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(V2ManifestVerticle.class, MessageCodes.BUNDLE);
+
+    private static final String SEQUENCE_URI = "{}/{}/manifest/sequence/normal";
+
+    private static final String MANIFEST_URI = "{}/{}/manifest";
+
+    private static final String CANVAS_URI = "{}/{}/manifest/canvas/{}";
+
+    private static final String ANNOTATION_URI = "{}/{}/annotation/{}";
+
+    private static final String SIMPLE_URI = "{}/{}";
+
+    private static final String DEFAULT_THUMBNAIL_URI = "/full/{},/0/default.jpg";
+
+    private static final int DEFAULT_THUMBNAIL_SIZE = 600;
+
+    /**
+     * Starts a verticle to update pages on a manifest.
+     */
+    @Override
+    public void start(final Promise<Void> aPromise) {
+        getJsonConsumer().handler(message -> {
+            final String action = message.headers().get(Constants.ACTION);
+
+            try {
+                // These are the actions that a versioned manifest verticle needs to implement
+                // This seems like something we could turn into a Vert.x service in the future
+                switch (action) {
+                    case ManifestVerticle.UPDATE_PAGES:
+                        updatePages(message);
+                        break;
+                    case ManifestVerticle.UPDATE_COLLECTION:
+                        updateCollection(message);
+                        break;
+                    case ManifestVerticle.CREATE_COLLECTION:
+                        createCollection(message);
+                        break;
+                    case ManifestVerticle.CREATE_WORK:
+                        createWork(message);
+                        break;
+                    default:
+                        message.fail(HTTP.INTERNAL_SERVER_ERROR, "Unexpected manifest action");
+                }
+            } catch (JsonProcessingException details) {
+                LOGGER.error(details, details.getMessage());
+                message.fail(HTTP.INTERNAL_SERVER_ERROR, details.getMessage());
+            }
+        });
+
+        aPromise.complete();
+    }
+
+    /**
+     * Create a new collection.
+     *
+     * @param aMessage An event queue message
+     * @throws JsonProcessingException If
+     */
+    private void createCollection(final Message<JsonObject> aMessage) throws JsonProcessingException {
+        final JsonObject body = aMessage.body();
+        final JsonObject message = new JsonObject();
+        final ObjectMapper mapper = new ObjectMapper();
+        final DeliveryOptions options = new DeliveryOptions();
+        final String collectionName = body.getString(Constants.COLLECTION_NAME);
+        final JsonArray collectionArray = body.getJsonArray(Constants.COLLECTION_CONTENT);
+        final CsvHeaders csvHeaders = CsvHeaders.fromJSON(body.getJsonObject(Constants.CSV_HEADERS));
+        final TypeReference<String[]> typeRef = new TypeReference<String[]>() {};
+        final String[] collectionData = mapper.readValue(collectionArray.encode(), typeRef);
+        final String collectionID = collectionData[csvHeaders.getItemArkIndex()];
+        final URI uri = IDUtils.getResourceURI(Constants.URL_PLACEHOLDER, IDUtils.getCollectionS3Key(collectionID));
+        final Label label = new Label(collectionData[csvHeaders.getTitleIndex()]);
+        final Collection collection = new Collection(uri, label);
+        final Metadata metadata = new Metadata();
+
+        // Add optional properties below
+        getMetadata(collectionData, csvHeaders.getRepositoryNameIndex()).ifPresent(repoName -> {
+            metadata.add(MetadataLabels.REPOSITORY_NAME, repoName);
+        });
+
+        getMetadata(collectionData, csvHeaders.getLocalRightsStatementIndex()).ifPresent(rightsStatement -> {
+            collection.setAttribution(new Attribution(rightsStatement));
+        });
+
+        getMetadata(collectionData, csvHeaders.getRightsContactIndex()).ifPresent(rightsContract -> {
+            metadata.add(MetadataLabels.RIGHTS_CONTACT, rightsContract);
+        });
+
+        if (metadata.getEntries().size() > 0) {
+            collection.setMetadata(metadata);
+        }
+
+        options.addHeader(Constants.ACTION, Op.PUT_COLLECTION);
+        message.put(Constants.COLLECTION_NAME, collectionName);
+        message.put(Constants.DATA, collection.toJSON());
+
+        sendMessage(S3BucketVerticle.class.getName(), message, options, send -> {
+            if (send.succeeded()) {
+                aMessage.reply(new JsonObject());
+            } else {
+                final Throwable throwable = send.cause();
+                final String logMessage = LOGGER.getMessage(MessageCodes.MFS_125, throwable.getMessage());
+
+                LOGGER.error(throwable, logMessage);
+                aMessage.fail(HTTP.INTERNAL_SERVER_ERROR, logMessage);
+            }
+        });
+    }
+
+    /**
+     * Creates a single work from the data that sent as a message.
+     *
+     * @param aMessage Information needed to create a work manifest
+     * @throws JsonProcessingException If there is trouble deserializing shared information
+     */
+    private void createWork(final Message<JsonObject> aMessage) throws JsonProcessingException {
+        final JsonObject body = aMessage.body();
+        final ObjectMapper mapper = new ObjectMapper();
+        final CsvHeaders csvHeaders = CsvHeaders.fromJSON(body.getJsonObject(Constants.CSV_HEADERS));
+        final JsonArray workArray = body.getJsonArray(Constants.MANIFEST_CONTENT);
+        final String[] workRow = mapper.readValue(workArray.encode(), new TypeReference<String[]>() {});
+        final JsonObject pagesJSON = body.getJsonObject(Constants.MANIFEST_PAGES);
+        final TypeReference<Map<String, List<String[]>>> type = new TypeReference<Map<String, List<String[]>>>() {};
+        final Map<String, List<String[]>> pagesMap = mapper.readValue(pagesJSON.encode(), type);
+        final String placeholderImage = body.getString(Constants.PLACEHOLDER_IMAGE);
+        final String imageHost = body.getString(Constants.IIIF_HOST);
+        final String workID = workRow[csvHeaders.getItemArkIndex()];
+        final String encodedWorkID = URLEncoder.encode(workID, StandardCharsets.UTF_8);
+        final String manifestID = StringUtils.format(MANIFEST_URI, Constants.URL_PLACEHOLDER, encodedWorkID);
+        final String sequenceID = StringUtils.format(SEQUENCE_URI, Constants.URL_PLACEHOLDER, encodedWorkID);
+        final Manifest manifest = new Manifest(manifestID, workRow[csvHeaders.getTitleIndex()]);
+        final Sequence sequence = new Sequence().setID(sequenceID);
+        final DeliveryOptions options = new DeliveryOptions();
+        final JsonObject message = new JsonObject();
+        final Metadata metadata = new Metadata();
+        final JsonObject jsonManifest;
+
+        getMetadata(workRow, csvHeaders.getViewingDirectionIndex()).ifPresent(viewingDirection -> {
+            manifest.setViewingDirection(ViewingDirection.fromString(viewingDirection));
+        });
+
+        getMetadata(workRow, csvHeaders.getViewingHintIndex()).ifPresent(viewingHint -> {
+            manifest.setViewingHint(new ViewingHint(viewingHint));
+        });
+
+        getMetadata(workRow, csvHeaders.getRepositoryNameIndex()).ifPresent(repositoryName -> {
+            metadata.add(MetadataLabels.REPOSITORY_NAME, repositoryName);
+        });
+
+        getMetadata(workRow, csvHeaders.getLocalRightsStatementIndex()).ifPresent(localRightsStatement -> {
+            manifest.setAttribution(new Attribution(localRightsStatement));
+        });
+
+        getMetadata(workRow, csvHeaders.getRightsContactIndex()).ifPresent(rightsContract -> {
+            metadata.add(MetadataLabels.RIGHTS_CONTACT, rightsContract);
+        });
+
+        if (metadata.getEntries().size() > 0) {
+            manifest.setMetadata(metadata);
+        }
+
+        // Check first for pages, then if the work itself is an image
+        if (pagesMap.containsKey(workID)) {
+            final List<String[]> pageList = pagesMap.get(workID);
+
+            manifest.addSequence(sequence);
+            pageList.sort(new ItemSequenceComparator(csvHeaders.getItemSequenceIndex()));
+            sequence.addCanvas(createCanvases(csvHeaders, pageList, imageHost, placeholderImage, encodedWorkID));
+        } else {
+            getMetadata(workRow, csvHeaders.getImageAccessUrlIndex()).ifPresent(accessURL -> {
+                final List<String[]> pageList = new ArrayList<>(1);
+
+                pageList.add(workRow);
+                manifest.addSequence(sequence);
+                sequence.addCanvas(createCanvases(csvHeaders, pageList, imageHost, placeholderImage, encodedWorkID));
+            });
+        }
+
+        jsonManifest = manifest.toJSON();
+        message.put(Constants.DATA, jsonManifest);
+        message.put(Constants.MANIFEST_ID, workID);
+        options.addHeader(Constants.ACTION, Op.PUT_MANIFEST);
+
+        sendMessage(S3BucketVerticle.class.getName(), message, options, send -> {
+            if (send.succeeded()) {
+                aMessage.reply(jsonManifest);
+            } else {
+                aMessage.fail(HTTP.INTERNAL_SERVER_ERROR, send.cause().getMessage());
+            }
+        });
+    }
+
+    /**
+     * Update a collection with new works.
+     *
+     * @param aMessage A event queue message
+     */
+    private void updateCollection(final Message<JsonObject> aMessage) throws JsonProcessingException {
+        final JsonObject body = aMessage.body();
+        final String collectionName = body.getString(Constants.COLLECTION_NAME);
+        final JsonObject worksJSON = body.getJsonObject(Constants.MANIFEST_CONTENT);
+        final Collection collection = Collection.fromJSON(body.getJsonObject(Constants.COLLECTION_CONTENT));
+        final TypeReference<Map<String, List<String[]>>> type = new TypeReference<Map<String, List<String[]>>>() {};
+        final Map<String, List<String[]>> worksMap = new ObjectMapper().readValue(worksJSON.encode(), type);
+        final SortedSet<Collection.Manifest> sortedManifestSet = new TreeSet<>(new V2ManifestLabelComparator());
+        final Map<URI, Collection.Manifest> manifestMap = new HashMap<>(); // Using to eliminate duplicates
+        final DeliveryOptions options = new DeliveryOptions();
+        final JsonObject message = new JsonObject();
+
+        // First, add the old manifests to the map
+        final Stream<Collection.Manifest> stream = collection.getManifests().stream();
+        manifestMap.putAll(stream.collect(Collectors.toMap(Collection.Manifest::getID, manifest -> manifest)));
+
+        // Next, add the new manifests to the map, replacing any that already exist
+        worksMap.get(IDUtils.getResourceID(collection.getID())).stream().forEach(workArray -> {
+            final URI manifestURI = URI.create(workArray[0]);
+            manifestMap.put(manifestURI, new Collection.Manifest(manifestURI, new Label(workArray[1])));
+        });
+
+        // Update the manifest list with the manifests in the map, ordered by their label
+        sortedManifestSet.addAll(manifestMap.values());
+
+        collection.getManifests().clear();
+        collection.getManifests().addAll(sortedManifestSet);
+
+        message.put(Constants.DATA, collection.toJSON());
+        message.put(Constants.COLLECTION_NAME, collectionName);
+        options.addHeader(Constants.ACTION, Op.PUT_COLLECTION);
+
+        sendMessage(S3BucketVerticle.class.getName(), message, options, update -> {
+            if (update.succeeded()) {
+                aMessage.reply(collection.toJSON());
+            } else {
+                aMessage.fail(HTTP.INTERNAL_SERVER_ERROR, update.cause().getMessage());
+            }
+        });
+    }
+
+    private void updatePages(final Message<JsonObject> aMessage) throws JsonProcessingException {
+        final JsonObject body = aMessage.body();
+        final String workID = body.getString(Constants.MANIFEST_ID);
+        final String imageHost = body.getString(Constants.IIIF_HOST);
+        final String placeholderImage = body.getString(Constants.PLACEHOLDER_IMAGE);
+        final String encodedWorkID = URLEncoder.encode(workID, StandardCharsets.UTF_8);
+        final Manifest manifest = Manifest.fromJSON(body.getJsonObject(Constants.MANIFEST_CONTENT));
+        final CsvHeaders csvHeaders = CsvHeaders.fromJSON(body.getJsonObject(Constants.CSV_HEADERS));
+        final TypeReference<List<String[]>> typeRef = new TypeReference<List<String[]>>() {};
+        final JsonArray pagesArray = body.getJsonArray(Constants.MANIFEST_PAGES);
+        final List<String[]> pagesList = new ObjectMapper().readValue(pagesArray.encode(), typeRef);
+        final List<Sequence> sequences = manifest.getSequences();
+        final DeliveryOptions options = new DeliveryOptions();
+        final JsonObject message = new JsonObject();
+        final JsonObject jsonManifest;
+        final Sequence sequence;
+
+        // If the work doesn't already have any sequences, create one for it
+        if (sequences.size() == 0) {
+            final String sequenceID = StringUtils.format(SEQUENCE_URI, Constants.URL_PLACEHOLDER, encodedWorkID);
+
+            sequence = new Sequence().setID(sequenceID);
+            manifest.addSequence(sequence);
+        } else {
+            sequence = sequences.get(0); // For now we're just dealing with single sequence works
+        }
+
+        sequence.getCanvases().clear(); // Overwrite whatever canvases are on the manifest
+        pagesList.sort(new ItemSequenceComparator(csvHeaders.getItemSequenceIndex()));
+        sequence.addCanvas(createCanvases(csvHeaders, pagesList, imageHost, placeholderImage, encodedWorkID));
+
+        jsonManifest = manifest.toJSON();
+        message.put(Constants.DATA, jsonManifest);
+        message.put(Constants.MANIFEST_ID, workID);
+        options.addHeader(Constants.ACTION, Op.PUT_MANIFEST);
+
+        sendMessage(S3BucketVerticle.class.getName(), message, options, send -> {
+            if (send.succeeded()) {
+                aMessage.reply(jsonManifest);
+            } else {
+                final Throwable throwable = send.cause();
+                final String logMessage = LOGGER.getMessage(MessageCodes.MFS_054, workID, throwable.getMessage());
+
+                LOGGER.error(throwable, logMessage);
+                aMessage.fail(CodeUtils.getInt(MessageCodes.MFS_054), logMessage);
+            }
+        });
+    }
+
+    /**
+     * Adds pages to a sequence from a work manifest.
+     *
+     * @param aCsvHeaders A CSV headers
+     * @param aPageList A list of pages to add
+     * @param aSequence A sequence to add pages to
+     * @param aImageHost An image host for image links
+     * @param aWorkID A URL encoded work ID
+     * @throws IOException If there is trouble adding a page
+     */
+    private Canvas[] createCanvases(final CsvHeaders aCsvHeaders, final List<String[]> aPageList,
+            final String aImageHost, final String aPlaceholderImage, final String aWorkID) {
+        final Iterator<String[]> iterator = aPageList.iterator();
+        final List<Canvas> canvases = new ArrayList<>();
+
+        while (iterator.hasNext()) {
+            final String[] columns = iterator.next();
+            final String pageID = columns[aCsvHeaders.getItemArkIndex()];
+            final String idPart = IDUtils.getLastPart(pageID);
+            final String pageLabel = columns[aCsvHeaders.getTitleIndex()];
+            final String encodedPageID = URLEncoder.encode(pageID, StandardCharsets.UTF_8);
+            final String canvasID = StringUtils.format(CANVAS_URI, Constants.URL_PLACEHOLDER, aWorkID, idPart);
+            final String pageURI = StringUtils.format(SIMPLE_URI, aImageHost, encodedPageID);
+            final String contentURI = StringUtils.format(ANNOTATION_URI, Constants.URL_PLACEHOLDER, aWorkID, idPart);
+
+            String resourceURI = pageURI + StringUtils.format(DEFAULT_THUMBNAIL_URI, DEFAULT_THUMBNAIL_SIZE);
+            ImageResource imageResource = new ImageResource(resourceURI, new ImageInfoService(pageURI));
+            ImageContent imageContent;
+            Canvas canvas;
+
+            try {
+                final ImageInfoLookup infoLookup = new ImageInfoLookup(pageURI);
+                final int width = infoLookup.getWidth();
+                final int height = infoLookup.getHeight();
+
+                // Create a canvas using the width and height of the related image
+                canvas = new Canvas(canvasID, pageLabel, width, height);
+                imageContent = new ImageContent(contentURI, canvas);
+                imageContent.addResource(imageResource);
+                canvas.addImageContent(imageContent);
+            } catch (final ImageNotFoundException | IOException details) {
+                LOGGER.info(MessageCodes.MFS_078, pageID);
+
+                if (aPlaceholderImage != null) {
+                    try {
+                        final ImageInfoLookup placeholderLookup = new ImageInfoLookup(aPlaceholderImage);
+                        final int width = placeholderLookup.getWidth();
+                        final int height = placeholderLookup.getHeight();
+                        final int size = width >= DEFAULT_THUMBNAIL_SIZE ? DEFAULT_THUMBNAIL_SIZE : width;
+
+                        // If placeholder image found, use its URL for image resource and service
+                        resourceURI = aPlaceholderImage + StringUtils.format(DEFAULT_THUMBNAIL_URI, size);
+                        imageResource = new ImageResource(resourceURI, new ImageInfoService(aPlaceholderImage));
+
+                        // Create a canvas using the width and height of the placeholder image
+                        canvas = new Canvas(canvasID, pageLabel, width, height);
+                        imageContent = new ImageContent(contentURI, canvas);
+                        imageContent.addResource(imageResource);
+                        canvas.addImageContent(imageContent);
+                    } catch (final ImageNotFoundException | IOException lookupDetails) {
+                        // We couldn't find the placeholder image so we create an empty canvas
+                        canvas = new Canvas(canvasID, pageLabel, 0, 0);
+                        LOGGER.error(lookupDetails, lookupDetails.getMessage());
+
+                        // No image content added to canvas when we couldn't find any
+                    }
+                } else {
+                    // We couldn't find the placeholder image so we create an empty canvas
+                    canvas = new Canvas(canvasID, pageLabel, 0, 0);
+                    LOGGER.info(MessageCodes.MFS_099, pageID);
+
+                    // No image content added to canvas when we couldn't find any
+                }
+            }
+
+            if (aCsvHeaders.hasViewingHintIndex()) {
+                final String viewingHint = StringUtils.trimToNull(columns[aCsvHeaders.getViewingHintIndex()]);
+
+                if (viewingHint != null) {
+                    canvas.setViewingHint(new ViewingHint(viewingHint));
+                }
+            }
+
+            canvases.add(canvas);
+        }
+
+        return canvases.toArray(new Canvas[] {});
+    }
+
+    private Optional<String> getMetadata(final String[] aRow, final int aIndex) {
+        try {
+            return Optional.ofNullable(StringUtils.trimToNull(aRow[aIndex]));
+        } catch (final IndexOutOfBoundsException details) {
+            // Checking for required metadata is done in the parser, not here
+            return Optional.empty();
+        }
+    }
+}

--- a/src/main/java/edu/ucla/library/iiif/fester/verticles/V2ManifestVerticle.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/verticles/V2ManifestVerticle.java
@@ -99,7 +99,7 @@ public class V2ManifestVerticle extends AbstractFesterVerticle {
                         createWork(message);
                         break;
                     default:
-                        message.fail(HTTP.INTERNAL_SERVER_ERROR, "Unexpected manifest action");
+                        message.fail(HTTP.INTERNAL_SERVER_ERROR, LOGGER.getMessage(MessageCodes.MFS_153, action));
                 }
             } catch (JsonProcessingException details) {
                 LOGGER.error(details, details.getMessage());
@@ -111,10 +111,10 @@ public class V2ManifestVerticle extends AbstractFesterVerticle {
     }
 
     /**
-     * Create a new collection.
+     * Creates a new collection.
      *
      * @param aMessage An event queue message
-     * @throws JsonProcessingException If
+     * @throws JsonProcessingException If there is trouble deserializing message components
      */
     private void createCollection(final Message<JsonObject> aMessage) throws JsonProcessingException {
         final JsonObject body = aMessage.body();
@@ -246,7 +246,7 @@ public class V2ManifestVerticle extends AbstractFesterVerticle {
     }
 
     /**
-     * Update a collection with new works.
+     * Updates a collection with new works.
      *
      * @param aMessage A event queue message
      */
@@ -291,6 +291,12 @@ public class V2ManifestVerticle extends AbstractFesterVerticle {
         });
     }
 
+    /**
+     * Updates pages in a work.
+     *
+     * @param aMessage A message with information about the page updates
+     * @throws JsonProcessingException If there is trouble deserializing message components
+     */
     private void updatePages(final Message<JsonObject> aMessage) throws JsonProcessingException {
         final JsonObject body = aMessage.body();
         final String workID = body.getString(Constants.MANIFEST_ID);
@@ -425,6 +431,13 @@ public class V2ManifestVerticle extends AbstractFesterVerticle {
         return canvases.toArray(new Canvas[] {});
     }
 
+    /**
+     * Gets the metadata from the supplied row and index position.
+     *
+     * @param aRow A row of metadata
+     * @param aIndex An index position of the metadata to retrieve
+     * @return An optional metadata value
+     */
     private Optional<String> getMetadata(final String[] aRow, final int aIndex) {
         try {
             return Optional.ofNullable(StringUtils.trimToNull(aRow[aIndex]));

--- a/src/main/java/edu/ucla/library/iiif/fester/verticles/V2ManifestVerticle.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/verticles/V2ManifestVerticle.java
@@ -44,7 +44,6 @@ import edu.ucla.library.iiif.fester.ImageNotFoundException;
 import edu.ucla.library.iiif.fester.MessageCodes;
 import edu.ucla.library.iiif.fester.MetadataLabels;
 import edu.ucla.library.iiif.fester.Op;
-import edu.ucla.library.iiif.fester.utils.CodeUtils;
 import edu.ucla.library.iiif.fester.utils.IDUtils;
 import edu.ucla.library.iiif.fester.utils.ItemSequenceComparator;
 import edu.ucla.library.iiif.fester.utils.V2ManifestLabelComparator;
@@ -158,11 +157,7 @@ public class V2ManifestVerticle extends AbstractFesterVerticle {
             if (send.succeeded()) {
                 aMessage.reply(new JsonObject());
             } else {
-                final Throwable throwable = send.cause();
-                final String logMessage = LOGGER.getMessage(MessageCodes.MFS_125, throwable.getMessage());
-
-                LOGGER.error(throwable, logMessage);
-                aMessage.fail(HTTP.INTERNAL_SERVER_ERROR, logMessage);
+                error(aMessage, send.cause(), MessageCodes.MFS_125, send.cause().getMessage());
             }
         });
     }
@@ -245,7 +240,7 @@ public class V2ManifestVerticle extends AbstractFesterVerticle {
             if (send.succeeded()) {
                 aMessage.reply(jsonManifest);
             } else {
-                aMessage.fail(HTTP.INTERNAL_SERVER_ERROR, send.cause().getMessage());
+                error(aMessage, send.cause(), MessageCodes.MFS_151, send.cause().getMessage());
             }
         });
     }
@@ -291,7 +286,7 @@ public class V2ManifestVerticle extends AbstractFesterVerticle {
             if (update.succeeded()) {
                 aMessage.reply(collection.toJSON());
             } else {
-                aMessage.fail(HTTP.INTERNAL_SERVER_ERROR, update.cause().getMessage());
+                error(aMessage, update.cause(), MessageCodes.MFS_152, update.cause().getMessage());
             }
         });
     }
@@ -336,11 +331,7 @@ public class V2ManifestVerticle extends AbstractFesterVerticle {
             if (send.succeeded()) {
                 aMessage.reply(jsonManifest);
             } else {
-                final Throwable throwable = send.cause();
-                final String logMessage = LOGGER.getMessage(MessageCodes.MFS_054, workID, throwable.getMessage());
-
-                LOGGER.error(throwable, logMessage);
-                aMessage.fail(CodeUtils.getInt(MessageCodes.MFS_054), logMessage);
+                error(aMessage, send.cause(), MessageCodes.MFS_054, workID, send.cause().getMessage());
             }
         });
     }

--- a/src/main/java/edu/ucla/library/iiif/fester/verticles/V3ManifestVerticle.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/verticles/V3ManifestVerticle.java
@@ -1,0 +1,23 @@
+
+package edu.ucla.library.iiif.fester.verticles;
+
+import io.vertx.core.Promise;
+
+/**
+ * A verticle that updates pages on a version 3 presentation manifest.
+ */
+public class V3ManifestVerticle extends AbstractFesterVerticle {
+
+    /**
+     * Starts a verticle to update pages on a manifest.
+     */
+    @Override
+    public void start(final Promise<Void> aPromise) {
+        getJsonConsumer().handler(message -> {
+            message.body();
+        });
+
+        aPromise.complete();
+    }
+
+}

--- a/src/main/java/edu/ucla/library/iiif/fester/verticles/package-info.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/verticles/package-info.java
@@ -3,3 +3,4 @@
  */
 
 package edu.ucla.library.iiif.fester.verticles;
+

--- a/src/main/java/edu/ucla/library/iiif/fester/verticles/package-info.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/verticles/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Verticles (or workers) for doing tasks needed by the Fester application.
+ */
+
+package edu.ucla.library.iiif.fester.verticles;

--- a/src/main/resources/fester_messages.xml
+++ b/src/main/resources/fester_messages.xml
@@ -163,4 +163,5 @@
   <entry key="MFS-150">Work update failed: {}</entry>
   <entry key="MFS-151">Work creation failed: {}</entry>
   <entry key="MFS-152">Collection update failed: {}</entry>
+  <entry key="MFS-153">Unexpected manifest action: {}</entry>
 </properties>

--- a/src/main/resources/fester_messages.xml
+++ b/src/main/resources/fester_messages.xml
@@ -159,4 +159,8 @@
   <entry key="MFS-146">Could not find {} manifest '{}' to update</entry>
   <entry key="MFS-147">Festerize is outdated, please upgrade to v{} (see README for instructions)</entry>
   <entry key="MFS-148">Could not read pages list value: {}</entry>
+  <entry key="MFS-149">Pages update failed: {}</entry>
+  <entry key="MFS-150">Work update failed: {}</entry>
+  <entry key="MFS-151">Work creation failed: {}</entry>
+  <entry key="MFS-152">Collection update failed: {}</entry>
 </properties>

--- a/src/main/resources/fester_messages.xml
+++ b/src/main/resources/fester_messages.xml
@@ -3,10 +3,7 @@
 <!DOCTYPE properties SYSTEM "http://java.sun.com/dtd/properties.dtd">
 
 <!--<![CDATA[
-  To process this file outside of a full build, run:
-    mvn info.freelibrary:freelib-utils:generate-codes -DmessageFiles=src/main/resources/fester_messages.xml
-  Bash shell users can run the shorter form:
-    mvn info.freelibrary:freelib-utils:generate-codes -DmessageFiles=$(find src -name *_messages.xml)
+  To process this file outside of a full build, run: mvn info.freelibrary:freelib-utils:generate-codes
 ]]>-->
 
 <properties>
@@ -135,7 +132,7 @@
   <entry key="MFS-119">Creating brief Work manifest ({}) to associate with collection manifest ({})</entry>
   <entry key="MFS-120">Sending {} CSV to {}</entry>
   <entry key="MFS-121">Page row in the CSV is missing its &quot;Parent ARK&quot; value</entry>
-  <entry key="MFS-122">Manifesting a collection ({}): {}</entry>
+  <entry key="MFS-122">Manifesting a collection: {}</entry>
   <entry key="MFS-123">Uploaded CSV's &quot;Item Sequence&quot; header could not be found</entry>
   <entry key="MFS-124">FakeS3BucketVerticle received a storage request: {}</entry>
   <entry key="MFS-125">Failed to upload collection manifest: {}</entry>
@@ -161,4 +158,5 @@
   <entry key="MFS-145">S3 key already ends with .json extension: {}</entry>
   <entry key="MFS-146">Could not find {} manifest '{}' to update</entry>
   <entry key="MFS-147">Festerize is outdated, please upgrade to v{} (see README for instructions)</entry>
+  <entry key="MFS-148">Could not read pages list value: {}</entry>
 </properties>

--- a/src/main/tools/checkstyle/checkstyle-suppressions.xml
+++ b/src/main/tools/checkstyle/checkstyle-suppressions.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!DOCTYPE suppressions PUBLIC "-//Checkstyle//DTD SuppressionFilter Configuration 1.2//EN"
+  "https://checkstyle.org/dtds/suppressions_1_2.dtd">
+
+<suppressions>
+  <suppress files="src[\\/]main[\\/]generated[\\/]" checks="."/>
+</suppressions>

--- a/src/main/tools/checkstyle/checkstyle.xml
+++ b/src/main/tools/checkstyle/checkstyle.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!DOCTYPE module PUBLIC "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+  "https://checkstyle.org/dtds/configuration_1_3.dtd">
+
+<!-- Checkstyle-Configuration: FreeLibrary Description: Checkstyle configuration for the FreeLibrary projects -->
+<module name="Checker">
+  <property name="severity" value="warning" />
+  <module name="LineLength">
+    <property name="max" value="120" />
+    <property name="fileExtensions" value="java, py, sh, txt"/>
+  </module>
+  <module name="TreeWalker">
+    <module name="RedundantImport" />
+    <module name="RedundantModifier" />
+    <module name="UnusedImports" />
+    <module name="AvoidStarImport">
+      <property name="excludes" value="j2html.TagCreator,org.junit.Assert,com.google.common.base.Preconditions"/>
+    </module>
+    <module name="ConstantName" />
+    <module name="EqualsHashCode" />
+    <module name="StringLiteralEquality" />
+    <module name="SuperClone" />
+    <module name="IllegalImport" />
+    <module name="DefaultComesLast" />
+    <module name="InnerTypeLast" />
+    <module name="UpperEll" />
+    <module name="MemberName">
+      <property name="format" value="^(my|is|has)[A-Z0-9][a-zA-Z0-9]*$" />
+    </module>
+    <!-- Below checks to make sure there are no stray main methods -->
+    <module name="UncommentedMain" />
+    <module name="UnnecessaryParentheses" />
+    <module name="DeclarationOrder" />
+    <module name="SuperFinalize" />
+    <module name="EmptyStatement" />
+    <module name="SingleSpaceSeparator" />
+    <module name="EqualsAvoidNull" />
+    <module name="FinalClass" />
+    <module name="EmptyCatchBlock">
+      <property name="exceptionVariableName" value="expected" />
+    </module>
+    <module name="BooleanExpressionComplexity">
+      <property name="max" value="4" />
+    </module>
+    <module name="JavadocType">
+      <property name="excludeScope" value="anoninner" />
+      <property name="scope" value="public" />
+      <property name="allowUnknownTags" value="true" />
+    </module>
+    <module name="JavadocMethod">
+      <property name="scope" value="public" />
+    </module>
+    <module name="NeedBraces" />
+    <module name="LeftCurly" />
+    <module name="RightCurly" />
+    <module name="WhitespaceAround">
+      <property name="tokens"
+        value="ASSIGN, BAND, BAND_ASSIGN, BOR, BOR_ASSIGN, BSR, BSR_ASSIGN, BXOR, BXOR_ASSIGN, COLON, DIV, DIV_ASSIGN, EQUAL, GE, GT, LAND, LE, LITERAL_CATCH, LITERAL_DO, LITERAL_ELSE, LITERAL_FINALLY, LITERAL_FOR, LITERAL_IF, LITERAL_RETURN, LITERAL_SYNCHRONIZED, LITERAL_TRY, LITERAL_WHILE, LOR, LT, MINUS, MINUS_ASSIGN, MOD, MOD_ASSIGN, NOT_EQUAL, PLUS, PLUS_ASSIGN, QUESTION, SL, SLIST, SL_ASSIGN, SR, SR_ASSIGN, STAR, STAR_ASSIGN, TYPE_EXTENSION_AND" />
+    </module>
+    <module name="Indentation">
+      <property name="throwsIndent" value="8" />
+    </module>
+    <module name="SuppressWarningsHolder" />
+    <module name="FinalLocalVariable" />
+    <module name="FinalParameters" />
+    <module name="GenericWhitespace" />
+    <module name="MissingDeprecated" />
+    <module name="MultipleStringLiterals">
+      <property name="allowedDuplicates" value="1" />
+    </module>
+    <module name="MissingSwitchDefault" />
+    <module name="MultipleVariableDeclarations" />
+    <module name="ParameterName">
+      <property name="format" value="^a[a-zA-Z0-9]+$" />
+    </module>
+    <module name="ModifierOrder" />
+    <module name="IllegalThrows" />
+    <module name="HideUtilityClassConstructor" />
+    <module name="MultipleVariableDeclarations" />
+    <module name="SuppressionCommentFilter">
+      <property name="offCommentFormat" value="BEGIN GENERATED CODE" />
+      <property name="onCommentFormat" value="END GENERATED CODE" />
+    </module>
+  </module>
+  <module name="SuppressionFilter">
+    <property name="file" value="src/main/tools/checkstyle/checkstyle-suppressions.xml" />
+  </module>
+  <module name="FileTabCharacter">
+    <property name="eachLine" value="true" />
+    <property name="fileExtensions" value="java,css,js,xml,xq" />
+  </module>
+  <module name="RegexpSingleline">
+    <property name="format" value="(?&lt;!\*)\s+$|\*\s\s+$" />
+    <property name="message" value="Trailing whitespace" />
+    <property name="fileExtensions" value="java,css,js,xml,html" />
+  </module>
+  <module name="SuppressWarningsFilter" />
+  <module name="NewlineAtEndOfFile">
+    <property name="fileExtensions" value="java,css,js,xml,html" />
+  </module>
+</module>

--- a/src/main/tools/pmd/pmd-rules.xml
+++ b/src/main/tools/pmd/pmd-rules.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0"?>
+<ruleset name="Custom ruleset" xmlns="http://pmd.sourceforge.net/ruleset/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 https://pmd.sourceforge.io/ruleset_2_0_0.xsd">
+
+  <description>FreeLibrary PMD Rules</description>
+
+  <exclude-pattern>.*/test/.*</exclude-pattern>
+  <exclude-pattern>.*/generated/.*</exclude-pattern>
+  <rule ref="rulesets/java/android.xml" />
+  <rule ref="rulesets/java/basic.xml">
+    <exclude name="AvoidUsingOctalValues" />
+  </rule>
+  <rule ref="rulesets/java/braces.xml" />
+  <rule ref="rulesets/java/clone.xml" />
+  <rule ref="rulesets/java/codesize.xml">
+    <exclude name="NPathComplexity" />
+    <exclude name="CyclomaticComplexity" />
+    <exclude name="StdCyclomaticComplexity" />
+    <exclude name="ModifiedCyclomaticComplexity" />
+  </rule>
+  <rule ref="rulesets/java/codesize.xml/TooManyMethods">
+    <properties>
+      <property name="maxmethods" value="15" />
+    </properties>
+  </rule>
+  <rule ref="rulesets/java/design.xml">
+    <exclude name="GodClass" />
+    <exclude name="AccessorMethodGeneration" />
+    <exclude name="AccessorClassGeneration" />
+    <exclude name="ConfusingTernary" />
+  </rule>
+  <rule ref="rulesets/java/design.xml/AvoidDeeplyNestedIfStmts">
+    <properties>
+      <property name="problemDepth" value="5" />
+    </properties>
+  </rule>
+  <rule ref="rulesets/java/empty.xml" />
+  <rule ref="rulesets/java/finalizers.xml" />
+  <rule ref="rulesets/java/imports.xml">
+    <exclude name="TooManyStaticImports" />
+  </rule>
+  <rule ref="rulesets/java/junit.xml" />
+  <rule ref="rulesets/java/migrating.xml" />
+  <rule ref="rulesets/java/naming.xml">
+    <exclude name="ShortVariable" />
+  </rule>
+  <rule ref="rulesets/java/naming.xml/ShortClassName">
+    <properties>
+      <property name="minimum" value="3" />
+    </properties>
+  </rule>
+  <rule ref="rulesets/java/naming.xml/LongVariable">
+    <properties>
+      <property name="minimum" value="25" />
+    </properties>
+  </rule>
+  <rule ref="rulesets/java/optimizations.xml">
+    <exclude name="AvoidInstantiatingObjectsInLoops" />
+  </rule>
+  <rule ref="rulesets/java/strictexception.xml" />
+  <rule ref="rulesets/java/strings.xml" />
+  <rule ref="rulesets/java/sunsecure.xml" />
+  <rule ref="rulesets/java/typeresolution.xml" />
+  <rule ref="rulesets/java/unnecessary.xml">
+    <exclude name="UselessParentheses" />
+  </rule>
+  <rule ref="rulesets/java/unusedcode.xml">
+    <exclude name="UnusedPrivateMethod" />
+  </rule>
+  <rule ref="category/java/codestyle.xml/ClassNamingConventions">
+    <properties>
+      <property name="utilityClassPattern" value="[A-Z][a-zA-Z0-9]+"/>
+    </properties>
+  </rule>
+</ruleset>

--- a/src/test/java/edu/ucla/library/iiif/fester/CsvParserTest.java
+++ b/src/test/java/edu/ucla/library/iiif/fester/CsvParserTest.java
@@ -69,7 +69,7 @@ public class CsvParserTest {
      */
     @Test
     public final void testGetCollection() throws CsvParsingException, CsvException, IOException {
-        assertNotNull(myCsvParser.parse(getTestPath(GOOD_CSV)).getCollection().get());
+        assertNotNull(myCsvParser.parse(getTestPath(GOOD_CSV)).getCsvCollection().get());
     }
 
     /**
@@ -192,7 +192,8 @@ public class CsvParserTest {
      * @throws IOException If there is trouble reading the CSV data
      */
     @Test(expected = CsvParsingException.class)
-    public final void testCollectionWorkPageCsvNoItemSequence() throws CsvParsingException, CsvException, IOException {
+    public final void testCollectionWorkPageCsvNoItemSequence() throws CsvParsingException, CsvException,
+            IOException {
         myCsvParser.parse(getTestPath("hathaway_combined_no_item_seq.csv"));
     }
 

--- a/src/test/java/edu/ucla/library/iiif/fester/fit/BaseFesterFT.java
+++ b/src/test/java/edu/ucla/library/iiif/fester/fit/BaseFesterFT.java
@@ -34,7 +34,7 @@ public class BaseFesterFT extends AbstractFesterFIT {
     private static final ContainerConfig FESTER_CONFIG = new ContainerConfig(SERVICE_NAME, SERVICE_PORT, S3);
 
     /* The application's singleton container against which we're going to run our tests */
-    private static final GenericContainer FESTER_CONTAINER = ContainerUtils.getFesterContainer(FESTER_CONFIG);
+    private static final GenericContainer<?> FESTER_CONTAINER = ContainerUtils.getFesterContainer(FESTER_CONFIG);
 
     /**
      * Sets up our testing environment.

--- a/src/test/java/edu/ucla/library/iiif/fester/fit/MissingImageFT.java
+++ b/src/test/java/edu/ucla/library/iiif/fester/fit/MissingImageFT.java
@@ -13,10 +13,10 @@ import org.junit.runner.RunWith;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
 import com.opencsv.exceptions.CsvException;
 
-import info.freelibrary.iiif.presentation.Canvas;
-import info.freelibrary.iiif.presentation.ImageResource;
-import info.freelibrary.iiif.presentation.Manifest;
-import info.freelibrary.iiif.presentation.Sequence;
+import info.freelibrary.iiif.presentation.v2.Canvas;
+import info.freelibrary.iiif.presentation.v2.ImageResource;
+import info.freelibrary.iiif.presentation.v2.Manifest;
+import info.freelibrary.iiif.presentation.v2.Sequence;
 import info.freelibrary.util.Logger;
 import info.freelibrary.util.LoggerFactory;
 

--- a/src/test/java/edu/ucla/library/iiif/fester/fit/PagesManifestFT.java
+++ b/src/test/java/edu/ucla/library/iiif/fester/fit/PagesManifestFT.java
@@ -3,16 +3,18 @@ package edu.ucla.library.iiif.fester.fit;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import com.amazonaws.services.s3.model.S3ObjectSummary;
 import com.opencsv.exceptions.CsvException;
 
-import info.freelibrary.iiif.presentation.Manifest;
+import info.freelibrary.iiif.presentation.v2.Manifest;
 import info.freelibrary.util.Logger;
 import info.freelibrary.util.LoggerFactory;
 
@@ -23,6 +25,7 @@ import io.vertx.core.Promise;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.Timeout;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.ext.web.multipart.MultipartForm;
@@ -45,6 +48,9 @@ public class PagesManifestFT extends BaseFesterFT {
         "works/ark:/21198/zz000wrh7t.json" };
 
     private static final int[] CANVAS_COUNTS = new int[] { 42, 26, 46, 39, 36 };
+
+    @Rule
+    public Timeout myTimeout = new Timeout(3, TimeUnit.MINUTES);
 
     /**
      * Sets up testing environment.

--- a/src/test/java/edu/ucla/library/iiif/fester/fit/PostCsvFIT.java
+++ b/src/test/java/edu/ucla/library/iiif/fester/fit/PostCsvFIT.java
@@ -306,7 +306,7 @@ public class PostCsvFIT {
                 if (post.succeeded()) {
                     final HttpResponse<Buffer> response = post.result();
                     final String expectedErrorMessage = LOGGER.getMessage(MessageCodes.MFS_103, LOGGER.getMessage(
-                            MessageCodes.MFS_146, "collection", HATHAWAY_COLLECTION_ARK));
+                            MessageCodes.MFS_146, Constants.COLLECTION, HATHAWAY_COLLECTION_ARK));
 
                     aContext.assertEquals(response.statusCode(), HTTP.INTERNAL_SERVER_ERROR);
                     aContext.assertEquals(response.getHeader(Constants.CONTENT_TYPE), Constants.HTML_MEDIA_TYPE);

--- a/src/test/java/edu/ucla/library/iiif/fester/fit/PostCsvFIT.java
+++ b/src/test/java/edu/ucla/library/iiif/fester/fit/PostCsvFIT.java
@@ -17,7 +17,7 @@ import com.amazonaws.services.s3.model.S3ObjectSummary;
 import com.opencsv.CSVReader;
 import com.opencsv.exceptions.CsvException;
 
-import info.freelibrary.iiif.presentation.Collection;
+import info.freelibrary.iiif.presentation.v2.Collection;
 import info.freelibrary.util.Logger;
 import info.freelibrary.util.LoggerFactory;
 
@@ -28,7 +28,7 @@ import edu.ucla.library.iiif.fester.MessageCodes;
 import edu.ucla.library.iiif.fester.utils.IDUtils;
 import edu.ucla.library.iiif.fester.utils.LinkUtils;
 import edu.ucla.library.iiif.fester.utils.LinkUtilsTest;
-import edu.ucla.library.iiif.fester.utils.ManifestLabelComparator;
+import edu.ucla.library.iiif.fester.utils.V2ManifestLabelComparator;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 import io.vertx.core.buffer.Buffer;
@@ -63,7 +63,8 @@ public class PostCsvFIT {
 
     private static final File EOL_CHECK_CSV = new File(DIR, "csv/eolcheck.csv");
 
-    private static final File WORKS_CSV_PROTESTA_1 = new File(DIR, "csv/lat_newspapers/protesta/protesta_works_1.csv");
+    private static final File WORKS_CSV_PROTESTA_1 = new File(DIR,
+            "csv/lat_newspapers/protesta/protesta_works_1.csv");
 
     private static final File PROTESTA_COLLECTION_MANIFEST = new File(DIR, "json/ark%3A%2F21198%2Fzz0025hqmb.json");
 
@@ -357,7 +358,8 @@ public class PostCsvFIT {
                             final Long timerDelay = 500L;
 
                             VERTX_INSTANCE.setTimer(timerDelay, timerId -> {
-                                final boolean isDeleted = !VERTX_INSTANCE.fileSystem().existsBlocking(uploadedFilePath);
+                                final boolean isDeleted = !VERTX_INSTANCE.fileSystem().existsBlocking(
+                                        uploadedFilePath);
                                 try {
                                     aContext.assertTrue(isDeleted);
                                 } catch (final AssertionError details) {
@@ -417,10 +419,13 @@ public class PostCsvFIT {
                                 if (getStatusCode == HTTP.OK) {
                                     final JsonObject json = get.result().bodyAsJsonObject();
                                     final List<Collection.Manifest> works = Collection.fromJSON(json).getManifests();
-                                    final ManifestLabelComparator comparator = new ManifestLabelComparator();
+                                    final V2ManifestLabelComparator comparator = new V2ManifestLabelComparator();
 
-                                    for (int i = 0; i < works.size() - 1; i++) {
-                                        aContext.assertTrue(comparator.compare(works.get(i), works.get(i + 1)) < 0);
+                                    for (int index = 0; index < works.size() - 1; index++) {
+                                        final Collection.Manifest work1 = works.get(index);
+                                        final Collection.Manifest work2 = works.get(index + 1);
+
+                                        aContext.assertTrue(comparator.compare(work1, work2) < 0);
                                     }
 
                                     complete(asyncTask);
@@ -512,8 +517,8 @@ public class PostCsvFIT {
                     aTestFile.getAbsolutePath(), Constants.CSV_MEDIA_TYPE).attribute(Constants.IIIF_HOST,
                             ImageInfoLookup.FAKE_IIIF_SERVER);
 
-            myWebClient.post(FESTER_PORT, Constants.UNSPECIFIED_HOST, Constants.POST_CSV_ROUTE).sendMultipartForm(form,
-                    aHandler);
+            myWebClient.post(FESTER_PORT, Constants.UNSPECIFIED_HOST, Constants.POST_CSV_ROUTE).sendMultipartForm(
+                    form, aHandler);
         }
     }
 }

--- a/src/test/java/edu/ucla/library/iiif/fester/utils/TestUtils.java
+++ b/src/test/java/edu/ucla/library/iiif/fester/utils/TestUtils.java
@@ -10,8 +10,6 @@ import io.vertx.core.Vertx;
  */
 public final class TestUtils {
 
-    private static final String JSON_EXT = ".json";
-
     private TestUtils() {
     }
 

--- a/src/test/java/edu/ucla/library/iiif/fester/verticles/FakeS3BucketVerticle.java
+++ b/src/test/java/edu/ucla/library/iiif/fester/verticles/FakeS3BucketVerticle.java
@@ -60,30 +60,30 @@ public class FakeS3BucketVerticle extends AbstractFesterVerticle {
                 new File("src/test/resources/json/ark%3A%2F21198%2Fz12f8rtw.json"));
 
         vertx.eventBus().<JsonObject>consumer(S3BucketVerticle.class.getName()).handler(message -> {
-            final JsonObject msg = message.body();
+            final JsonObject body = message.body();
             final String manifestID;
             final JsonObject manifest;
             final String action = message.headers().get(Constants.ACTION);
 
             switch (action) {
                 case Op.GET_MANIFEST:
-                    manifestID = msg.getString(Constants.MANIFEST_ID);
+                    manifestID = body.getString(Constants.MANIFEST_ID);
                     LOGGER.debug(MessageCodes.MFS_127, manifestID);
                     get(IDUtils.getWorkS3Key(manifestID), message);
                     break;
                 case Op.PUT_MANIFEST:
-                    manifestID = msg.getString(Constants.MANIFEST_ID);
-                    manifest = msg.getJsonObject(Constants.DATA);
+                    manifestID = body.getString(Constants.MANIFEST_ID);
+                    manifest = body.getJsonObject(Constants.DATA);
                     put(IDUtils.getWorkS3Key(manifestID), manifest, message);
                     break;
                 case Op.GET_COLLECTION:
-                    manifestID = msg.getString(Constants.COLLECTION_NAME);
+                    manifestID = body.getString(Constants.COLLECTION_NAME);
                     LOGGER.debug(MessageCodes.MFS_127, manifestID);
                     get(IDUtils.getCollectionS3Key(manifestID), message);
                     break;
                 case Op.PUT_COLLECTION:
-                    manifestID = msg.getString(Constants.COLLECTION_NAME);
-                    manifest = msg.getJsonObject(Constants.DATA);
+                    manifestID = body.getString(Constants.COLLECTION_NAME);
+                    manifest = body.getJsonObject(Constants.DATA);
                     put(IDUtils.getCollectionS3Key(manifestID), manifest, message);
                     break;
                 default:


### PR DESCRIPTION
* Add CODEOWNERS file
* Update dependencies and parent project
* Make CsvHeaders (de)serializable
* Remove the jiiify-presentation v2 classes and related logic from ManifestVerticle
* Create a V2ManifestVerticle and move v2 classes and the logic specific to them to it
* Move ManifestLabelComparator to V2ManifestLabelComparator
* Create stub V3ManifestVerticle and V3ManifestLabelComparator
* Update a couple of deprecated Future(s) to Promise(s)
* Update a few descriptive/stylistic things (variable names, etc.)