### PR TITLE
[IIIF-1107] Fix GPG key installation in release build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,13 +34,15 @@ jobs:
         if: ${{ env.MAVEN_CACHE_KEY }}
         with:
           path: ~/.m2
-          key: freelibrary-cache-${{ secrets.MAVEN_CACHE_KEY }}-${{ hashFiles('**/pom.xml') }}
-          restore-keys: freelibrary-cache-${{ secrets.MAVEN_CACHE_KEY }}-
+          key: uclalibrary-cache-${{ secrets.MAVEN_CACHE_KEY }}-${{ hashFiles('**/pom.xml') }}
+          restore-keys: uclalibrary-cache-${{ secrets.MAVEN_CACHE_KEY }}-
       - name: Build with Maven
         uses: samuelmeuli/action-maven-publish@201a45a3f311b2ee888f252ba9f4194257545709 # v1.4.0
         with:
           maven_goals_phases: "clean verify"
-          maven_profiles: default,${{ secrets.BUILD_PROFILES }}
+          maven_profiles: default
           maven_args: >
-            -V -ntp -Dorg.slf4j.simpleLogger.log.net.sourceforge.pmd=error ${{ secrets.BUILD_PROPERTIES }}
-            -DlogLevel=DEBUG -DtestLogLevel=DEBUG
+            -V -ntp -Dorg.slf4j.simpleLogger.log.net.sourceforge.pmd=error -DlogLevel=DEBUG -DtestLogLevel=DEBUG
+            -Dfester.s3.access_key="${{ secrets.AWS_ACCESS_KEY }}"
+            -Dfester.s3.secret_key="${{ secrets.AWS_SECRET_KEY }}"
+            -Dfester.s3.bucket="${{ secrets.S3_BUCKET }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,6 @@ jobs:
     name: Maven Artifact Publisher (JDK 11)
     runs-on: ubuntu-latest
     env:
-      AUTORELEASE_ARTIFACT: ${{ secrets.AUTORELEASE_ARTIFACT }}
       SKIP_JAR_DEPLOYMENT: ${{ secrets.SKIP_JAR_DEPLOYMENT }}
       MAVEN_CACHE_KEY: ${{ secrets.MAVEN_CACHE_KEY }}
     steps:
@@ -31,11 +30,8 @@ jobs:
         if: ${{ env.MAVEN_CACHE_KEY }}
         with:
           path: ~/.m2
-          key: freelibrary-cache-${{ secrets.MAVEN_CACHE_KEY }}-${{ hashFiles('**/pom.xml') }}
-          restore-keys: freelibrary-cache-${{ secrets.MAVEN_CACHE_KEY }}-
-      - name: Set autorelease config
-        if: env.AUTORELEASE_ARTIFACT == null
-        run: echo "AUTORELEASE_ARTIFACT=false" >> $GITHUB_ENV
+          key: uclalibrary-cache-${{ secrets.MAVEN_CACHE_KEY }}-${{ hashFiles('**/pom.xml') }}
+          restore-keys: uclalibrary-cache-${{ secrets.MAVEN_CACHE_KEY }}-
       - name: Set Jar deployment config
         if: env.SKIP_JAR_DEPLOYMENT == null
         run: echo "SKIP_JAR_DEPLOYMENT=false" >> $GITHUB_ENV
@@ -50,14 +46,18 @@ jobs:
       - name: Release with Maven
         uses: samuelmeuli/action-maven-publish@201a45a3f311b2ee888f252ba9f4194257545709 # v1.4.0
         with:
+          gpg_private_key: ${{ secrets.BUILD_KEY }}
+          gpg_passphrase: ${{ secrets.BUILD_PASSPHRASE }}
           nexus_username: ${{ secrets.SONATYPE_USERNAME }}
           nexus_password: ${{ secrets.SONATYPE_PASSWORD }}
-          maven_profiles: release,${{ secrets.BUILD_PROFILES }}
+          maven_profiles: release
           maven_args: >
-            -Drevision=${{ github.event.release.tag_name }} -DautoReleaseAfterClose=${{ env.AUTORELEASE_ARTIFACT }}
-            -ntp -Dorg.slf4j.simpleLogger.log.net.sourceforge.pmd=error ${{ secrets.BUILD_PROPERTIES }}
-            -DlogLevel=DEBUG -DtestLogLevel=DEBUG
-            -DskipNexusStagingDeployMojo=${{ env.SKIP_JAR_DEPLOYMENT }}
-            -Ddocker.registry.username=${{ secrets.DOCKER_USERNAME }}
-            -Ddocker.registry.account=${{ secrets.DOCKER_REGISTRY_ACCOUNT}}
-            -Ddocker.registry.password=${{ secrets.DOCKER_PASSWORD }}
+            -Drevision=${{ github.event.release.tag_name }}
+            -ntp -Dorg.slf4j.simpleLogger.log.net.sourceforge.pmd=error -DlogLevel=DEBUG -DtestLogLevel=DEBUG
+            -DskipNexusStagingDeployMojo="${{ env.SKIP_JAR_DEPLOYMENT }}"
+            -Ddocker.registry.username="${{ secrets.DOCKER_USERNAME }}"
+            -Ddocker.registry.account="${{ secrets.DOCKER_REGISTRY_ACCOUNT}}"
+            -Ddocker.registry.password="${{ secrets.DOCKER_PASSWORD }}"
+            -Dfester.s3.access_key="${{ secrets.AWS_ACCESS_KEY }}"
+            -Dfester.s3.secret_key="${{ secrets.AWS_SECRET_KEY }}"
+            -Dfester.s3.bucket="${{ secrets.S3_BUCKET }}"


### PR DESCRIPTION
The main thing this commit does is add the following to the release build:
* gpg_private_key
* gpg_passphrase

I also added these values as secrets in the GitHub project.

I took the opportunity though to also clean up the release.yml a bit, giving
up on the hope of a generic release.yml that would work for all projects (at
least for now).

This also meant moving parameters from the ${BUILD_PROPERTIES}
to individual parameters in the release.yml's Maven Action config. The
functionality is the same, but perhaps it's clearer broken out.