### PR TITLE
[IIIF-953] Fix v2 verticle so it adds works to collection

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,9 +84,9 @@
 
     <!-- Versions of tools used for testing -->
     <jsoup.version>1.13.1</jsoup.version>
-    <aws.sdk.version>1.11.813</aws.sdk.version>
-    <localstack.version>1.13.0</localstack.version>
-    <testcontainers.version>1.12.5</testcontainers.version>
+    <aws.sdk.version>1.11.850</aws.sdk.version>
+    <localstack.version>1.14.3</localstack.version>
+    <testcontainers.version>1.14.3</testcontainers.version>
     <jcip.annotations.version>1.0-1</jcip.annotations.version>
 
     <!-- Build plug-in versions -->
@@ -549,13 +549,6 @@
         </executions>
       </plugin>
 
-      <!-- Codacy runs automated code reviews and code analytics -->
-      <plugin>
-        <groupId>com.gavinmogan</groupId>
-        <artifactId>codacy-maven-plugin</artifactId>
-        <version>${codacy.plugin.version}</version>
-      </plugin>
-
       <!-- Maven dependency helps freelib-resources copy files into the project -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -804,6 +797,7 @@
                   <exclude>com.fasterxml.jackson.datatype:jackson-datatype-jdk8</exclude>
                   <exclude>com.fasterxml.jackson.datatype:jackson-datatype-jsr310</exclude>
                   <exclude>com.github.dblock:oshi-core</exclude>
+                  <exclude>com.github.dpaukov:combinatoricslib3</exclude>
                   <exclude>com.github.fge:btf</exclude>
                   <exclude>com.github.fge:jackson-coreutils</exclude>
                   <exclude>com.github.fge:json-patch</exclude>
@@ -811,6 +805,7 @@
                   <exclude>com.github.fge:uri-template</exclude>
                   <exclude>com.github.java-json-tools:json-schema-core</exclude>
                   <exclude>com.github.java-json-tools:json-schema-validator</exclude>
+                  <exclude>com.github.tkurz:media-fragments-uri</exclude>
                   <exclude>com.google.code.findbugs:jsr305</exclude>
                   <exclude>com.google.errorprone:error_prone_annotations</exclude>
                   <exclude>com.google.guava:failureaccess</exclude>
@@ -828,7 +823,8 @@
                   <exclude>commons-io:commons-io</exclude>
                   <exclude>commons-logging:commons-logging</exclude>
                   <exclude>info.freelibrary:freelib-utils</exclude>
-                  <exclude>info.freelibrary:jiiify-presentation</exclude>
+                  <exclude>info.freelibrary:jiiify-presentation-v2</exclude>
+                  <exclude>info.freelibrary:jiiify-presentation-v3</exclude>
                   <exclude>info.freelibrary:vertx-pairtree</exclude>
                   <exclude>info.freelibrary:vertx-super-s3</exclude>
                   <exclude>io.netty:netty-buffer</exclude>

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -9,7 +9,7 @@ LABEL ContainerName=${project.name} ContainerSourceCode=${project.url}
 RUN apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get install -qq --no-install-recommends \
     openjdk-11-jre-headless=11.0.7+10-3ubuntu1 \
     python3=3.8.2-0ubuntu2 \
-    curl=7.68.0-1ubuntu2.1 \
+    curl=7.68.0-1ubuntu2.2 \
     < /dev/null > /dev/null && \
     rm -rf /var/lib/apt/lists/*
 

--- a/src/main/java/edu/ucla/library/iiif/fester/Constants.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/Constants.java
@@ -27,8 +27,8 @@ public final class Constants {
     public static final String ACTION = "action";
 
     /**
-     * The message body key associated with the Fester operation input data (HTTP request body) that caused the
-     * message send.
+     * The message body key associated with the Fester operation input data (HTTP request body) that caused the message
+     * send.
      */
     public static final String DATA = "data";
 
@@ -46,6 +46,11 @@ public final class Constants {
      * The content-type header key.
      */
     public static final String CONTENT_TYPE = "content-type";
+
+    /**
+     * The content-disposition of the reponse.
+     */
+    public static final String CONTENT_DISPOSITION = "Content-Disposition";
 
     /**
      * The media type for JSON (the format of IIIF manifests).
@@ -128,8 +133,8 @@ public final class Constants {
     public static final String NO_REWRITE_URLS = "no-rewrite-urls";
 
     /**
-     * A unique random placeholder URL that prefixes all IIIF Presentation API resource URLs in all manifests at rest
-     * in S3. It gets replaced with Constants.URL on each GET request.
+     * A unique random placeholder URL that prefixes all IIIF Presentation API resource URLs in all manifests at rest in
+     * S3. It gets replaced with Constants.URL on each GET request.
      */
     public static final String URL_PLACEHOLDER = "http://b1dbe4a0-443c-479f-bf0a-25c352df0d8f.iiif.library.ucla.edu";
 

--- a/src/main/java/edu/ucla/library/iiif/fester/handlers/PostCsvHandler.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/handlers/PostCsvHandler.java
@@ -25,6 +25,7 @@ import edu.ucla.library.iiif.fester.MessageCodes;
 import edu.ucla.library.iiif.fester.Op;
 import edu.ucla.library.iiif.fester.utils.LinkUtils;
 import edu.ucla.library.iiif.fester.verticles.ManifestVerticle;
+
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.eventbus.DeliveryOptions;
@@ -42,6 +43,8 @@ import io.vertx.ext.web.RoutingContext;
 public class PostCsvHandler extends AbstractFesterHandler {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(PostCsvHandler.class, Constants.MESSAGES);
+
+    private static final String ATTACHMENT = "attachment; filename=\"{}\"";
 
     private static final String BR_TAG = "<br>";
 
@@ -88,8 +91,8 @@ public class PostCsvHandler extends AbstractFesterHandler {
             response.setStatusMessage(errorMessage);
             response.putHeader(Constants.CONTENT_TYPE, Constants.HTML_MEDIA_TYPE);
             response.end(StringUtils.format(myExceptionPage, errorMessage));
-        } else if (festerizeUserAgentMatcher.matches() && !festerizeUserAgentMatcher.group("version").equals(
-                myFesterizeVersion)) { // Festerize version mismatch
+        } else if (festerizeUserAgentMatcher.matches() &&
+                !festerizeUserAgentMatcher.group("version").equals(myFesterizeVersion)) { // Festerize version mismatch
             errorMessage = LOGGER.getMessage(MessageCodes.MFS_147, myFesterizeVersion);
 
             response.setStatusCode(HTTP.BAD_REQUEST);
@@ -147,6 +150,7 @@ public class PostCsvHandler extends AbstractFesterHandler {
                     aResponse.setStatusCode(HTTP.CREATED);
                     aResponse.setStatusMessage(responseMessage);
                     aResponse.putHeader(Constants.CONTENT_TYPE, Constants.CSV_MEDIA_TYPE);
+                    aResponse.putHeader(Constants.CONTENT_DISPOSITION, StringUtils.format(ATTACHMENT, aFileName));
                     aResponse.end(Buffer.buffer(writer.toString()));
                 } catch (final IOException details) {
                     returnError(aResponse, HTTP.INTERNAL_SERVER_ERROR, details);

--- a/src/main/java/edu/ucla/library/iiif/fester/verticles/ManifestVerticle.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/verticles/ManifestVerticle.java
@@ -30,6 +30,7 @@ import edu.ucla.library.iiif.fester.LockedManifest;
 import edu.ucla.library.iiif.fester.ManifestNotFoundException;
 import edu.ucla.library.iiif.fester.MessageCodes;
 import edu.ucla.library.iiif.fester.Op;
+
 import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
@@ -256,7 +257,7 @@ public class ManifestVerticle extends AbstractFesterVerticle {
 
                         lockedManifest.release();
                     });
-                } catch (JsonProcessingException details) {
+                } catch (final JsonProcessingException details) {
                     lockedManifest.release();
                     aPromise.fail(details);
                 }
@@ -387,8 +388,8 @@ public class ManifestVerticle extends AbstractFesterVerticle {
             if (lockRequest.succeeded()) {
                 try {
                     final JsonObject message = new JsonObject();
-                    final DeliveryOptions options = new DeliveryOptions().addHeader(Constants.NO_REWRITE_URLS,
-                            Boolean.TRUE.toString());
+                    final DeliveryOptions options =
+                            new DeliveryOptions().addHeader(Constants.NO_REWRITE_URLS, Boolean.TRUE.toString());
 
                     if (aCollDoc) {
                         message.put(Constants.COLLECTION_NAME, aID);

--- a/src/main/resources/fester_messages.xml
+++ b/src/main/resources/fester_messages.xml
@@ -164,4 +164,5 @@
   <entry key="MFS-151">Work creation failed: {}</entry>
   <entry key="MFS-152">Collection update failed: {}</entry>
   <entry key="MFS-153">Unexpected manifest action: {}</entry>
+  <entry key="MFS-154">Failed to find expected S3 object for '{}'</entry>
 </properties>

--- a/src/test/java/edu/ucla/library/iiif/fester/fit/BaseFesterFT.java
+++ b/src/test/java/edu/ucla/library/iiif/fester/fit/BaseFesterFT.java
@@ -56,7 +56,7 @@ public class BaseFesterFT extends AbstractFesterFIT {
         s3ClientBuilder.withEndpointConfiguration(endpoint).withCredentials(s3Credentials);
         s3ClientBuilder.withClientConfiguration(new ClientConfiguration().withProtocol(Protocol.HTTP));
 
-        myS3Client = s3ClientBuilder.build();
+        myS3Client = s3ClientBuilder.withPathStyleAccessEnabled(true).build();
     }
 
 }

--- a/src/test/java/edu/ucla/library/iiif/fester/fit/PagesManifestFT.java
+++ b/src/test/java/edu/ucla/library/iiif/fester/fit/PagesManifestFT.java
@@ -14,13 +14,15 @@ import org.junit.runner.RunWith;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
 import com.opencsv.exceptions.CsvException;
 
-import info.freelibrary.iiif.presentation.v2.Manifest;
 import info.freelibrary.util.Logger;
 import info.freelibrary.util.LoggerFactory;
+
+import info.freelibrary.iiif.presentation.v2.Manifest;
 
 import edu.ucla.library.iiif.fester.Constants;
 import edu.ucla.library.iiif.fester.HTTP;
 import edu.ucla.library.iiif.fester.MessageCodes;
+
 import io.vertx.core.Promise;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.ext.unit.Async;
@@ -50,7 +52,7 @@ public class PagesManifestFT extends BaseFesterFT {
     private static final int[] CANVAS_COUNTS = new int[] { 42, 26, 46, 39, 36 };
 
     @Rule
-    public Timeout myTimeout = new Timeout(3, TimeUnit.MINUTES);
+    public Timeout myTimeout = new Timeout(5, TimeUnit.MINUTES);
 
     /**
      * Sets up testing environment.
@@ -79,10 +81,10 @@ public class PagesManifestFT extends BaseFesterFT {
     }
 
     /**
-     * Tests that pages have been added to works manifests. Several things have to happen in sequential order before
-     * we can check the results of the test: the collection CSV must be loaded, the works CSV must be loaded, and
-     * finally the pages CSV must be loaded. After this has all happened, we can check the canvas counts in each of
-     * the work manifests to confirm all the pages were loaded.
+     * Tests that pages have been added to works manifests. Several things have to happen in sequential order before we
+     * can check the results of the test: the collection CSV must be loaded, the works CSV must be loaded, and finally
+     * the pages CSV must be loaded. After this has all happened, we can check the canvas counts in each of the work
+     * manifests to confirm all the pages were loaded.
      *
      * @param aContext A testing context
      * @throws CsvException If there is trouble parsing the CSV test fixtures

--- a/src/test/resources/json/ark%3A%2F21198%2Fzz0009gsq9.json
+++ b/src/test/resources/json/ark%3A%2F21198%2Fzz0009gsq9.json
@@ -1,23 +1,38 @@
 {
-  "@context" : "http://iiif.io/api/presentation/2/context.json",
-  "label" : "Hathaway Manuscripts",
-  "@id" : "http://b1dbe4a0-443c-479f-bf0a-25c352df0d8f.iiif.library.ucla.edu/collections/ark%3A%2F21198%2Fzz0009gsq9",
-  "@type" : "sc:Collection",
-  "manifests" : [ {
-    "@type" : "sc:Manifest",
-    "@id" : "http://b1dbe4a0-443c-479f-bf0a-25c352df0d8f.iiif.library.ucla.edu/ark%3A%2F21198%2Fzz0009gv8j/manifest",
-    "label" : "Hathaway 1"
-  }, {
-    "@type" : "sc:Manifest",
-    "@id" : "http://b1dbe4a0-443c-479f-bf0a-25c352df0d8f.iiif.library.ucla.edu/ark%3A%2F21198%2Fzz000bjdtv/manifest",
-    "label" : "Hathaway 2"
-  }, {
-    "@type" : "sc:Manifest",
-    "@id" : "http://b1dbe4a0-443c-479f-bf0a-25c352df0d8f.iiif.library.ucla.edu/ark%3A%2F21198%2Fzz000bjfhp/manifest",
-    "label" : "Hathaway 3"
-  }, {
-    "@type" : "sc:Manifest",
-    "@id" : "http://b1dbe4a0-443c-479f-bf0a-25c352df0d8f.iiif.library.ucla.edu/ark%3A%2F21198%2Fzz000bjfj6/manifest",
-    "label" : "Hathaway 4"
-  } ]
+    "@context": "http://iiif.io/api/presentation/2/context.json",
+    "label": "Hathaway Manuscripts",
+    "@id": "http://b1dbe4a0-443c-479f-bf0a-25c352df0d8f.iiif.library.ucla.edu/collections/ark%3A%2F21198%2Fzz0009gsq9",
+    "@type": "sc:Collection",
+    "metadata": [
+        {
+            "label": "Repository",
+            "value": "University of California, Los Angeles. Library. Performing Arts Special Collections"
+        },
+        {
+            "label": "Rights contact",
+            "value": "UCLA Charles E. Young Research Library Department of Special Collections, A1713 Young Research Library, Box 951575, Los Angeles, CA 90095-1575. E-mail: spec-coll@library.ucla.edu. Phone: (310)825-4988"
+        }
+    ],
+    "manifests": [
+        {
+            "@type": "sc:Manifest",
+            "@id": "http://b1dbe4a0-443c-479f-bf0a-25c352df0d8f.iiif.library.ucla.edu/ark%3A%2F21198%2Fzz0009gv8j/manifest",
+            "label": "Hathaway 1"
+        },
+        {
+            "@type": "sc:Manifest",
+            "@id": "http://b1dbe4a0-443c-479f-bf0a-25c352df0d8f.iiif.library.ucla.edu/ark%3A%2F21198%2Fzz000bjdtv/manifest",
+            "label": "Hathaway 2"
+        },
+        {
+            "@type": "sc:Manifest",
+            "@id": "http://b1dbe4a0-443c-479f-bf0a-25c352df0d8f.iiif.library.ucla.edu/ark%3A%2F21198%2Fzz000bjfhp/manifest",
+            "label": "Hathaway 3"
+        },
+        {
+            "@type": "sc:Manifest",
+            "@id": "http://b1dbe4a0-443c-479f-bf0a-25c352df0d8f.iiif.library.ucla.edu/ark%3A%2F21198%2Fzz000bjfj6/manifest",
+            "label": "Hathaway 4"
+        }
+    ]
 }


### PR DESCRIPTION
* Update some POM dependencies to fix an S3 test problem.
* Update obsolete curl version in the Dockerfile.
* Remove obsolete codacy plugin config (this has been done on main already but this branch needs it removed too in order to pass the Codacy check).
* Add some exclusions to the shade plugin config to remove warning messages.
* Add content-disposition to PostCsvHandler's response so downloaded file has the same name as the uploaded file.
* Fix v2 manifest creator so that it creates manifest references in the collection (this information was being sent to the v2 manifest verticle, but I neglected to do anything with it when creating the manifest).
* Extended the timeout on one of the tests since my new laptop is slower than the last and sometimes times out (side comment: we really need to update the way image height/width is found).
* Updated test to check the newly created collection manifest put into S3 (in addition to checking the CSV output, which is all the test previously checked).
* Eclipse made some formatting changes and I made a few, too, manually to adjust to new styling changes.