### PR TITLE
[IIIF-1029] Bump Festerize version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -145,7 +145,7 @@
     <fester.http.port>8888</fester.http.port>
 
     <!-- The version of Festerize that is compatible with this version of Fester -->
-    <festerize.version>0.1.0</festerize.version>
+    <festerize.version>0.2.0</festerize.version>
 
     <!-- The port a debugger may attach to when Fester is running in debug mode -->
     <fester.debug.port>5555</fester.debug.port>


### PR DESCRIPTION
The next release of Festerize will be 0.2.0, which will add the capability of requesting updates to only the metadata of a manifest.