### PR TITLE
[IIIF-1099] Add version check profile

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,3 +43,4 @@ jobs:
           maven_profiles: default,${{ secrets.BUILD_PROFILES }}
           maven_args: >
             -V -ntp -Dorg.slf4j.simpleLogger.log.net.sourceforge.pmd=error ${{ secrets.BUILD_PROPERTIES }}
+            -DlogLevel=DEBUG -DtestLogLevel=DEBUG

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,6 +58,7 @@ jobs:
           maven_args: >
             -Drevision=${{ github.event.release.tag_name }} -DautoReleaseAfterClose=${{ env.AUTORELEASE_ARTIFACT }}
             -ntp -Dorg.slf4j.simpleLogger.log.net.sourceforge.pmd=error ${{ secrets.BUILD_PROPERTIES }}
+            -DlogLevel=DEBUG -DtestLogLevel=DEBUG
             -DskipNexusStagingDeployMojo=${{ env.SKIP_JAR_DEPLOYMENT }}
             -Ddocker.registry.username=${{ secrets.DOCKER_USERNAME }}
             -Ddocker.registry.account=${{ secrets.DOCKER_REGISTRY_ACCOUNT}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,8 +50,6 @@ jobs:
       - name: Release with Maven
         uses: samuelmeuli/action-maven-publish@201a45a3f311b2ee888f252ba9f4194257545709 # v1.4.0
         with:
-          gpg_private_key: ${{ secrets.BUILD_KEY }}
-          gpg_passphrase: ${{ secrets.BUILD_PASSPHRASE }}
           nexus_username: ${{ secrets.SONATYPE_USERNAME }}
           nexus_password: ${{ secrets.SONATYPE_PASSWORD }}
           maven_profiles: release,${{ secrets.BUILD_PROFILES }}

--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,6 @@ buildNumber.properties
 .editorconfig
 .checkstyle
 src/main/tools/eclipse
-src/main/tools/travis
 src/main/generated
 logback-test.xml
 .flattened-pom.xml

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# Fester &nbsp;[![Build Status](https://api.travis-ci.com/uclalibrary/fester.svg?branch=main)](https://travis-ci.com/uclalibrary/fester) [![Codacy Badge](https://app.codacy.com/project/badge/Grade/990b5c316e0a45d092c83d58f148e0e8)](https://www.codacy.com/gh/UCLALibrary/fester?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=UCLALibrary/fester&amp;utm_campaign=Badge_Grade) [![Codacy Badge](https://app.codacy.com/project/badge/Coverage/990b5c316e0a45d092c83d58f148e0e8)](https://www.codacy.com/gh/UCLALibrary/fester?utm_source=github.com&utm_medium=referral&utm_content=UCLALibrary/fester&utm_campaign=Badge_Coverage) [![Known Vulnerabilities](https://snyk.io/test/github/uclalibrary/fester/badge.svg)](https://snyk.io/test/github/uclalibrary/fester)
+# Fester
+[![Maven Build](https://github.com/uclalibrary/fester/workflows/Maven%20Build/badge.svg)](https://github.com/UCLALibrary/fester/actions) [![Codacy Badge](https://app.codacy.com/project/badge/Grade/990b5c316e0a45d092c83d58f148e0e8)](https://www.codacy.com/gh/UCLALibrary/fester?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=UCLALibrary/fester&amp;utm_campaign=Badge_Grade) [![Codacy Badge](https://app.codacy.com/project/badge/Coverage/990b5c316e0a45d092c83d58f148e0e8)](https://www.codacy.com/gh/UCLALibrary/fester?utm_source=github.com&utm_medium=referral&utm_content=UCLALibrary/fester&utm_campaign=Badge_Coverage) [![Known Vulnerabilities](https://snyk.io/test/github/uclalibrary/fester/badge.svg)](https://snyk.io/test/github/uclalibrary/fester)
 
 A microservice for facilitating the creation, storage, and retrieval of IIIF manifests and collections.
 
@@ -50,9 +51,9 @@ When running the build using the 'package' phase (as described above), only the 
 
 or
 
-    mvn install
+    mvn verify
 
-This will run the functional, feature flag, and integration tests, in addition to the unit tests. If you want to skip a particular type of test but still run the 'install' phase, you can use one of the following arguments to your Maven command:
+This will run the functional, feature flag, and integration tests, in addition to the unit tests. If you want to skip a particular type of test but still run the 'verify' phase, you can use one of the following arguments to your Maven command:
 
     -DskipUTs
     -DskipITs
@@ -61,9 +62,7 @@ This will run the functional, feature flag, and integration tests, in addition t
 
 The first will skip the unit tests; the second will skip the integration tests; the third will skip the functional tests; and, the fourth will skip the feature flag tests. They can also be combined so that two types of tests are skipped. For instance, only the functional tests will be run if the following is typed:
 
-    mvn install -DskipUTs -DskipITs
-
-For what it's worth, the difference between the 'install' phase and the 'integration-test' phase is just that the install phase installs the built Jar file into your machine's local Maven repository.
+    mvn verify -DskipUTs -DskipITs
 
 When running the integration and functional tests, it may be desirable to turn on logging for the containers that run the tests. This can be useful in debugging test failures that happen within the container. To do this, supply one (or any) of the following arguments to your build:
 
@@ -186,9 +185,17 @@ For example, if you wish to run a Locust test against a dev instance on your own
 
 ## Git Hooks
 
-To prevent accidentally pushing commits that would cause the Travis CI build to fail, you can configure your Git client to use a pre-push hook:
+To prevent accidentally pushing commits that would cause the CI build to fail, you can configure your Git client to use a pre-push hook:
 
     ln -s ../../src/test/scripts/git-hooks/pre-push .git/hooks
+
+## Working with Pinned OS Packages
+
+We pin the versions of packages that we install into our base image. What this means is that periodically a pinned version will become obsolete and the build will break. We have a nightly build that should catch this issues for us, but in the case that you find the breakage before us, there is a handy way to tell which pinned version has broken the build. To see the current versions inside the base image, run:
+
+    mvn validate -Dversions
+
+This will output a list of current versions, which can be compared to the pinned versions defined in the project's POM file (i.e., pom.xml).
 
 ## Festerize
 

--- a/pom.xml
+++ b/pom.xml
@@ -96,8 +96,7 @@
     <!-- Versions of tools used for testing -->
     <jsoup.version>1.13.1</jsoup.version>
     <aws.sdk.version>1.11.950</aws.sdk.version>
-    <localstack.version>1.14.3</localstack.version>
-    <testcontainers.version>1.14.3</testcontainers.version>
+    <testcontainers.version>1.15.1</testcontainers.version>
     <jcip.annotations.version>1.0-1</jcip.annotations.version>
 
     <!-- Build plug-in versions -->
@@ -171,6 +170,18 @@
     <docker.registry.account />
   </properties>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.testcontainers</groupId>
+        <artifactId>testcontainers-bom</artifactId>
+        <version>${testcontainers.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
 
     <!-- Vert.x is a toolkit for building reactive applications on the JVM -->
@@ -226,6 +237,7 @@
         </exclusion>
       </exclusions>
     </dependency>
+
     <!-- Below is a dependency that needs updating due to security issue (may be able to remove in future) -->
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -318,13 +330,11 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>testcontainers</artifactId>
-      <version>${testcontainers.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>localstack</artifactId>
-      <version>${localstack.version}</version>
       <scope>test</scope>
     </dependency>
     <!-- Allows us to suppress warnings from the AWS SDK (see https://github.com/aws/aws-sdk-java/issues/1707) -->

--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,13 @@
   </developers>
 
   <properties>
+    <!-- Docker image dependencies -->
+    <ubuntu.tag>20.04</ubuntu.tag>
+    <jdk.version>11.0.10+9-0ubuntu1~20.04</jdk.version>
+    <python3.version>3.8.2-0ubuntu2</python3.version>
+    <curl.version>7.68.0-1ubuntu2.4</curl.version>
+
+    <!-- Application dependencies -->
     <vertx.version>3.9.4</vertx.version>
     <opencsv.version>5.0</opencsv.version>
     <moirai.version>2.0.0</moirai.version>
@@ -341,6 +348,7 @@
         <directory>src/test/resources</directory>
         <filtering>true</filtering>
       </testResource>
+
       <!-- We can also override the default logging configuration with a file in our root project directory -->
       <testResource>
         <directory>${basedir}</directory>
@@ -361,6 +369,7 @@
           </compilerArgs>
         </configuration>
       </plugin>
+
       <!-- Disable standard deploy; we publish a Docker image, not Jar file -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -370,58 +379,7 @@
           <skip>true</skip>
         </configuration>
       </plugin>
-      <!-- A Maven plugin that can build a Docker image with our application -->
-      <plugin>
-        <groupId>io.fabric8</groupId>
-        <artifactId>docker-maven-plugin</artifactId>
-        <version>${docker.maven.plugin.version}</version>
-        <configuration>
-          <images>
-            <image>
-              <!-- Registry account, if supplied, must end in a slash (e.g. "account/") -->
-              <name>${docker.registry.account}${project.artifactId}:%l</name>
-              <build>
-                <dockerFile>${project.basedir}/src/main/docker/Dockerfile</dockerFile>
-                <assembly>
-                  <inline>
-                    <fileSets>
-                      <fileSet>
-                        <!-- The directory where we can find our Maven-built artifact -->
-                        <directory>${project.basedir}/target/build-artifact</directory>
-                        <!-- We don't want directory structure on output, just the artifact -->
-                        <outputDirectory>.</outputDirectory>
-                        <includes>
-                          <include>${project.artifactId}-${project.version}.jar</include>
-                        </includes>
-                      </fileSet>
-                    </fileSets>
-                  </inline>
-                </assembly>
-              </build>
-            </image>
-          </images>
-          <authConfig>
-            <username>${docker.registry.username}</username>
-            <password>${docker.registry.password}</password>
-          </authConfig>
-        </configuration>
-        <executions>
-          <execution>
-            <id>docker-build</id>
-            <phase>pre-integration-test</phase>
-            <goals>
-              <goal>build</goal>
-            </goals>
-          </execution>
-          <execution>
-            <id>docker-deploy</id>
-            <phase>deploy</phase>
-            <goals>
-              <goal>push</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
+
       <!-- Makes sure TestContainers doesn't leave unused networks around -->
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
@@ -445,11 +403,13 @@
           </execution>
         </executions>
       </plugin>
+
       <!-- The build-helper plug-in gets us a dynamic port for testing -->
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
       </plugin>
+
       <!--<![CDATA[
         To run the generate-codes plugin outside of a full build, run:
          mvn info.freelibrary:freelib-utils:generate-codes -DmessageFiles=src/main/resources/fester_messages.xml
@@ -574,146 +534,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
-      </plugin>
-
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <includes>
-            <include>**/*Test.java</include>
-          </includes>
-          <excludes>
-            <exclude>**/*FT.java</exclude>
-            <exclude>**/*IT.java</exclude>
-            <exclude>**/*FfT.java</exclude>
-          </excludes>
-          <systemPropertyVariables>
-            <vertx.logger-delegate-factory-class-name>io.vertx.core.logging.SLF4JLogDelegateFactory</vertx.logger-delegate-factory-class-name>
-            <fester.url>${fester.url}</fester.url>
-            <fester.http.port>${http.port}</fester.http.port>
-            <vertx-config-path>${project.basedir}/target/test-classes/test-config.properties</vertx-config-path>
-          </systemPropertyVariables>
-          <argLine>${jacoco.agent.arg}</argLine>
-          <skipTests>${skipUTs}</skipTests>
-          <forkCount>1</forkCount><!-- Multiple forks result in multiple containers -->
-        </configuration>
-        <executions>
-          <execution>
-            <id>feature-flags-off</id>
-            <phase>integration-test</phase>
-            <goals>
-              <goal>test</goal>
-            </goals>
-            <configuration>
-              <includes>
-                <include>**/*FfOffT.java</include>
-              </includes>
-              <excludes>
-                <exclude>**/*Test.java</exclude>
-                <exclude>**/*IT.java</exclude>
-                <exclude>**/*FT.java</exclude>
-                <exclude>**/*FfOnT.java</exclude>
-              </excludes>
-              <argLine>${jacoco.agent.arg}</argLine>
-              <skipTests>${skipFfTs}</skipTests>
-              <systemPropertyVariables>
-                <fester.logs.output>${seeLogsFfT}</fester.logs.output>
-                <fester.s3.bucket>${fester.s3.bucket}</fester.s3.bucket>
-                <fester.container.tag>${project.artifactId}:${project.version}</fester.container.tag>
-                <feature.flags>https://iiif-manifest-store.s3.amazonaws.com/fester-features-off.conf</feature.flags>
-                <jdwp.host.port>${jdwp.host.port}</jdwp.host.port>
-                <jdwp.client.config>${jdwp.client.config}</jdwp.client.config>
-              </systemPropertyVariables>
-            </configuration>
-          </execution>
-          <execution>
-            <id>feature-flags-on</id>
-            <phase>integration-test</phase>
-            <goals>
-              <goal>test</goal>
-            </goals>
-            <configuration>
-              <includes>
-                <include>**/*FfOnT.java</include>
-              </includes>
-              <excludes>
-                <exclude>**/*Test.java</exclude>
-                <exclude>**/*IT.java</exclude>
-                <exclude>**/*FT.java</exclude>
-                <exclude>**/*FfOffT.java</exclude>
-              </excludes>
-              <argLine>${jacoco.agent.arg}</argLine>
-              <skipTests>${skipFfTs}</skipTests>
-              <systemPropertyVariables>
-                <fester.logs.output>${seeLogsFfT}</fester.logs.output>
-                <fester.s3.bucket>${fester.s3.bucket}</fester.s3.bucket>
-                <fester.container.tag>${project.artifactId}:${project.version}</fester.container.tag>
-                <feature.flags>https://iiif-manifest-store.s3.amazonaws.com/fester-features-on.conf</feature.flags>
-                <jdwp.host.port>${jdwp.host.port}</jdwp.host.port>
-                <jdwp.client.config>${jdwp.client.config}</jdwp.client.config>
-              </systemPropertyVariables>
-            </configuration>
-          </execution>
-          <execution>
-            <id>functional-tests</id>
-            <phase>integration-test</phase>
-            <goals>
-              <goal>test</goal>
-            </goals>
-            <configuration>
-              <includes>
-                <include>**/*FT.java</include>
-              </includes>
-              <excludes>
-                <exclude>**/*Test.java</exclude>
-                <exclude>**/*IT.java</exclude>
-                <exclude>**/*FfT.java</exclude>
-              </excludes>
-              <argLine>${jacoco.agent.arg}</argLine>
-              <skipTests>${skipFTs}</skipTests>
-              <systemPropertyVariables>
-                <fester.logs.output>${seeLogsFT}</fester.logs.output>
-                <fester.s3.bucket>${fester.s3.bucket}</fester.s3.bucket>
-                <fester.placeholder.url>${fester.placeholder.url}</fester.placeholder.url>
-                <fester.container.tag>${docker.registry.account}${project.artifactId}:${project.version}</fester.container.tag>
-                <festerize.version>${festerize.version}</festerize.version>
-                <jdwp.host.port>${jdwp.host.port}</jdwp.host.port>
-                <jdwp.client.config>${jdwp.client.config}</jdwp.client.config>
-              </systemPropertyVariables>
-            </configuration>
-          </execution>
-          <execution>
-            <id>integration-tests</id>
-            <phase>integration-test</phase>
-            <goals>
-              <goal>test</goal>
-            </goals>
-            <configuration>
-              <includes>
-                <include>**/*IT.java</include>
-              </includes>
-              <excludes>
-                <exclude>**/*FT.java</exclude>
-                <exclude>**/*Test.java</exclude>
-                <exclude>**/*FfT.java</exclude>
-              </excludes>
-              <argLine>${jacoco.agent.arg}</argLine>
-              <skipTests>${skipITs}</skipTests>
-              <systemPropertyVariables>
-                <fester.logs.output>${seeLogsIT}</fester.logs.output>
-                <fester.s3.region>${fester.s3.region}</fester.s3.region>
-                <fester.s3.bucket>${fester.s3.bucket}</fester.s3.bucket>
-                <fester.s3.access_key>${fester.s3.access_key}</fester.s3.access_key>
-                <fester.s3.secret_key>${fester.s3.secret_key}</fester.s3.secret_key>
-                <fester.s3.endpoint>${fester.s3.endpoint}</fester.s3.endpoint>
-                <fester.container.tag>${docker.registry.account}${project.artifactId}:${project.version}</fester.container.tag>
-                <jdwp.host.port>${jdwp.host.port}</jdwp.host.port>
-                <jdwp.client.config>${jdwp.client.config}</jdwp.client.config>
-              </systemPropertyVariables>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
 
       <!-- The Vert.x plug-in enables running the application from within Maven for development -->
@@ -973,6 +793,7 @@
         </dependency>
       </dependencies>
     </profile>
+
     <profile>
       <id>debug</id>
       <properties>
@@ -980,6 +801,7 @@
         <jdwp.client.config>-agentlib:jdwp=transport=dt_socket,address=host.testcontainers.internal:${jdwp.host.port},suspend=n</jdwp.client.config>
       </properties>
     </profile>
+
     <profile>
       <id>runDebug</id>
       <properties>
@@ -1038,6 +860,7 @@
               </execution>
             </executions>
           </plugin>
+
           <plugin>
             <groupId>io.reactiverse</groupId>
             <artifactId>vertx-maven-plugin</artifactId>
@@ -1063,6 +886,7 @@
         </plugins>
       </build>
     </profile>
+
     <profile>
       <id>live</id>
       <properties>
@@ -1121,6 +945,7 @@
               </execution>
             </executions>
           </plugin>
+
           <plugin>
             <groupId>io.reactiverse</groupId>
             <artifactId>vertx-maven-plugin</artifactId>
@@ -1146,6 +971,7 @@
         </plugins>
       </build>
     </profile>
+
     <profile>
       <id>fluency</id>
       <properties>
@@ -1182,6 +1008,263 @@
           <version>${logback.more.appenders.version}</version>
         </dependency>
       </dependencies>
+    </profile>
+
+    <profile>
+      <id>default</id>
+      <activation>
+        <property>
+          <name>!versions</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <!-- A Maven plugin that can build a Docker image with our application -->
+          <plugin>
+            <groupId>io.fabric8</groupId>
+            <artifactId>docker-maven-plugin</artifactId>
+            <version>${docker.maven.plugin.version}</version>
+            <configuration>
+              <images>
+                <image>
+                  <!-- Registry account, if supplied, must end in a slash (e.g. "account/") -->
+                  <name>${docker.registry.account}${project.artifactId}:%l</name>
+                  <build>
+                    <dockerFile>${project.basedir}/src/main/docker/Dockerfile</dockerFile>
+                    <assembly>
+                      <inline>
+                        <fileSets>
+                          <fileSet>
+                            <!-- The directory where we can find our Maven-built artifact -->
+                            <directory>${project.basedir}/target/build-artifact</directory>
+                            <!-- We don't want directory structure on output, just the artifact -->
+                            <outputDirectory>.</outputDirectory>
+                            <includes>
+                              <include>${project.artifactId}-${project.version}.jar</include>
+                            </includes>
+                          </fileSet>
+                        </fileSets>
+                      </inline>
+                    </assembly>
+                  </build>
+                </image>
+              </images>
+              <authConfig>
+                <username>${docker.registry.username}</username>
+                <password>${docker.registry.password}</password>
+              </authConfig>
+            </configuration>
+            <executions>
+              <execution>
+                <id>docker-build</id>
+                <phase>pre-integration-test</phase>
+                <goals>
+                  <goal>build</goal>
+                </goals>
+              </execution>
+              <execution>
+                <id>docker-deploy</id>
+                <phase>deploy</phase>
+                <goals>
+                  <goal>push</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <includes>
+                <include>**/*Test.java</include>
+              </includes>
+              <excludes>
+                <exclude>**/*FT.java</exclude>
+                <exclude>**/*IT.java</exclude>
+                <exclude>**/*FfT.java</exclude>
+              </excludes>
+              <systemPropertyVariables>
+                <vertx.logger-delegate-factory-class-name>io.vertx.core.logging.SLF4JLogDelegateFactory</vertx.logger-delegate-factory-class-name>
+                <fester.url>${fester.url}</fester.url>
+                <fester.http.port>${http.port}</fester.http.port>
+                <vertx-config-path>${project.basedir}/target/test-classes/test-config.properties</vertx-config-path>
+              </systemPropertyVariables>
+              <argLine>${jacoco.agent.arg}</argLine>
+              <skipTests>${skipUTs}</skipTests>
+              <forkCount>1</forkCount><!-- Multiple forks result in multiple containers -->
+            </configuration>
+            <executions>
+              <execution>
+                <id>feature-flags-off</id>
+                <phase>integration-test</phase>
+                <goals>
+                  <goal>test</goal>
+                </goals>
+                <configuration>
+                  <includes>
+                    <include>**/*FfOffT.java</include>
+                  </includes>
+                  <excludes>
+                    <exclude>**/*Test.java</exclude>
+                    <exclude>**/*IT.java</exclude>
+                    <exclude>**/*FT.java</exclude>
+                    <exclude>**/*FfOnT.java</exclude>
+                  </excludes>
+                  <argLine>${jacoco.agent.arg}</argLine>
+                  <skipTests>${skipFfTs}</skipTests>
+                  <systemPropertyVariables>
+                    <fester.logs.output>${seeLogsFfT}</fester.logs.output>
+                    <fester.s3.bucket>${fester.s3.bucket}</fester.s3.bucket>
+                    <fester.container.tag>${project.artifactId}:${project.version}</fester.container.tag>
+                    <feature.flags>https://iiif-manifest-store.s3.amazonaws.com/fester-features-off.conf</feature.flags>
+                    <jdwp.host.port>${jdwp.host.port}</jdwp.host.port>
+                    <jdwp.client.config>${jdwp.client.config}</jdwp.client.config>
+                  </systemPropertyVariables>
+                </configuration>
+              </execution>
+              <execution>
+                <id>feature-flags-on</id>
+                <phase>integration-test</phase>
+                <goals>
+                  <goal>test</goal>
+                </goals>
+                <configuration>
+                  <includes>
+                    <include>**/*FfOnT.java</include>
+                  </includes>
+                  <excludes>
+                    <exclude>**/*Test.java</exclude>
+                    <exclude>**/*IT.java</exclude>
+                    <exclude>**/*FT.java</exclude>
+                    <exclude>**/*FfOffT.java</exclude>
+                  </excludes>
+                  <argLine>${jacoco.agent.arg}</argLine>
+                  <skipTests>${skipFfTs}</skipTests>
+                  <systemPropertyVariables>
+                    <fester.logs.output>${seeLogsFfT}</fester.logs.output>
+                    <fester.s3.bucket>${fester.s3.bucket}</fester.s3.bucket>
+                    <fester.container.tag>${project.artifactId}:${project.version}</fester.container.tag>
+                    <feature.flags>https://iiif-manifest-store.s3.amazonaws.com/fester-features-on.conf</feature.flags>
+                    <jdwp.host.port>${jdwp.host.port}</jdwp.host.port>
+                    <jdwp.client.config>${jdwp.client.config}</jdwp.client.config>
+                  </systemPropertyVariables>
+                </configuration>
+              </execution>
+              <execution>
+                <id>functional-tests</id>
+                <phase>integration-test</phase>
+                <goals>
+                  <goal>test</goal>
+                </goals>
+                <configuration>
+                  <includes>
+                    <include>**/*FT.java</include>
+                  </includes>
+                  <excludes>
+                    <exclude>**/*Test.java</exclude>
+                    <exclude>**/*IT.java</exclude>
+                    <exclude>**/*FfT.java</exclude>
+                  </excludes>
+                  <argLine>${jacoco.agent.arg}</argLine>
+                  <skipTests>${skipFTs}</skipTests>
+                  <systemPropertyVariables>
+                    <fester.logs.output>${seeLogsFT}</fester.logs.output>
+                    <fester.s3.bucket>${fester.s3.bucket}</fester.s3.bucket>
+                    <fester.placeholder.url>${fester.placeholder.url}</fester.placeholder.url>
+                    <fester.container.tag>${docker.registry.account}${project.artifactId}:${project.version}</fester.container.tag>
+                    <festerize.version>${festerize.version}</festerize.version>
+                    <jdwp.host.port>${jdwp.host.port}</jdwp.host.port>
+                    <jdwp.client.config>${jdwp.client.config}</jdwp.client.config>
+                  </systemPropertyVariables>
+                </configuration>
+              </execution>
+              <execution>
+                <id>integration-tests</id>
+                <phase>integration-test</phase>
+                <goals>
+                  <goal>test</goal>
+                </goals>
+                <configuration>
+                  <includes>
+                    <include>**/*IT.java</include>
+                  </includes>
+                  <excludes>
+                    <exclude>**/*FT.java</exclude>
+                    <exclude>**/*Test.java</exclude>
+                    <exclude>**/*FfT.java</exclude>
+                  </excludes>
+                  <argLine>${jacoco.agent.arg}</argLine>
+                  <skipTests>${skipITs}</skipTests>
+                  <systemPropertyVariables>
+                    <fester.logs.output>${seeLogsIT}</fester.logs.output>
+                    <fester.s3.region>${fester.s3.region}</fester.s3.region>
+                    <fester.s3.bucket>${fester.s3.bucket}</fester.s3.bucket>
+                    <fester.s3.access_key>${fester.s3.access_key}</fester.s3.access_key>
+                    <fester.s3.secret_key>${fester.s3.secret_key}</fester.s3.secret_key>
+                    <fester.s3.endpoint>${fester.s3.endpoint}</fester.s3.endpoint>
+                    <fester.container.tag>${docker.registry.account}${project.artifactId}:${project.version}</fester.container.tag>
+                    <jdwp.host.port>${jdwp.host.port}</jdwp.host.port>
+                    <jdwp.client.config>${jdwp.client.config}</jdwp.client.config>
+                  </systemPropertyVariables>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <!-- A profile that outputs the latest versions of the installed system dependencies -->
+    <profile>
+      <id>versions</id>
+      <activation>
+        <property>
+          <name>versions</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>io.fabric8</groupId>
+            <artifactId>docker-maven-plugin</artifactId>
+            <version>${docker.maven.plugin.version}</version>
+            <configuration>
+              <logStdout>true</logStdout>
+              <verbose>true</verbose>
+              <images>
+                <image>
+                  <name>ubuntu-versions:latest</name>
+                  <build>
+                    <from>ubuntu:${ubuntu.tag}</from>
+                    <assembly>
+                      <descriptorRef>project</descriptorRef>
+                    </assembly>
+                    <runCmds>
+                      <shell>/maven/src/main/docker/scripts/show_versions.sh</shell>
+                    </runCmds>
+                    <entryPoint>tail -f /dev/null</entryPoint>
+                  </build>
+                </image>
+              </images>
+              <authConfig>
+                <username>${docker.registry.username}</username>
+                <password>${docker.registry.password}</password>
+              </authConfig>
+            </configuration>
+            <executions>
+
+              <!-- Builds the Docker image -->
+              <execution>
+                <id>docker-build</id>
+                <phase>validate</phase>
+                <goals>
+                  <goal>build</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
   </profiles>
 

--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
 
     <!-- Versions of tools used for testing -->
     <jsoup.version>1.13.1</jsoup.version>
-    <aws.sdk.version>1.11.850</aws.sdk.version>
+    <aws.sdk.version>1.11.950</aws.sdk.version>
     <localstack.version>1.14.3</localstack.version>
     <testcontainers.version>1.14.3</testcontainers.version>
     <jcip.annotations.version>1.0-1</jcip.annotations.version>

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM ubuntu:20.04
+FROM ubuntu:${ubuntu.tag}
 
 # Store some project metadata in the Docker image
 LABEL ContainerName=${project.name} ContainerSourceCode=${project.url}
@@ -7,9 +7,9 @@ LABEL ContainerName=${project.name} ContainerSourceCode=${project.url}
 # Update packages and install tools
 #  Removing /var/lib/apt/lists/* prevents using `apt` unless you do `apt update` first
 RUN apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get install -qq --no-install-recommends \
-    openjdk-11-jre-headless=11.0.9.1+1-0ubuntu1~20.04 \
-    python3=3.8.2-0ubuntu2 \
-    curl=7.68.0-1ubuntu2.4 \
+    openjdk-11-jre-headless=${jdk.version} \
+    python3=${python3.version} \
+    curl=${curl.version} \
     < /dev/null > /dev/null && \
     rm -rf /var/lib/apt/lists/*
 

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -7,9 +7,9 @@ LABEL ContainerName=${project.name} ContainerSourceCode=${project.url}
 # Update packages and install tools
 #  Removing /var/lib/apt/lists/* prevents using `apt` unless you do `apt update` first
 RUN apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get install -qq --no-install-recommends \
-    openjdk-11-jre-headless=${jdk.version} \
-    python3=${python3.version} \
-    curl=${curl.version} \
+    openjdk-11-jre-headless="${jdk.version}" \
+    python3="${python3.version}" \
+    curl="${curl.version}" \
     < /dev/null > /dev/null && \
     rm -rf /var/lib/apt/lists/*
 

--- a/src/main/docker/scripts/show_versions.sh
+++ b/src/main/docker/scripts/show_versions.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+#
+# A simple script to print the versions of required system packages.
+#
+
+print_version() {
+  VERSION="$(apt show $1 2>/dev/null | grep Version)"
+  echo "$1 ${VERSION#Version: }"
+}
+
+print_line() {
+  printf "$(head -c 80 /dev/zero | tr '\0' '*')\n"
+}
+
+declare -a DEPENDENCIES=(
+  "openjdk-11-jre-headless"
+  "python3"
+  "curl"
+)
+
+print_line
+echo "               System dependency versions"
+print_line
+
+# Refresh packages so we can query them
+apt update > /dev/null 2>&1
+DEBIAN_FRONTEND=noninteractive apt -y upgrade > /dev/null 2>&1
+
+for DEPENDENCY in "${DEPENDENCIES[@]}" ; do
+  print_version $DEPENDENCY
+done
+
+print_line

--- a/src/test/java/edu/ucla/library/iiif/fester/fit/BatchIngestFfOnT.java
+++ b/src/test/java/edu/ucla/library/iiif/fester/fit/BatchIngestFfOnT.java
@@ -3,6 +3,7 @@ package edu.ucla.library.iiif.fester.fit;
 
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Element;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -12,8 +13,10 @@ import info.freelibrary.util.LoggerFactory;
 import edu.ucla.library.iiif.fester.Constants;
 import edu.ucla.library.iiif.fester.HTTP;
 import edu.ucla.library.iiif.fester.MessageCodes;
+
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.Timeout;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 
 /**
@@ -24,6 +27,10 @@ public class BatchIngestFfOnT extends BaseFesterFfT {
 
     /* Our feature flag test logger */
     private static final Logger LOGGER = LoggerFactory.getLogger(BatchIngestFfOnT.class, Constants.MESSAGES);
+
+    /* Slower systems may have trouble finishing within the default timeout */
+    @Rule
+    public final Timeout myTimeoutRule = Timeout.seconds(600);
 
     /**
      * Tests that the POST collections endpoint returns a 201 on success.
@@ -38,8 +45,8 @@ public class BatchIngestFfOnT extends BaseFesterFfT {
         // Create our bucket so we have some place to put the manifests
         myS3Client.createBucket(BUCKET);
 
-        myWebClient.post(FESTER_PORT, Constants.UNSPECIFIED_HOST, Constants.POST_CSV_ROUTE).sendMultipartForm(
-                CSV_UPLOAD_FORM, request -> {
+        myWebClient.post(FESTER_PORT, Constants.UNSPECIFIED_HOST, Constants.POST_CSV_ROUTE)
+                .sendMultipartForm(CSV_UPLOAD_FORM, request -> {
                     if (request.succeeded()) {
                         // Check that we get a 201 response code
                         aContext.assertEquals(HTTP.CREATED, request.result().statusCode());

--- a/src/test/java/edu/ucla/library/iiif/fester/fit/BatchIngestFfOnT.java
+++ b/src/test/java/edu/ucla/library/iiif/fester/fit/BatchIngestFfOnT.java
@@ -3,7 +3,6 @@ package edu.ucla.library.iiif.fester.fit;
 
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Element;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -16,7 +15,6 @@ import edu.ucla.library.iiif.fester.MessageCodes;
 
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
-import io.vertx.ext.unit.junit.Timeout;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 
 /**
@@ -28,17 +26,12 @@ public class BatchIngestFfOnT extends BaseFesterFfT {
     /* Our feature flag test logger */
     private static final Logger LOGGER = LoggerFactory.getLogger(BatchIngestFfOnT.class, Constants.MESSAGES);
 
-    /* Slower systems may have trouble finishing within the default timeout */
-    @Rule
-    public final Timeout myTimeoutRule = Timeout.seconds(600);
-
     /**
      * Tests that the POST collections endpoint returns a 201 on success.
      *
      * @param aContext A testing context
      */
     @Test
-    @SuppressWarnings("checkstyle:indentation") // Checkstyle doesn't handle lambda indentations well
     public final void testCsvPostEndpoint(final TestContext aContext) {
         final Async asyncTask = aContext.async();
 

--- a/src/test/java/edu/ucla/library/iiif/fester/fit/PagesManifestFT.java
+++ b/src/test/java/edu/ucla/library/iiif/fester/fit/PagesManifestFT.java
@@ -3,7 +3,6 @@ package edu.ucla.library.iiif.fester.fit;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.concurrent.TimeUnit;
 
 import org.junit.After;
 import org.junit.Before;
@@ -56,7 +55,7 @@ public class PagesManifestFT extends BaseFesterFT {
 
     /* Slower systems may have trouble finishing within the default timeout */
     @Rule
-    public Timeout myTimeout = new Timeout(5, TimeUnit.MINUTES);
+    public Timeout myTimeout = Timeout.seconds(600);
 
     /**
      * Sets up testing environment.

--- a/src/test/java/edu/ucla/library/iiif/fester/utils/ContainerUtils.java
+++ b/src/test/java/edu/ucla/library/iiif/fester/utils/ContainerUtils.java
@@ -13,6 +13,7 @@ import org.testcontainers.containers.Network;
 import org.testcontainers.containers.localstack.LocalStackContainer;
 import org.testcontainers.containers.localstack.LocalStackContainer.Service;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.utility.DockerImageName;
 
 import info.freelibrary.util.LoggerFactory;
 import info.freelibrary.util.StringUtils;
@@ -82,7 +83,8 @@ public final class ContainerUtils {
      * @return A local S3-compatible container
      */
     public static LocalStackContainer getS3Container() {
-        final LocalStackContainer s3Container = new LocalStackContainer();
+        final DockerImageName localstackImage = DockerImageName.parse("localstack/localstack");
+        final LocalStackContainer s3Container = new LocalStackContainer(localstackImage);
 
         s3Container.withServices(Service.S3).withNetwork(NETWORK).withNetworkAliases(S3_ALIAS).start();
 

--- a/src/test/scripts/git-hooks/pre-push
+++ b/src/test/scripts/git-hooks/pre-push
@@ -2,11 +2,11 @@
 
 # Prevent pushes that would cause the CI build to fail.
 
-mvn clean install
+mvn clean verify
 
 if [ $? -ne 0 ]
 then
-    echo >&2 "\nThe build command 'mvn clean install' failed, not pushing"
+    echo >&2 "\nThe build command 'mvn clean verify' failed, not pushing"
     exit 1
 fi
 

--- a/src/test/scripts/git-hooks/pre-push
+++ b/src/test/scripts/git-hooks/pre-push
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# Prevent pushes that would cause the Travis CI build to fail.
+# Prevent pushes that would cause the CI build to fail.
 
 mvn clean install
 


### PR DESCRIPTION
* Add a build profile (and script) for checking Docker image package versions
* Update obsolete image package versions and application dependency versions
* Changed 'install's in README to 'verify's (which makes more sense since we're not installing to a local Maven repo)
* Parameterized versions in Dockerfile
* Extended timeouts on some of the longer running tests
* Remove stray Travis references