### PR TITLE
[IIIF-1143] Update A/V URL Code

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -152,7 +152,7 @@
     <fester.http.port>8888</fester.http.port>
 
     <!-- String that should be present in A/V access URLs -->
-    <fester.av.string>pairtree</fester.av.string>
+    <fester.av.string>https://wowza.library.ucla.edu/iiif_av_public/</fester.av.string>
 
     <!-- The version of Festerize that is compatible with this version of Fester -->
     <festerize.version>0.2.0</festerize.version>

--- a/pom.xml
+++ b/pom.xml
@@ -151,6 +151,9 @@
     <!-- The port Fester listens on -->
     <fester.http.port>8888</fester.http.port>
 
+    <!-- String that should be present in A/V access URLs -->
+    <fester.av.string>pairtree</fester.av.string>
+
     <!-- The version of Festerize that is compatible with this version of Fester -->
     <festerize.version>0.2.0</festerize.version>
 

--- a/src/main/docker/configs/fester.properties.default
+++ b/src/main/docker/configs/fester.properties.default
@@ -26,7 +26,7 @@ FESTER_S3_ENDPOINT=https://s3.amazonaws.com
 IIIF_BASE_URL=https://iiif.library.ucla.edu/iiif/2
 
 # String that should be present in A/V access URLs
-AV_URL_STRING=pairtree
+AV_URL_STRING=https://wowza.library.ucla.edu/iiif_av_public/
 
 # The version of Festerize that is compatible with this version of Fester
 FESTERIZE_VERSION=

--- a/src/main/docker/configs/fester.properties.default
+++ b/src/main/docker/configs/fester.properties.default
@@ -25,5 +25,8 @@ FESTER_S3_ENDPOINT=https://s3.amazonaws.com
 
 IIIF_BASE_URL=https://iiif.library.ucla.edu/iiif/2
 
+# String that should be present in A/V access URLs
+AV_URL_STRING=pairtree
+
 # The version of Festerize that is compatible with this version of Fester
 FESTERIZE_VERSION=

--- a/src/main/docker/configs/fester.properties.tmpl
+++ b/src/main/docker/configs/fester.properties.tmpl
@@ -24,7 +24,7 @@ fester.http.port=$FESTER_HTTP_PORT
 iiif.base.url=$IIIF_BASE_URL
 
 # String that should be present in A/V access URLs
-fester.av.string=AV_URL_STRING
+fester.av.string=$AV_URL_STRING
 
 # The version of Festerize that is compatible with this version of Fester
 festerize.version=$FESTERIZE_VERSION

--- a/src/main/docker/configs/fester.properties.tmpl
+++ b/src/main/docker/configs/fester.properties.tmpl
@@ -23,5 +23,8 @@ fester.http.port=$FESTER_HTTP_PORT
 # The base URL for the IIIF image service (includes service prefix)
 iiif.base.url=$IIIF_BASE_URL
 
+# String that should be present in A/V access URLs
+fester.av.string=AV_URL_STRING
+
 # The version of Festerize that is compatible with this version of Fester
 festerize.version=$FESTERIZE_VERSION

--- a/src/main/java/edu/ucla/library/iiif/fester/CSV.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/CSV.java
@@ -59,7 +59,7 @@ public final class CSV {
     /**
      * The rows's audio/video access URL.
      */
-    public static final String AV_ACCESS_URL = "AV Access URL";
+    //public static final String AV_ACCESS_URL = "AV Access URL";
 
     /**
      * The row's repository name.

--- a/src/main/java/edu/ucla/library/iiif/fester/CSV.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/CSV.java
@@ -57,11 +57,6 @@ public final class CSV {
     public static final String IIIF_ACCESS_URL = "IIIF Access URL";
 
     /**
-     * The rows's audio/video access URL.
-     */
-    //public static final String AV_ACCESS_URL = "AV Access URL";
-
-    /**
      * The row's repository name.
      */
     public static final String REPOSITORY_NAME = "Name.repository";

--- a/src/main/java/edu/ucla/library/iiif/fester/Config.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/Config.java
@@ -48,6 +48,9 @@ public final class Config {
     /* The version of Festerize that is compatible with this version of Fester */
     public static final String FESTERIZE_VERSION = "festerize.version";
 
+    /* A string to distinguish A/V access URLs from generic IIF access URLs */
+    public static final String AV_URL_STRING = "fester.av.string";
+
     /**
      * Private constructor for the Constants class.
      */

--- a/src/main/java/edu/ucla/library/iiif/fester/Constants.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/Constants.java
@@ -285,6 +285,12 @@ public final class Constants {
     public static final String CONTEXT_V3 = "http://iiif.io/api/presentation/3/context.json";
 
     /**
+     * The default pattern for A/V URLs.
+     * .
+     */
+    public static final String DEFAULT_AV_STRING = "https://wowza.library.ucla.edu/iiif_av_public/";
+ 
+    /**
      * Private constructor for Constants class.
      */
     private Constants() {

--- a/src/main/java/edu/ucla/library/iiif/fester/Constants.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/Constants.java
@@ -288,7 +288,7 @@ public final class Constants {
      * The default pattern for A/V URLs.
      * .
      */
-    public static final String DEFAULT_AV_STRING = "https://wowza.library.ucla.edu/iiif_av_public/";
+    public static final String DEFAULT_AV_STRING = "mpd";
 
     /**
      * Private constructor for Constants class.

--- a/src/main/java/edu/ucla/library/iiif/fester/Constants.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/Constants.java
@@ -289,7 +289,7 @@ public final class Constants {
      * .
      */
     public static final String DEFAULT_AV_STRING = "https://wowza.library.ucla.edu/iiif_av_public/";
- 
+
     /**
      * Private constructor for Constants class.
      */

--- a/src/main/java/edu/ucla/library/iiif/fester/CsvHeaders.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/CsvHeaders.java
@@ -54,15 +54,9 @@ public class CsvHeaders {
     private int myViewingDirectionIndex = -1;
 
     /**
-     * The index position for the image access URL column.
+     * The index position for the content access URL column.
      */
     private int myContentAccessUrlIndex = -1;
-
-    /**
-     * The index position for the audio/video access URL column.
-     */
-    //@SuppressWarnings("PMD.LongVariable")
-    //private int myAudioVideoAccessUrlIndex = -1;
 
     /**
      * The index position for the repository name column.

--- a/src/main/java/edu/ucla/library/iiif/fester/CsvHeaders.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/CsvHeaders.java
@@ -56,13 +56,13 @@ public class CsvHeaders {
     /**
      * The index position for the image access URL column.
      */
-    private int myImageAccessUrlIndex = -1;
+    private int myContentAccessUrlIndex = -1;
 
     /**
      * The index position for the audio/video access URL column.
      */
-    @SuppressWarnings("PMD.LongVariable")
-    private int myAudioVideoAccessUrlIndex = -1;
+    //@SuppressWarnings("PMD.LongVariable")
+    //private int myAudioVideoAccessUrlIndex = -1;
 
     /**
      * The index position for the repository name column.
@@ -134,10 +134,7 @@ public class CsvHeaders {
                     setViewingHintIndex(index);
                     break;
                 case CSV.IIIF_ACCESS_URL:
-                    setImageAccessUrlIndex(index);
-                    break;
-                case CSV.AV_ACCESS_URL:
-                    setAudioVideoAccessUrlIndex(index);
+                    setContentAccessUrlIndex(index);
                     break;
                 case CSV.REPOSITORY_NAME:
                     setRepositoryNameIndex(index);
@@ -205,65 +202,34 @@ public class CsvHeaders {
     }
 
     /**
-     * Gets the image access URL index position.
+     * Gets the content access URL index position.
      *
-     * @return The image access URL index position
+     * @return The content access URL index position
      */
     @JsonGetter
-    public int getImageAccessUrlIndex() {
-        return myImageAccessUrlIndex;
+    public int getContentAccessUrlIndex() {
+        return myContentAccessUrlIndex;
     }
 
     /**
-     * Sets the image access URL index position.
+     * Sets the content access URL index position.
      *
-     * @param aImageAccessUrlIndex The position of the image access URL header
+     * @param aContentAccessUrlIndex The position of the content access URL header
      * @return This CSV headers
      */
     @JsonSetter
-    public CsvHeaders setImageAccessUrlIndex(final int aImageAccessUrlIndex) {
-        myImageAccessUrlIndex = aImageAccessUrlIndex;
+    public CsvHeaders setContentAccessUrlIndex(final int aContentAccessUrlIndex) {
+        myContentAccessUrlIndex = aContentAccessUrlIndex;
         return this;
     }
 
     /**
-     * Checks whether there is an image access URL index position
+     * Checks whether there is a content access URL index position
      *
-     * @return True if there is an image access URL index position; else, false
+     * @return True if there is a content access URL index position; else, false
      */
-    public boolean hasImageAccessUrlIndex() {
-        return myImageAccessUrlIndex != -1;
-    }
-
-    /**
-     * Gets the audio/video access URL index position.
-     *
-     * @return The audio/video access URL index position
-     */
-    @JsonGetter
-    public int getAudioVideoAccessUrlIndex() {
-        return myAudioVideoAccessUrlIndex;
-    }
-
-    /**
-     * Sets the audio/video access URL index position.
-     *
-     * @param aAudioVideoAccessUrlIndex The position of the audio/video access URL header
-     * @return This CSV headers
-     */
-    @JsonSetter
-    public CsvHeaders setAudioVideoAccessUrlIndex(final int aAudioVideoAccessUrlIndex) {
-        myAudioVideoAccessUrlIndex = aAudioVideoAccessUrlIndex;
-        return this;
-    }
-
-    /**
-     * Checks whether there is an audio/video access URL index position
-     *
-     * @return True if there is an audio/video access URL index position; else, false
-     */
-    public boolean hasAudioVideoAccessUrlIndex() {
-        return myAudioVideoAccessUrlIndex != -1;
+    public boolean hasContentAccessUrlIndex() {
+        return myContentAccessUrlIndex != -1;
     }
 
     /**

--- a/src/main/java/edu/ucla/library/iiif/fester/CsvParser.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/CsvParser.java
@@ -41,6 +41,8 @@ public class CsvParser {
 
     private static final Pattern EOL_PATTERN = Pattern.compile(".*\\R");
 
+    private static final String AV_URL_STRING = "pairtree";
+
     private final Map<String, List<String[]>> myWorksMap = new HashMap<>();
 
     private final Map<String, List<String[]>> myPagesMap = new LinkedHashMap<>();
@@ -337,6 +339,7 @@ public class CsvParser {
      * @throws CsvParsingException If the row represents a v2 canvas and contains any A/V metadata
      */
     @SuppressWarnings("unchecked")
+    @SuppressWarnings("BooleanExpressionComplexity")
     private String[] checkApiCompatibility(final String[] aRow, final Path aPath, final String aIiifVersion)
             throws CsvParsingException {
         final String rowId = getMetadata(aRow, myCsvHeaders.getItemArkIndex()).get();
@@ -348,11 +351,13 @@ public class CsvParser {
         final Optional<Float> mediaDuration =
                 (Optional<Float>) getMetadata(aRow, myCsvHeaders.getMediaDurationIndex(), Float.class, aPath);
         final Optional<String> mediaFormat = getMetadata(aRow, myCsvHeaders.getMediaFormatIndex());
-        final Optional<String> audioVideoAccessUrl = getMetadata(aRow, myCsvHeaders.getAudioVideoAccessUrlIndex());
+        final Optional<String> audioVideoAccessUrl = getMetadata(aRow, myCsvHeaders.getContentAccessUrlIndex());
 
         if (Constants.IIIF_API_V2.equals(aIiifVersion)) {
+            //if (hasAVContent(mediaWidth, mediaHeight, mediaDuration, mediaFormat, audioVideoAccessUrl)) {
             if (mediaWidth.isPresent() || mediaHeight.isPresent() || mediaDuration.isPresent() ||
-                    mediaFormat.isPresent() || audioVideoAccessUrl.isPresent()) {
+                    mediaFormat.isPresent() || (audioVideoAccessUrl.isPresent() &&
+                    audioVideoAccessUrl.toString().contains(AV_URL_STRING))) {
                 throw new CsvParsingException(MessageCodes.MFS_168, rowId, aPath);
             }
         } else { // Constants.IIIF_API_V3
@@ -388,7 +393,7 @@ public class CsvParser {
                     }
                 }
             } else if (mediaWidth.isPresent() || mediaHeight.isPresent() || mediaDuration.isPresent() ||
-                    audioVideoAccessUrl.isPresent()) {
+                    (audioVideoAccessUrl.isPresent() && audioVideoAccessUrl.toString().contains(AV_URL_STRING))) {
                 throw new CsvParsingException(MessageCodes.MFS_172, rowId, aPath);
             }
         }

--- a/src/main/java/edu/ucla/library/iiif/fester/CsvParser.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/CsvParser.java
@@ -41,7 +41,7 @@ public class CsvParser {
 
     private static final Pattern EOL_PATTERN = Pattern.compile(".*\\R");
 
-    private static final String AV_URL_STRING = "pairtree";
+    //private static final String AV_URL_STRING = "pairtree";
 
     private final Map<String, List<String[]>> myWorksMap = new HashMap<>();
 
@@ -50,6 +50,8 @@ public class CsvParser {
     private final List<String[]> myWorksList = new ArrayList<>();
 
     private String[] myCollectionData;
+
+    private String myAVUrlString;
 
     private CsvHeaders myCsvHeaders;
 
@@ -353,10 +355,9 @@ public class CsvParser {
         final Optional<String> audioVideoAccessUrl = getMetadata(aRow, myCsvHeaders.getContentAccessUrlIndex());
 
         if (Constants.IIIF_API_V2.equals(aIiifVersion)) {
-            //if (hasAVContent(mediaWidth, mediaHeight, mediaDuration, mediaFormat, audioVideoAccessUrl)) {
             if (mediaWidth.isPresent() || mediaHeight.isPresent() || mediaDuration.isPresent() ||
                     mediaFormat.isPresent() || (audioVideoAccessUrl.isPresent() &&
-                    audioVideoAccessUrl.toString().contains(AV_URL_STRING))) {
+                    audioVideoAccessUrl.toString().contains(myAVUrlString))) {
                 throw new CsvParsingException(MessageCodes.MFS_168, rowId, aPath);
             }
         } else { // Constants.IIIF_API_V3
@@ -376,6 +377,10 @@ public class CsvParser {
                                 audioVideoAccessUrl.isEmpty()) {
                             throw new CsvParsingException(MessageCodes.MFS_170, rowId, format, aPath);
                         }
+                        if (audioVideoAccessUrl.isPresent() &&
+                            !audioVideoAccessUrl.toString().contains(myAVUrlString)) {
+                            throw new CsvParsingException(MessageCodes.MFS_176, rowId, format, aPath);
+                        }
                         break;
                     }
                     case "audio": {
@@ -385,6 +390,10 @@ public class CsvParser {
                         if (!mediaWidth.isEmpty() || !mediaHeight.isEmpty()) {
                             throw new CsvParsingException(MessageCodes.MFS_175, rowId, format, aPath);
                         }
+                        if (audioVideoAccessUrl.isPresent() &&
+                            !audioVideoAccessUrl.toString().contains(myAVUrlString)) {
+                            throw new CsvParsingException(MessageCodes.MFS_176, rowId, format, aPath);
+                        }
                         break;
                     }
                     default: {
@@ -392,7 +401,7 @@ public class CsvParser {
                     }
                 }
             } else if (mediaWidth.isPresent() || mediaHeight.isPresent() || mediaDuration.isPresent() ||
-                    (audioVideoAccessUrl.isPresent() && audioVideoAccessUrl.toString().contains(AV_URL_STRING))) {
+                    (audioVideoAccessUrl.isPresent() && audioVideoAccessUrl.toString().contains(myAVUrlString))) {
                 throw new CsvParsingException(MessageCodes.MFS_172, rowId, aPath);
             }
         }
@@ -506,5 +515,16 @@ public class CsvParser {
         } catch (final IndexOutOfBoundsException details) {
             return Optional.empty();
         }
+    }
+
+    /**
+     * Sets the A/V URL identifier string.
+     *
+     * @param aAVUrlString The A/V URL identifier string
+     * @return This CSV parser
+     */
+    public CsvParser setAVUrlString(final String aAVUrlString) {
+        myAVUrlString = aAVUrlString;
+        return this;
     }
 }

--- a/src/main/java/edu/ucla/library/iiif/fester/CsvParser.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/CsvParser.java
@@ -63,6 +63,14 @@ public class CsvParser {
     }
 
     /**
+     * Creates a new CsvParser.
+     *
+     */
+    public CsvParser() {
+        myAVUrlString = Constants.DEFAULT_AV_STRING;
+    }
+
+    /**
      * Parses the CSV file at the supplied path. This is not thread-safe. Optional CSV columns: IIIF Access URL, Item
      * Sequence (if the CSV contains no page rows), viewingHint, viewingDirection, Name.repository,
      * Rights.statementLocal, Rights.servicesContact,

--- a/src/main/java/edu/ucla/library/iiif/fester/CsvParser.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/CsvParser.java
@@ -49,25 +49,14 @@ public class CsvParser {
 
     private String[] myCollectionData;
 
-    private String myAVUrlString;
-
     private CsvHeaders myCsvHeaders;
-
-    /**
-     * Creates a new CsvParser.
-     *
-     * @param aAVUrlString The A/V URL identifier string
-     */
-    public CsvParser(final String aAVUrlString) {
-        myAVUrlString = aAVUrlString;
-    }
 
     /**
      * Creates a new CsvParser.
      *
      */
     public CsvParser() {
-        myAVUrlString = Constants.DEFAULT_AV_STRING;
+
     }
 
     /**
@@ -77,12 +66,13 @@ public class CsvParser {
      *
      * @param aPath A path to a CSV file
      * @param aIiifVersion The target IIIF Presentation API version
+     * @param aAVUrlString A string expected to be found in A/V access URLs
      * @return This CSV parser
      * @throws IOException If there is trouble reading or writing data
      * @throws CsvException If there is trouble reading the CSV data
      * @throws CsvParsingException If there is trouble parsing the CSV data
      */
-    public CsvParser parse(final Path aPath, final String aIiifVersion)
+    public CsvParser parse(final Path aPath, final String aIiifVersion, final String aAVUrlString)
             throws IOException, CsvException, CsvParsingException {
         reset();
 
@@ -128,7 +118,7 @@ public class CsvParser {
                 checkForEOLs(row);
                 trimValues(row);
                 if (aIiifVersion != null) {
-                    checkApiCompatibility(row, aPath, aIiifVersion);
+                    checkApiCompatibility(row, aPath, aIiifVersion, aAVUrlString);
                 }
 
                 switch (getObjectType(row, myCsvHeaders)) {
@@ -175,7 +165,7 @@ public class CsvParser {
      * @throws CsvParsingException If there is trouble parsing the CSV data
      */
     public CsvParser parse(final Path aPath) throws IOException, CsvException, CsvParsingException {
-        return parse(aPath, null);
+        return parse(aPath, null, null);
     }
 
     /**
@@ -349,7 +339,8 @@ public class CsvParser {
      * @throws CsvParsingException If the row represents a v2 canvas and contains any A/V metadata
      */
     @SuppressWarnings({"unchecked", "BooleanExpressionComplexity"})
-    private String[] checkApiCompatibility(final String[] aRow, final Path aPath, final String aIiifVersion)
+    private String[] checkApiCompatibility(final String[] aRow, final Path aPath,
+        final String aIiifVersion, final String aAVUrlString)
             throws CsvParsingException {
         final String rowId = getMetadata(aRow, myCsvHeaders.getItemArkIndex()).get();
 
@@ -365,7 +356,7 @@ public class CsvParser {
         if (Constants.IIIF_API_V2.equals(aIiifVersion)) {
             if (mediaWidth.isPresent() || mediaHeight.isPresent() || mediaDuration.isPresent() ||
                     mediaFormat.isPresent() || (audioVideoAccessUrl.isPresent() &&
-                    audioVideoAccessUrl.toString().contains(myAVUrlString))) {
+                    audioVideoAccessUrl.toString().contains(aAVUrlString))) {
                 throw new CsvParsingException(MessageCodes.MFS_168, rowId, aPath);
             }
         } else { // Constants.IIIF_API_V3
@@ -386,7 +377,7 @@ public class CsvParser {
                             throw new CsvParsingException(MessageCodes.MFS_170, rowId, format, aPath);
                         }
                         if (audioVideoAccessUrl.isPresent() &&
-                            !audioVideoAccessUrl.toString().contains(myAVUrlString)) {
+                            !audioVideoAccessUrl.toString().contains(aAVUrlString)) {
                             throw new CsvParsingException(MessageCodes.MFS_176, rowId, format, aPath);
                         }
                         break;
@@ -399,7 +390,7 @@ public class CsvParser {
                             throw new CsvParsingException(MessageCodes.MFS_175, rowId, format, aPath);
                         }
                         if (audioVideoAccessUrl.isPresent() &&
-                            !audioVideoAccessUrl.toString().contains(myAVUrlString)) {
+                            !audioVideoAccessUrl.toString().contains(aAVUrlString)) {
                             throw new CsvParsingException(MessageCodes.MFS_176, rowId, format, aPath);
                         }
                         break;
@@ -409,7 +400,7 @@ public class CsvParser {
                     }
                 }
             } else if (mediaWidth.isPresent() || mediaHeight.isPresent() || mediaDuration.isPresent() ||
-                    (audioVideoAccessUrl.isPresent() && audioVideoAccessUrl.toString().contains(myAVUrlString))) {
+                    (audioVideoAccessUrl.isPresent() && audioVideoAccessUrl.toString().contains(aAVUrlString))) {
                 throw new CsvParsingException(MessageCodes.MFS_172, rowId, aPath);
             }
         }
@@ -523,16 +514,5 @@ public class CsvParser {
         } catch (final IndexOutOfBoundsException details) {
             return Optional.empty();
         }
-    }
-
-    /**
-     * Sets the A/V URL identifier string.
-     *
-     * @param aAVUrlString The A/V URL identifier string
-     * @return This CSV parser
-     */
-    public CsvParser setAVUrlString(final String aAVUrlString) {
-        myAVUrlString = aAVUrlString;
-        return this;
     }
 }

--- a/src/main/java/edu/ucla/library/iiif/fester/CsvParser.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/CsvParser.java
@@ -338,8 +338,7 @@ public class CsvParser {
      * @return The row
      * @throws CsvParsingException If the row represents a v2 canvas and contains any A/V metadata
      */
-    @SuppressWarnings("unchecked")
-    @SuppressWarnings("BooleanExpressionComplexity")
+    @SuppressWarnings({"unchecked", "BooleanExpressionComplexity"})
     private String[] checkApiCompatibility(final String[] aRow, final Path aPath, final String aIiifVersion)
             throws CsvParsingException {
         final String rowId = getMetadata(aRow, myCsvHeaders.getItemArkIndex()).get();

--- a/src/main/java/edu/ucla/library/iiif/fester/CsvParser.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/CsvParser.java
@@ -41,8 +41,6 @@ public class CsvParser {
 
     private static final Pattern EOL_PATTERN = Pattern.compile(".*\\R");
 
-    //private static final String AV_URL_STRING = "pairtree";
-
     private final Map<String, List<String[]>> myWorksMap = new HashMap<>();
 
     private final Map<String, List<String[]>> myPagesMap = new LinkedHashMap<>();
@@ -57,9 +55,11 @@ public class CsvParser {
 
     /**
      * Creates a new CsvParser.
+     *
+     * @param aAVUrlString The A/V URL identifier string
      */
-    public CsvParser() {
-
+    public CsvParser(final String aAVUrlString) {
+        myAVUrlString = aAVUrlString;
     }
 
     /**

--- a/src/main/java/edu/ucla/library/iiif/fester/handlers/PostThumbnailsHandler.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/handlers/PostThumbnailsHandler.java
@@ -74,6 +74,8 @@ public class PostThumbnailsHandler extends AbstractFesterHandler {
 
     private final String myFesterizeVersion;
 
+    private final String myAVUrlString;
+
     /* FUA = Festerize User Agent; agent to verify festerize version, acronymed for codacy */
     private final Pattern myFUAPattern;
 
@@ -92,6 +94,7 @@ public class PostThumbnailsHandler extends AbstractFesterHandler {
         myExceptionPage = new String(bytes, StandardCharsets.UTF_8);
         myFesterizeVersion = aConfig.getString(Config.FESTERIZE_VERSION);
         myFUAPattern = Pattern.compile("Festerize/(?<version>\\d+\\.\\d+\\.\\d+)");
+	myAVUrlString = aConfig.getString(Config.AV_URL_STRING, Constants.DEFAULT_AV_STRING);
     }
 
     /*
@@ -121,7 +124,7 @@ public class PostThumbnailsHandler extends AbstractFesterHandler {
             final String fileName = csvFile.fileName();
 
             try (CSVReader csvReader = new CSVReader(Files.newBufferedReader(Paths.get(filePath)))) {
-                final CsvParser parser = new CsvParser().parse(Paths.get(filePath));
+                final CsvParser parser = new CsvParser(myAVUrlString).parse(Paths.get(filePath));
                 final List<String[]> originalLines = csvReader.readAll();
                 final List<String[]> linesWithThumbs = ThumbnailUtils.addThumbnailColumn(originalLines);
                 final int manifestIndex = Arrays.asList(linesWithThumbs.get(0)).indexOf(CSV.MANIFEST_URL);

--- a/src/main/java/edu/ucla/library/iiif/fester/handlers/PostThumbnailsHandler.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/handlers/PostThumbnailsHandler.java
@@ -94,7 +94,7 @@ public class PostThumbnailsHandler extends AbstractFesterHandler {
         myExceptionPage = new String(bytes, StandardCharsets.UTF_8);
         myFesterizeVersion = aConfig.getString(Config.FESTERIZE_VERSION);
         myFUAPattern = Pattern.compile("Festerize/(?<version>\\d+\\.\\d+\\.\\d+)");
-	myAVUrlString = aConfig.getString(Config.AV_URL_STRING, Constants.DEFAULT_AV_STRING);
+        myAVUrlString = aConfig.getString(Config.AV_URL_STRING, Constants.DEFAULT_AV_STRING);
     }
 
     /*

--- a/src/main/java/edu/ucla/library/iiif/fester/handlers/PostThumbnailsHandler.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/handlers/PostThumbnailsHandler.java
@@ -124,7 +124,7 @@ public class PostThumbnailsHandler extends AbstractFesterHandler {
             final String fileName = csvFile.fileName();
 
             try (CSVReader csvReader = new CSVReader(Files.newBufferedReader(Paths.get(filePath)))) {
-                final CsvParser parser = new CsvParser(myAVUrlString).parse(Paths.get(filePath));
+                final CsvParser parser = new CsvParser().parse(Paths.get(filePath), null, myAVUrlString);
                 final List<String[]> originalLines = csvReader.readAll();
                 final List<String[]> linesWithThumbs = ThumbnailUtils.addThumbnailColumn(originalLines);
                 final int manifestIndex = Arrays.asList(linesWithThumbs.get(0)).indexOf(CSV.MANIFEST_URL);

--- a/src/main/java/edu/ucla/library/iiif/fester/verticles/ManifestVerticle.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/verticles/ManifestVerticle.java
@@ -103,8 +103,7 @@ public class ManifestVerticle extends AbstractFesterVerticle {
                 final String action = message.headers().get(Constants.ACTION);
                 final Path filePath = Paths.get(body.getString(Constants.CSV_FILE_PATH));
                 final String iiifVersion = body.getString(Constants.IIIF_API_VERSION);
-		final String avUrlString = config().getString(Config.AV_URL_STRING, Constants.DEFAULT_AV_STRING);
-                //final CsvParser csvParser = new CsvParser().setAVUrlString(config().getString(Config.AV_URL_STRING, DEFAULT_AV_STRING))
+                final String avUrlString = config().getString(Config.AV_URL_STRING, Constants.DEFAULT_AV_STRING);
                 final CsvParser csvParser = new CsvParser(avUrlString).parse(filePath, iiifVersion);
                 final CsvMetadata csvMetadata = csvParser.getCsvMetadata();
 

--- a/src/main/java/edu/ucla/library/iiif/fester/verticles/ManifestVerticle.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/verticles/ManifestVerticle.java
@@ -103,7 +103,8 @@ public class ManifestVerticle extends AbstractFesterVerticle {
                 final String action = message.headers().get(Constants.ACTION);
                 final Path filePath = Paths.get(body.getString(Constants.CSV_FILE_PATH));
                 final String iiifVersion = body.getString(Constants.IIIF_API_VERSION);
-                final CsvParser csvParser = new CsvParser().parse(filePath, iiifVersion);
+                final CsvParser csvParser = new CsvParser().setAVUrlString(config().getString(Config.AV_URL_STRING))
+                      .parse(filePath, iiifVersion);
                 final CsvMetadata csvMetadata = csvParser.getCsvMetadata();
 
                 if (Op.POST_CSV.equals(action)) {

--- a/src/main/java/edu/ucla/library/iiif/fester/verticles/ManifestVerticle.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/verticles/ManifestVerticle.java
@@ -104,7 +104,7 @@ public class ManifestVerticle extends AbstractFesterVerticle {
                 final Path filePath = Paths.get(body.getString(Constants.CSV_FILE_PATH));
                 final String iiifVersion = body.getString(Constants.IIIF_API_VERSION);
                 final String avUrlString = config().getString(Config.AV_URL_STRING, Constants.DEFAULT_AV_STRING);
-                final CsvParser csvParser = new CsvParser(avUrlString).parse(filePath, iiifVersion);
+                final CsvParser csvParser = new CsvParser().parse(filePath, iiifVersion, avUrlString);
                 final CsvMetadata csvMetadata = csvParser.getCsvMetadata();
 
                 if (Op.POST_CSV.equals(action)) {

--- a/src/main/java/edu/ucla/library/iiif/fester/verticles/ManifestVerticle.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/verticles/ManifestVerticle.java
@@ -76,7 +76,6 @@ public class ManifestVerticle extends AbstractFesterVerticle {
      */
     public static final String CREATE_WORK = "create-work";
 
-    private static final String DEFAULT_AV_STRING = "https://wowza.library.ucla.edu/iiif_av_public/";
     private static final Logger LOGGER = LoggerFactory.getLogger(ManifestVerticle.class, Constants.MESSAGES);
 
     private static final long TIMEOUT = Long.MAX_VALUE; // A temporary over the top setting for image lookups
@@ -104,8 +103,9 @@ public class ManifestVerticle extends AbstractFesterVerticle {
                 final String action = message.headers().get(Constants.ACTION);
                 final Path filePath = Paths.get(body.getString(Constants.CSV_FILE_PATH));
                 final String iiifVersion = body.getString(Constants.IIIF_API_VERSION);
-                final CsvParser csvParser = new CsvParser().setAVUrlString(config().getString(Config.AV_URL_STRING, DEFAULT_AV_STRING))
-                      .parse(filePath, iiifVersion);
+		final String avUrlString = config().getString(Config.AV_URL_STRING, Constants.DEFAULT_AV_STRING);
+                //final CsvParser csvParser = new CsvParser().setAVUrlString(config().getString(Config.AV_URL_STRING, DEFAULT_AV_STRING))
+                final CsvParser csvParser = new CsvParser(avUrlString).parse(filePath, iiifVersion);
                 final CsvMetadata csvMetadata = csvParser.getCsvMetadata();
 
                 if (Op.POST_CSV.equals(action)) {

--- a/src/main/java/edu/ucla/library/iiif/fester/verticles/ManifestVerticle.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/verticles/ManifestVerticle.java
@@ -76,6 +76,7 @@ public class ManifestVerticle extends AbstractFesterVerticle {
      */
     public static final String CREATE_WORK = "create-work";
 
+    //private static final String DEFAULT_AV_STRING = "pairtree";
     private static final Logger LOGGER = LoggerFactory.getLogger(ManifestVerticle.class, Constants.MESSAGES);
 
     private static final long TIMEOUT = Long.MAX_VALUE; // A temporary over the top setting for image lookups
@@ -103,7 +104,7 @@ public class ManifestVerticle extends AbstractFesterVerticle {
                 final String action = message.headers().get(Constants.ACTION);
                 final Path filePath = Paths.get(body.getString(Constants.CSV_FILE_PATH));
                 final String iiifVersion = body.getString(Constants.IIIF_API_VERSION);
-                final CsvParser csvParser = new CsvParser().setAVUrlString(config().getString(Config.AV_URL_STRING))
+                final CsvParser csvParser = new CsvParser().setAVUrlString(config().getString(Config.AV_URL_STRING)) //, DEFAULT_AV_STRING))
                       .parse(filePath, iiifVersion);
                 final CsvMetadata csvMetadata = csvParser.getCsvMetadata();
 

--- a/src/main/java/edu/ucla/library/iiif/fester/verticles/ManifestVerticle.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/verticles/ManifestVerticle.java
@@ -76,7 +76,7 @@ public class ManifestVerticle extends AbstractFesterVerticle {
      */
     public static final String CREATE_WORK = "create-work";
 
-    //private static final String DEFAULT_AV_STRING = "pairtree";
+    private static final String DEFAULT_AV_STRING = "https://wowza.library.ucla.edu/iiif_av_public/";
     private static final Logger LOGGER = LoggerFactory.getLogger(ManifestVerticle.class, Constants.MESSAGES);
 
     private static final long TIMEOUT = Long.MAX_VALUE; // A temporary over the top setting for image lookups
@@ -104,7 +104,7 @@ public class ManifestVerticle extends AbstractFesterVerticle {
                 final String action = message.headers().get(Constants.ACTION);
                 final Path filePath = Paths.get(body.getString(Constants.CSV_FILE_PATH));
                 final String iiifVersion = body.getString(Constants.IIIF_API_VERSION);
-                final CsvParser csvParser = new CsvParser().setAVUrlString(config().getString(Config.AV_URL_STRING)) //, DEFAULT_AV_STRING))
+                final CsvParser csvParser = new CsvParser().setAVUrlString(config().getString(Config.AV_URL_STRING, DEFAULT_AV_STRING))
                       .parse(filePath, iiifVersion);
                 final CsvMetadata csvMetadata = csvParser.getCsvMetadata();
 

--- a/src/main/java/edu/ucla/library/iiif/fester/verticles/V2ManifestVerticle.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/verticles/V2ManifestVerticle.java
@@ -240,7 +240,7 @@ public class V2ManifestVerticle extends AbstractFesterVerticle {
             pageList.sort(new ItemSequenceComparator(csvHeaders.getItemSequenceIndex()));
             sequence.addCanvas(createCanvases(csvHeaders, pageList, imageHost, placeholderImage, encodedWorkID));
         } else {
-            CsvParser.getMetadata(workRow, csvHeaders.getImageAccessUrlIndex()).ifPresent(accessURL -> {
+            CsvParser.getMetadata(workRow, csvHeaders.getContentAccessUrlIndex()).ifPresent(accessURL -> {
                 final List<String[]> pageList = new ArrayList<>(1);
 
                 pageList.add(workRow);

--- a/src/main/java/edu/ucla/library/iiif/fester/verticles/V3ManifestVerticle.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/verticles/V3ManifestVerticle.java
@@ -228,8 +228,8 @@ public class V3ManifestVerticle extends AbstractFesterVerticle {
             canvases = createCanvases(csvHeaders, pageList, imageHost, placeholderImage, minter);
             manifest.addCanvas(canvases);
         } else {
-            if (CsvParser.getMetadata(workRow, csvHeaders.getImageAccessUrlIndex()).isPresent() ||
-                    CsvParser.getMetadata(workRow, csvHeaders.getAudioVideoAccessUrlIndex()).isPresent()) {
+            if (CsvParser.getMetadata(workRow, csvHeaders.getContentAccessUrlIndex()).isPresent() ||
+                    CsvParser.getMetadata(workRow, csvHeaders.getContentAccessUrlIndex()).isPresent()) {
                 final List<String[]> pageList = new ArrayList<>(1);
                 final Canvas[] canvases;
 
@@ -439,7 +439,7 @@ public class V3ManifestVerticle extends AbstractFesterVerticle {
             if (format.isPresent() && format.get().contains("video/")) {
                 final VideoContent video;
 
-                resourceURI = CsvParser.getMetadata(columns, aCsvHeaders.getAudioVideoAccessUrlIndex()).get();
+                resourceURI = CsvParser.getMetadata(columns, aCsvHeaders.getContentAccessUrlIndex()).get();
                 video = new VideoContent(resourceURI);
 
                 // We've already validated these numeric values in CsvParser
@@ -451,7 +451,7 @@ public class V3ManifestVerticle extends AbstractFesterVerticle {
             } else if (format.isPresent() && format.get().contains("audio/")) {
                 final SoundContent audio;
 
-                resourceURI = CsvParser.getMetadata(columns, aCsvHeaders.getAudioVideoAccessUrlIndex()).get();
+                resourceURI = CsvParser.getMetadata(columns, aCsvHeaders.getContentAccessUrlIndex()).get();
                 audio = new SoundContent(resourceURI);
 
                 // We've already validated this numeric value in CsvParser

--- a/src/main/resources/fester_messages.xml
+++ b/src/main/resources/fester_messages.xml
@@ -186,4 +186,5 @@
   <entry key="MFS-173">Cannot parse value '{}' from CSV '{}' as '{}'</entry>
   <entry key="MFS-174">Found item '{}' with format '{}' in CSV '{}', but is missing either duration or A/V access URL</entry>
   <entry key="MFS-175">Found item '{}' with format '{}' in CSV '{}', but it has either height or width, unnecessary for audio content</entry>
+  <entry key="MFS-176">Found item '{}' with format '{}' in CSV '{}', but the access url has not been processed for Wowza</entry>
 </properties>

--- a/src/test/java/edu/ucla/library/iiif/fester/CsvParserTest.java
+++ b/src/test/java/edu/ucla/library/iiif/fester/CsvParserTest.java
@@ -84,7 +84,7 @@ public class CsvParserTest {
         final CsvHeaders csvHeaders = myCsvParser.parse(getTestPath(GOOD_CSV)).getCsvHeaders();
 
         assertEquals(6, csvHeaders.getFileNameIndex());
-        assertEquals(38, csvHeaders.getImageAccessUrlIndex());
+        assertEquals(38, csvHeaders.getContentAccessUrlIndex());
         assertEquals(1, csvHeaders.getItemArkIndex());
         assertEquals(7, csvHeaders.getItemSequenceIndex());
         assertEquals(-1, csvHeaders.getLocalRightsStatementIndex());

--- a/src/test/java/edu/ucla/library/iiif/fester/fit/PostCsvFIT.java
+++ b/src/test/java/edu/ucla/library/iiif/fester/fit/PostCsvFIT.java
@@ -543,6 +543,7 @@ public class PostCsvFIT {
          *
          * @param aContext A test context
          */
+        @Test
         public final void testVideoMissingMetadata(final TestContext aContext) {
             final Async asyncTask = aContext.async();
 
@@ -570,6 +571,7 @@ public class PostCsvFIT {
          *
          * @param aContext A test context
          */
+        @Test
         public final void testVideoMalformedMetadata(final TestContext aContext) {
             final Async asyncTask = aContext.async();
 
@@ -596,6 +598,7 @@ public class PostCsvFIT {
          *
          * @param aContext A test context
          */
+        @Test
         public final void testVideoIiifPresApiV2(final TestContext aContext) {
             final Async asyncTask = aContext.async();
 

--- a/src/test/resources/csv/audio/audio.csv
+++ b/src/test/resources/csv/audio/audio.csv
@@ -1,3 +1,3 @@
-Project Name,Item ARK,Parent ARK,Object Type,File Name,Item Sequence,Title,media.width,media.height,media.duration,media.format,Bucketeer State,IIIF Access URL,AV Access URL
-Test Audio,ark:/21198/zz00000000,,Collection,,,Test Audio,,,,,succeeded,,
-Test Audio,ark:/21198/zz00000001,ark:/21198/zz00000000,Work,,1,Test Audio 1,,,1985.024,audio/mp4,,,https://fixtures.iiif.io/audio/indiana/mahler-symphony-3/CD1/medium/128Kbps.mp4
+Project Name,Item ARK,Parent ARK,Object Type,File Name,Item Sequence,Title,media.width,media.height,media.duration,media.format,Bucketeer State,IIIF Access URL
+Test Audio,ark:/21198/zz00000000,,Collection,,,Test Audio,,,,,succeeded,
+Test Audio,ark:/21198/zz00000001,ark:/21198/zz00000000,Work,,1,Test Audio 1,,,1985.024,audio/mp4,,https://fixtures.iiif.io/audio/indiana/mahler-symphony-3/CD1/medium/128Kbps.mp4

--- a/src/test/resources/csv/audio/audio.csv
+++ b/src/test/resources/csv/audio/audio.csv
@@ -1,3 +1,3 @@
 Project Name,Item ARK,Parent ARK,Object Type,File Name,Item Sequence,Title,media.width,media.height,media.duration,media.format,Bucketeer State,IIIF Access URL
 Test Audio,ark:/21198/zz00000000,,Collection,,,Test Audio,,,,,succeeded,
-Test Audio,ark:/21198/zz00000001,ark:/21198/zz00000000,Work,,1,Test Audio 1,,,1985.024,audio/mp4,,https://fixtures.iiif.io/audio/indiana/mahler-symphony-3/CD1/medium/128Kbps.mp4
+Test Audio,ark:/21198/zz00000001,ark:/21198/zz00000000,Work,,1,Test Audio 1,,,1985.024,audio/mp4,,https://wowza.library.ucla.edu/iiif_av_public/audio/indiana/mahler-symphony-3/CD1/medium/128Kbps.mp4

--- a/src/test/resources/csv/audio/audio_malformed_metadata.csv
+++ b/src/test/resources/csv/audio/audio_malformed_metadata.csv
@@ -1,3 +1,3 @@
-Project Name,Item ARK,Parent ARK,Object Type,File Name,Item Sequence,Title,media.width,media.height,media.duration,media.format,Bucketeer State,IIIF Access URL,AV Access URL
-Test Audio,ark:/21198/zz00000000,,Collection,,,Test Audio,,,,,succeeded,,
-Test Audio,ark:/21198/zz00000001,ark:/21198/zz00000000,Work,,1,Test Audio 1,,,???,audio/ogg,,,https://wowza.library.ucla.edu/audio/1
+Project Name,Item ARK,Parent ARK,Object Type,File Name,Item Sequence,Title,media.width,media.height,media.duration,media.format,Bucketeer State,IIIF Access URL
+Test Audio,ark:/21198/zz00000000,,Collection,,,Test Audio,,,,,succeeded,
+Test Audio,ark:/21198/zz00000001,ark:/21198/zz00000000,Work,,1,Test Audio 1,,,???,audio/ogg,,https://wowza.library.ucla.edu/audio/1

--- a/src/test/resources/csv/audio/audio_malformed_metadata.csv
+++ b/src/test/resources/csv/audio/audio_malformed_metadata.csv
@@ -1,3 +1,3 @@
 Project Name,Item ARK,Parent ARK,Object Type,File Name,Item Sequence,Title,media.width,media.height,media.duration,media.format,Bucketeer State,IIIF Access URL
 Test Audio,ark:/21198/zz00000000,,Collection,,,Test Audio,,,,,succeeded,
-Test Audio,ark:/21198/zz00000001,ark:/21198/zz00000000,Work,,1,Test Audio 1,,,???,audio/ogg,,https://wowza.library.ucla.edu/audio/1
+Test Audio,ark:/21198/zz00000001,ark:/21198/zz00000000,Work,,1,Test Audio 1,,,???,audio/ogg,,https://wowza.library.ucla.edu/iiif_av_public/audio/1

--- a/src/test/resources/csv/audio/audio_missing_metadata.csv
+++ b/src/test/resources/csv/audio/audio_missing_metadata.csv
@@ -1,3 +1,3 @@
 Project Name,Item ARK,Parent ARK,Object Type,File Name,Item Sequence,Title,media.width,media.height,media.duration,media.format,Bucketeer State,IIIF Access URL
 Test Audio,ark:/21198/zz00000000,,Collection,,,Test Audio,,,,,succeeded,
-Test Audio,ark:/21198/zz00000001,ark:/21198/zz00000000,Work,,1,Test Audio 1,,,,audio/ogg,,https://wowza.library.ucla.edu/audio/1
+Test Audio,ark:/21198/zz00000001,ark:/21198/zz00000000,Work,,1,Test Audio 1,,,,audio/ogg,,https://wowza.library.ucla.edu/iiif_av_public/audio/1

--- a/src/test/resources/csv/audio/audio_missing_metadata.csv
+++ b/src/test/resources/csv/audio/audio_missing_metadata.csv
@@ -1,3 +1,3 @@
-Project Name,Item ARK,Parent ARK,Object Type,File Name,Item Sequence,Title,media.width,media.height,media.duration,media.format,Bucketeer State,IIIF Access URL,AV Access URL
-Test Audio,ark:/21198/zz00000000,,Collection,,,Test Audio,,,,,succeeded,,
-Test Audio,ark:/21198/zz00000001,ark:/21198/zz00000000,Work,,1,Test Audio 1,,,,audio/ogg,,,https://wowza.library.ucla.edu/audio/1
+Project Name,Item ARK,Parent ARK,Object Type,File Name,Item Sequence,Title,media.width,media.height,media.duration,media.format,Bucketeer State,IIIF Access URL
+Test Audio,ark:/21198/zz00000000,,Collection,,,Test Audio,,,,,succeeded,
+Test Audio,ark:/21198/zz00000001,ark:/21198/zz00000000,Work,,1,Test Audio 1,,,,audio/ogg,,https://wowza.library.ucla.edu/audio/1

--- a/src/test/resources/csv/audio/audio_unneedded_metadata.csv
+++ b/src/test/resources/csv/audio/audio_unneedded_metadata.csv
@@ -1,3 +1,3 @@
-Project Name,Item ARK,Parent ARK,Object Type,File Name,Item Sequence,Title,media.width,media.height,media.duration,media.format,Bucketeer State,IIIF Access URL,AV Access URL
-Test Audio,ark:/21198/zz00000000,,Collection,,,Test Audio,,,,,succeeded,,
-Test Audio,ark:/21198/zz00000001,ark:/21198/zz00000000,Work,,1,Test Audio 1,,600,1985.024,audio/mp4,,,https://fixtures.iiif.io/audio/indiana/mahler-symphony-3/CD1/medium/128Kbps.mp4
+Project Name,Item ARK,Parent ARK,Object Type,File Name,Item Sequence,Title,media.width,media.height,media.duration,media.format,Bucketeer State,IIIF Access URL
+Test Audio,ark:/21198/zz00000000,,Collection,,,Test Audio,,,,,succeeded,
+Test Audio,ark:/21198/zz00000001,ark:/21198/zz00000000,Work,,1,Test Audio 1,,600,1985.024,audio/mp4,,https://fixtures.iiif.io/audio/indiana/mahler-symphony-3/CD1/medium/128Kbps.mp4

--- a/src/test/resources/csv/audio/audio_unneedded_metadata.csv
+++ b/src/test/resources/csv/audio/audio_unneedded_metadata.csv
@@ -1,3 +1,3 @@
 Project Name,Item ARK,Parent ARK,Object Type,File Name,Item Sequence,Title,media.width,media.height,media.duration,media.format,Bucketeer State,IIIF Access URL
 Test Audio,ark:/21198/zz00000000,,Collection,,,Test Audio,,,,,succeeded,
-Test Audio,ark:/21198/zz00000001,ark:/21198/zz00000000,Work,,1,Test Audio 1,,600,1985.024,audio/mp4,,https://fixtures.iiif.io/audio/indiana/mahler-symphony-3/CD1/medium/128Kbps.mp4
+Test Audio,ark:/21198/zz00000001,ark:/21198/zz00000000,Work,,1,Test Audio 1,,600,1985.024,audio/mp4,,https://wowza.library.ucla.edu/iiif_av_public/audio/indiana/mahler-symphony-3/CD1/medium/128Kbps.mp4

--- a/src/test/resources/csv/video/video.csv
+++ b/src/test/resources/csv/video/video.csv
@@ -1,3 +1,3 @@
 Project Name,Item ARK,Parent ARK,Object Type,File Name,Item Sequence,Title,media.width,media.height,media.duration,media.format,Bucketeer State,IIIF Access URL
 Test Video,ark:/21198/zz00000000,,Collection,,,Test Video,,,,,succeeded,
-Test Video,ark:/21198/zz00000001,ark:/21198/zz00000000,Work,,1,Test Video 1,640,360,1801.055,video/mp4,,https://fixtures.iiif.io/video/indiana/30-minute-clock/medium/30-minute-clock.mp4
+Test Video,ark:/21198/zz00000001,ark:/21198/zz00000000,Work,,1,Test Video 1,640,360,1801.055,video/mp4,,https://wowza.library.ucla.edu/iiif_av_public/video/indiana/30-minute-clock/medium/30-minute-clock.mp4

--- a/src/test/resources/csv/video/video.csv
+++ b/src/test/resources/csv/video/video.csv
@@ -1,3 +1,3 @@
-Project Name,Item ARK,Parent ARK,Object Type,File Name,Item Sequence,Title,media.width,media.height,media.duration,media.format,Bucketeer State,IIIF Access URL,AV Access URL
-Test Video,ark:/21198/zz00000000,,Collection,,,Test Video,,,,,succeeded,,
-Test Video,ark:/21198/zz00000001,ark:/21198/zz00000000,Work,,1,Test Video 1,640,360,1801.055,video/mp4,,,https://fixtures.iiif.io/video/indiana/30-minute-clock/medium/30-minute-clock.mp4
+Project Name,Item ARK,Parent ARK,Object Type,File Name,Item Sequence,Title,media.width,media.height,media.duration,media.format,Bucketeer State,IIIF Access URL
+Test Video,ark:/21198/zz00000000,,Collection,,,Test Video,,,,,succeeded,
+Test Video,ark:/21198/zz00000001,ark:/21198/zz00000000,Work,,1,Test Video 1,640,360,1801.055,video/mp4,,https://fixtures.iiif.io/video/indiana/30-minute-clock/medium/30-minute-clock.mp4

--- a/src/test/resources/csv/video/video_malformed_metadata.csv
+++ b/src/test/resources/csv/video/video_malformed_metadata.csv
@@ -1,3 +1,3 @@
-Project Name,Item ARK,Parent ARK,Object Type,File Name,Item Sequence,Title,media.width,media.height,media.duration,media.format,Bucketeer State,IIIF Access URL,AV Access URL
-Test Video,ark:/21198/zz00000000,,Collection,,,Test Video,,,,,succeeded,,
-Test Video,ark:/21198/zz00000001,ark:/21198/zz00000000,Work,,1,Test Video 1,800,600,???,video/ogg,,,https://wowza.library.ucla.edu/video/1
+Project Name,Item ARK,Parent ARK,Object Type,File Name,Item Sequence,Title,media.width,media.height,media.duration,media.format,Bucketeer State,IIIF Access URL
+Test Video,ark:/21198/zz00000000,,Collection,,,Test Video,,,,,succeeded,
+Test Video,ark:/21198/zz00000001,ark:/21198/zz00000000,Work,,1,Test Video 1,800,600,???,video/ogg,,https://wowza.library.ucla.edu/video/1

--- a/src/test/resources/csv/video/video_malformed_metadata.csv
+++ b/src/test/resources/csv/video/video_malformed_metadata.csv
@@ -1,3 +1,3 @@
 Project Name,Item ARK,Parent ARK,Object Type,File Name,Item Sequence,Title,media.width,media.height,media.duration,media.format,Bucketeer State,IIIF Access URL
 Test Video,ark:/21198/zz00000000,,Collection,,,Test Video,,,,,succeeded,
-Test Video,ark:/21198/zz00000001,ark:/21198/zz00000000,Work,,1,Test Video 1,800,600,???,video/ogg,,https://wowza.library.ucla.edu/video/1
+Test Video,ark:/21198/zz00000001,ark:/21198/zz00000000,Work,,1,Test Video 1,800,600,???,video/ogg,,https://wowza.library.ucla.edu/iiif_av_public/video/1

--- a/src/test/resources/csv/video/video_missing_metadata.csv
+++ b/src/test/resources/csv/video/video_missing_metadata.csv
@@ -1,3 +1,3 @@
 Project Name,Item ARK,Parent ARK,Object Type,File Name,Item Sequence,Title,media.width,media.height,media.duration,media.format,Bucketeer State,IIIF Access URL
 Test Video,ark:/21198/zz00000000,,Collection,,,Test Video,,,,,succeeded,
-Test Video,ark:/21198/zz00000001,ark:/21198/zz00000000,Work,,1,Test Video 1,800,600,,video/ogg,,https://wowza.library.ucla.edu/video/1
+Test Video,ark:/21198/zz00000001,ark:/21198/zz00000000,Work,,1,Test Video 1,800,600,,video/ogg,,https://wowza.library.ucla.edu/iiif_av_public/video/1

--- a/src/test/resources/csv/video/video_missing_metadata.csv
+++ b/src/test/resources/csv/video/video_missing_metadata.csv
@@ -1,3 +1,3 @@
-Project Name,Item ARK,Parent ARK,Object Type,File Name,Item Sequence,Title,media.width,media.height,media.duration,media.format,Bucketeer State,IIIF Access URL,AV Access URL
-Test Video,ark:/21198/zz00000000,,Collection,,,Test Video,,,,,succeeded,,
-Test Video,ark:/21198/zz00000001,ark:/21198/zz00000000,Work,,1,Test Video 1,800,600,,video/ogg,,,https://wowza.library.ucla.edu/video/1
+Project Name,Item ARK,Parent ARK,Object Type,File Name,Item Sequence,Title,media.width,media.height,media.duration,media.format,Bucketeer State,IIIF Access URL
+Test Video,ark:/21198/zz00000000,,Collection,,,Test Video,,,,,succeeded,
+Test Video,ark:/21198/zz00000001,ark:/21198/zz00000000,Work,,1,Test Video 1,800,600,,video/ogg,,https://wowza.library.ucla.edu/video/1

--- a/src/test/resources/csv/video/video_mpd.csv
+++ b/src/test/resources/csv/video/video_mpd.csv
@@ -1,3 +1,3 @@
-Project Name,Item ARK,Parent ARK,Object Type,File Name,Item Sequence,Title,media.width,media.height,media.duration,media.format,Bucketeer State,IIIF Access URL,AV Access URL
-Test Video,ark:/21198/zz00000000,,Collection,,,Test Video,,,,,succeeded,,
-Test Video,ark:/21198/zz00000001,ark:/21198/zz00000000,Work,,1,Texas Chainsaw Massacre,720,540,5021,video/mp4,,,https://test-wowza.library.ucla.edu/iiif_av_public/mp4:woolseytexaschainsawmassacre.mp4/manifest.mpd
+Project Name,Item ARK,Parent ARK,Object Type,File Name,Item Sequence,Title,media.width,media.height,media.duration,media.format,Bucketeer State,IIIF Access URL
+Test Video,ark:/21198/zz00000000,,Collection,,,Test Video,,,,,succeeded,
+Test Video,ark:/21198/zz00000001,ark:/21198/zz00000000,Work,,1,Texas Chainsaw Massacre,720,540,5021,video/mp4,,https://wowza.library.ucla.edu/iiif_av_public/mp4:woolseytexaschainsawmassacre.mp4/manifest.mpd

--- a/src/test/resources/json/v3/audio.json
+++ b/src/test/resources/json/v3/audio.json
@@ -28,7 +28,7 @@
           "motivation" : "painting",
           "body" : {
             "type" : "Sound",
-            "id" : "https://fixtures.iiif.io/audio/indiana/mahler-symphony-3/CD1/medium/128Kbps.mp4",
+            "id" : "https://wowza.library.ucla.edu/iiif_av_public/audio/indiana/mahler-symphony-3/CD1/medium/128Kbps.mp4",
             "format" : "video/mp4"
           },
           "target" : "http://b1dbe4a0-443c-479f-bf0a-25c352df0d8f.iiif.library.ucla.edu/ark%3A%2F21198%2Fzz00000001/manifest/canvas-wh66"

--- a/src/test/resources/json/v3/video.json
+++ b/src/test/resources/json/v3/video.json
@@ -30,7 +30,7 @@
               "motivation": "painting",
               "body": {
                 "type": "Video",
-                "id": "https://fixtures.iiif.io/video/indiana/30-minute-clock/medium/30-minute-clock.mp4",
+                "id": "https://wowza.library.ucla.edu/iiif_av_public/video/indiana/30-minute-clock/medium/30-minute-clock.mp4",
                 "format": "video/mp4"
               },
               "target": "http://b1dbe4a0-443c-479f-bf0a-25c352df0d8f.iiif.library.ucla.edu/ark%3A%2F21198%2Fzz00000001/manifest/canvas-wx3d"

--- a/src/test/resources/json/v3/video_mpd.json
+++ b/src/test/resources/json/v3/video_mpd.json
@@ -30,7 +30,7 @@
               "motivation": "painting",
               "body": {
                 "type": "Video",
-                "id": "https://test-wowza.library.ucla.edu/iiif_av_public/mp4:woolseytexaschainsawmassacre.mp4/manifest.mpd",
+                "id": "https://wowza.library.ucla.edu/iiif_av_public/mp4:woolseytexaschainsawmassacre.mp4/manifest.mpd",
                 "format": "application/dash+xml"
               },
               "target": "http://b1dbe4a0-443c-479f-bf0a-25c352df0d8f.iiif.library.ucla.edu/ark%3A%2F21198%2Fzz00000001/manifest/canvas-s39o"

--- a/src/test/resources/test-config.properties
+++ b/src/test/resources/test-config.properties
@@ -22,5 +22,8 @@ fester.http.port=${fester.http.port}
 # The base URL for the IIIF image service (includes service prefix)
 iiif.base.url=${iiif.base.url}
 
+# String that should be present in A/V access URLs
+fester.av.string=${fester.av.string}
+
 # The version of Festerize that is compatible with this version of Fester
 festerize.version=${festerize.version}


### PR DESCRIPTION
Updates:
* Removed references to "A/V Access URL"
* Renamed `myAudioVideoAccessUrlIndex` (and related methods) to `myContentAccessUrlIndex`
* Updated `CsvParser` to distinguish between image and A/V URLs in IIIF Access URL field
* Fixed some missing @Test entries in `PostCsvFIT`
* Updated A/V test resources 