### PR TITLE
0.13.0 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
 
 services: docker
 
-# We want all PRs built but only merges on master branch
+# We want all PRs built but only merges on master branch and tags under semantic version scheme
 branches:
   only:
   - main
+  - /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/
 
 jobs:
   include:

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ This will prepare the code for release by making two commits to Git and tagging 
 
 Note that Git won't allow creating a tag with the same name as an existing branch (so, for example, the name `0.13.0` couldn't be used as the branch name).
 
-A new pull request should then be created on the main branch to update the version in the POM. The PR should be merged using the `Merge pull request` option that creates a merge commit so that the tagged commit ends up in the main branch.
+A new pull request should then be created on the main branch to update the version in the POM. The PR should be merged using the `Create a merge commit` option so that the tagged commit ends up in the main branch.
 
 ## Festerize
 

--- a/README.md
+++ b/README.md
@@ -188,13 +188,15 @@ Releases follow semantic versioning, with the exception that we don't consider a
 
 To create a new release, update the `version` element in the POM file (if needed). The updated version should still end with `-SNAPSHOT`, just change the numeric designation.
 
-After the version in the POM file is ready, the following script can be run:
+After the version in the POM file is ready, the following script should be run on a new branch dedicated to the release (e.g., `0.13.0-release`):
 
     src/main/tools/travis/prepare_release
 
-This will prepare the code for release by making two commits to Git. The first will be one for the version to be released (minus the snapshot designation), and the second will be one for a new snapshot version.
+This will prepare the code for release by making two commits to Git and tagging one of them. The first will be one for the version to be released (minus the snapshot designation) and will be tagged with the version number, and the second will be one for a new snapshot version. When the tag pointing to a non-snapshot commit is pushed, a Docker image with that tag will be uploaded to the Docker registry if the Travis build succeeds.
 
-The actual release will be done by the Travis build. When a non-snapshot version is built by Travis, a Docker image will be uploaded to the Docker registry.
+Note that Git won't allow creating a tag with the same name as an existing branch (so, for example, the name `0.13.0` couldn't be used as the branch name).
+
+A new pull request should then be created on the main branch to update the version in the POM. The PR should be merged using the `Merge pull request` option that creates a merge commit so that the tagged commit ends up in the main branch.
 
 ## Festerize
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>fester</artifactId>
-  <version>0.13.1-SNAPSHOT</version>
+  <version>0.13.0</version>
   <name>Fester</name>
   <description>A read/write interface for storing and retrieving IIIF manifests</description>
   <url>https://github.com/uclalibrary/fester</url>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>fester</artifactId>
-  <version>0.13.0</version>
+  <version>0.13.1-SNAPSHOT</version>
   <name>Fester</name>
   <description>A read/write interface for storing and retrieving IIIF manifests</description>
   <url>https://github.com/uclalibrary/fester</url>


### PR DESCRIPTION
Changes:
- update rules for triggering Travis builds that push the versioned Docker images that correspond to our releases to the image registry
- update README to explain process