### PR TITLE
[IIIF-988] Fix thumbnail variable name

### DIFF
--- a/src/main/java/edu/ucla/library/iiif/fester/Constants.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/Constants.java
@@ -239,14 +239,14 @@ public final class Constants {
     public static final String IIIF_API_V3 = "v3";
 
     /**
-     * The string template of default thumbnail URIs.
+     * The string template of default sample URIs.
      */
-    public static final String THUMBNAIL_URI_TEMPLATE = "{}/full/{},/0/default.jpg";
+    public static final String SAMPLE_URI_TEMPLATE = "{}/full/{},/0/default.jpg";
 
     /**
-     * The default size of thumbnails.
+     * The default size of sample images.
      */
-    public static final int DEFAULT_THUMBNAIL_SIZE = 600;
+    public static final int DEFAULT_SAMPLE_SIZE = 600;
 
     /**
      * The id property of a v2 IIIF resource.

--- a/src/main/java/edu/ucla/library/iiif/fester/verticles/V2ManifestVerticle.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/verticles/V2ManifestVerticle.java
@@ -380,8 +380,8 @@ public class V2ManifestVerticle extends AbstractFesterVerticle {
             final String pageURI = StringUtils.format(SIMPLE_URI, aImageHost, encodedPageID);
             final String contentURI = StringUtils.format(ANNOTATION_URI, Constants.URL_PLACEHOLDER, aWorkID, idPart);
 
-            String resourceURI = StringUtils.format(Constants.THUMBNAIL_URI_TEMPLATE, pageURI,
-                    Constants.DEFAULT_THUMBNAIL_SIZE);
+            String resourceURI = StringUtils.format(Constants.SAMPLE_URI_TEMPLATE, pageURI,
+                    Constants.DEFAULT_SAMPLE_SIZE);
             ImageResource imageResource = new ImageResource(resourceURI,
                     new ImageInfoService(APIComplianceLevel.TWO, pageURI));
             ImageContent imageContent;
@@ -407,14 +407,14 @@ public class V2ManifestVerticle extends AbstractFesterVerticle {
                         final int height = placeholderLookup.getHeight();
                         final int size;
 
-                        if (width >= Constants.DEFAULT_THUMBNAIL_SIZE) {
-                            size = Constants.DEFAULT_THUMBNAIL_SIZE;
+                        if (width >= Constants.DEFAULT_SAMPLE_SIZE) {
+                            size = Constants.DEFAULT_SAMPLE_SIZE;
                         } else {
                             size = width;
                         }
 
                         // If placeholder image found, use its URL for image resource and service
-                        resourceURI = StringUtils.format(Constants.THUMBNAIL_URI_TEMPLATE, aPlaceholderImage, size);
+                        resourceURI = StringUtils.format(Constants.SAMPLE_URI_TEMPLATE, aPlaceholderImage, size);
                         imageResource = new ImageResource(resourceURI,
                                 new ImageInfoService(APIComplianceLevel.TWO, aPlaceholderImage));
 

--- a/src/main/java/edu/ucla/library/iiif/fester/verticles/V3ManifestVerticle.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/verticles/V3ManifestVerticle.java
@@ -350,8 +350,8 @@ public class V3ManifestVerticle extends AbstractFesterVerticle {
             final String encodedPageID = URLEncoder.encode(pageID, StandardCharsets.UTF_8);
             final String pageURI = StringUtils.format(SIMPLE_URI, aImageHost, encodedPageID);
 
-            String resourceURI = StringUtils.format(Constants.THUMBNAIL_URI_TEMPLATE, pageURI,
-                    Constants.DEFAULT_THUMBNAIL_SIZE);
+            String resourceURI = StringUtils.format(Constants.SAMPLE_URI_TEMPLATE, pageURI,
+                    Constants.DEFAULT_SAMPLE_SIZE);
             Canvas canvas;
             ImageContent image;
 
@@ -375,14 +375,14 @@ public class V3ManifestVerticle extends AbstractFesterVerticle {
                         final int height = placeholderLookup.getHeight();
                         final int size;
 
-                        if (width >= Constants.DEFAULT_THUMBNAIL_SIZE) {
-                            size = Constants.DEFAULT_THUMBNAIL_SIZE;
+                        if (width >= Constants.DEFAULT_SAMPLE_SIZE) {
+                            size = Constants.DEFAULT_SAMPLE_SIZE;
                         } else {
                             size = width;
                         }
 
                         // If placeholder image found, use its URL for image resource and service
-                        resourceURI = StringUtils.format(Constants.THUMBNAIL_URI_TEMPLATE, aPlaceholderImage, size);
+                        resourceURI = StringUtils.format(Constants.SAMPLE_URI_TEMPLATE, aPlaceholderImage, size);
 
                         // Create a canvas using the width and height of the placeholder image
                         canvas = new Canvas(aMinter, pageLabel);

--- a/src/test/java/edu/ucla/library/iiif/fester/fit/MissingImageFT.java
+++ b/src/test/java/edu/ucla/library/iiif/fester/fit/MissingImageFT.java
@@ -48,7 +48,7 @@ public class MissingImageFT extends BaseFesterFT {
 
     private static final String PLACEHOLDER_URL = "https://iiif.library.ucla.edu/iiif/2/blank";
 
-    private static final String PLACEHOLDER_THUMBNAIL_URL = PLACEHOLDER_URL + "/full/293,/0/default.jpg";
+    private static final String PLACEHOLDER_SAMPLE_URL = PLACEHOLDER_URL + "/full/293,/0/default.jpg";
 
     /**
      * Sets up testing environment.
@@ -167,7 +167,7 @@ public class MissingImageFT extends BaseFesterFT {
 
         // Check that we have the right page and that it's image resource URL is set to our placeholder
         aContext.assertEquals("cover page", coverPage.getLabel().getString());
-        aContext.assertEquals(PLACEHOLDER_THUMBNAIL_URL, image.getID().toString());
+        aContext.assertEquals(PLACEHOLDER_SAMPLE_URL, image.getID().toString());
         aContext.assertEquals(PLACEHOLDER_URL, image.getService().get().getID().toString());
 
         if (!aAsyncTask.isCompleted()) {


### PR DESCRIPTION
Updates: 
* Changed "THUMBNAIL" variable names and comments in Constants.java
* Updated V2ManifestVerticle.java to use new constant names
* Updated V3ManifestVerticle.java to use new constant names
* Updated MissingImageFT.java to remove "THUMBNAIL" names
FWIW: IIIF-988 references updating method names, but I didn't see any that used thumbnail or variations thereof.