### PR TITLE
Update MIME type database so Fester maps .mpd URLs to application/dash+xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -533,6 +533,7 @@
           <runArgs>
             <runArg>-Dvertx-config-path=${project.basedir}/target/test-classes/test-config.properties</runArg>
             <runArg>-Dvertx.logger-delegate-factory-class-name=io.vertx.core.logging.SLF4JLogDelegateFactory</runArg>
+            <runArg>-Dcontent.types.user.table=src/main/docker/configs/content-types.properties</runArg>
           </runArgs>
         </configuration>
       </plugin>
@@ -856,7 +857,6 @@
               <jvmArgs>
                 <jvmArg>-Dvertx.logger-delegate-factory-class-name=io.vertx.core.logging.SLF4JLogDelegateFactory</jvmArg>
                 <jvmArg>-Dvertx-config-path=target/test-classes/test-config.properties</jvmArg>
-                <jvmArg>-Dcontent.types.user.table=src/main/docker/configs/content-types.properties</jvmArg>
               </jvmArgs>
               <debugPort>${fester.debug.port}</debugPort>
             </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
     <ubuntu.tag>20.04</ubuntu.tag>
     <jdk.version>11.0.10+9-0ubuntu1~20.04</jdk.version>
     <python3.version>3.8.2-0ubuntu2</python3.version>
-    <curl.version>7.68.0-1ubuntu2.4</curl.version>
+    <curl.version>7.68.0-1ubuntu2.5</curl.version>
 
     <!-- Application dependencies -->
     <vertx.version>3.9.4</vertx.version>

--- a/pom.xml
+++ b/pom.xml
@@ -533,7 +533,6 @@
           <runArgs>
             <runArg>-Dvertx-config-path=${project.basedir}/target/test-classes/test-config.properties</runArg>
             <runArg>-Dvertx.logger-delegate-factory-class-name=io.vertx.core.logging.SLF4JLogDelegateFactory</runArg>
-            <runArg>-Dcontent.types.user.table=${project.basedir}/src/main/docker/configs/content-types.properties</runArg>
           </runArgs>
         </configuration>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -533,6 +533,7 @@
           <runArgs>
             <runArg>-Dvertx-config-path=${project.basedir}/target/test-classes/test-config.properties</runArg>
             <runArg>-Dvertx.logger-delegate-factory-class-name=io.vertx.core.logging.SLF4JLogDelegateFactory</runArg>
+            <runArg>-Dcontent.types.user.table=${project.basedir}/src/main/docker/configs/content-types.properties</runArg>
           </runArgs>
         </configuration>
       </plugin>
@@ -856,6 +857,7 @@
               <jvmArgs>
                 <jvmArg>-Dvertx.logger-delegate-factory-class-name=io.vertx.core.logging.SLF4JLogDelegateFactory</jvmArg>
                 <jvmArg>-Dvertx-config-path=target/test-classes/test-config.properties</jvmArg>
+                <jvmArg>-Dcontent.types.user.table=src/main/docker/configs/content-types.properties</jvmArg>
               </jvmArgs>
               <debugPort>${fester.debug.port}</debugPort>
             </configuration>
@@ -942,6 +944,7 @@
               <jvmArgs>
                 <jvmArg>-Dvertx.logger-delegate-factory-class-name=io.vertx.core.logging.SLF4JLogDelegateFactory</jvmArg>
                 <jvmArg>-Dvertx-config-path=target/test-classes/test-config.properties</jvmArg>
+                <jvmArg>-Dcontent.types.user.table=src/main/docker/configs/content-types.properties</jvmArg>
               </jvmArgs>
             </configuration>
           </plugin>
@@ -1065,6 +1068,7 @@
                 <fester.url>${fester.url}</fester.url>
                 <fester.http.port>${http.port}</fester.http.port>
                 <vertx-config-path>${project.basedir}/target/test-classes/test-config.properties</vertx-config-path>
+                <content.types.user.table>${project.basedir}/src/main/docker/configs/content-types.properties</content.types.user.table>
               </systemPropertyVariables>
               <argLine>${jacoco.agent.arg}</argLine>
               <skipTests>${skipUTs}</skipTests>

--- a/pom.xml
+++ b/pom.xml
@@ -853,11 +853,6 @@
               </execution>
             </executions>
             <configuration>
-              <verticle>${main.verticle}</verticle>
-              <jvmArgs>
-                <jvmArg>-Dvertx.logger-delegate-factory-class-name=io.vertx.core.logging.SLF4JLogDelegateFactory</jvmArg>
-                <jvmArg>-Dvertx-config-path=target/test-classes/test-config.properties</jvmArg>
-              </jvmArgs>
               <debugPort>${fester.debug.port}</debugPort>
             </configuration>
           </plugin>
@@ -937,15 +932,6 @@
                 </goals>
               </execution>
             </executions>
-            <configuration>
-              <verticle>${main.verticle}</verticle>
-              <redeploy>${live.test.reloads}</redeploy>
-              <jvmArgs>
-                <jvmArg>-Dvertx.logger-delegate-factory-class-name=io.vertx.core.logging.SLF4JLogDelegateFactory</jvmArg>
-                <jvmArg>-Dvertx-config-path=target/test-classes/test-config.properties</jvmArg>
-                <jvmArg>-Dcontent.types.user.table=src/main/docker/configs/content-types.properties</jvmArg>
-              </jvmArgs>
-            </configuration>
           </plugin>
         </plugins>
       </build>

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -23,20 +23,23 @@ COPY docker-entrypoint.sh /usr/local/bin/
 COPY configs/${project.artifactId}.properties.tmpl /etc/${project.artifactId}/${project.artifactId}.properties.tmpl
 COPY configs/${project.artifactId}.properties.default \
     /etc/${project.artifactId}/${project.artifactId}.properties.default
+COPY configs/content-types.properties /etc/${project.artifactId}/content-types.properties
 
 RUN mkdir -p /var/log/${project.artifactId} /var/cache/${project.artifactId} \
     /usr/local/${project.artifactId}/file-uploads /etc/${project.artifactId} \
  && touch /etc/${project.artifactId}/${project.artifactId}.properties \
  && chown -R ${project.artifactId} /var/log/${project.artifactId} /var/cache/${project.artifactId} \
     /usr/local/${project.artifactId}/file-uploads /etc/${project.artifactId} \
-    /etc/${project.artifactId}/${project.artifactId}.properties /usr/local/bin/docker-entrypoint.sh
+    /etc/${project.artifactId}/${project.artifactId}.properties /etc/${project.artifactId}/content-types.properties \
+    /usr/local/bin/docker-entrypoint.sh
 
 USER ${project.artifactId}
 ENTRYPOINT ["docker-entrypoint.sh"]
 ENV CACHE_DIR="-Dvertx.cacheDirBase=/tmp"
 ENV CONFIG_FILE="-Dvertx-config-path=/etc/${project.artifactId}/${project.artifactId}.properties"
+ENV CONTENT_TYPES="-Dcontent.types.user.table=/etc/${project.artifactId}/content-types.properties"
 ENV JAVA_TOOL_OPTIONS="${jdwp.client.config}"
 ENV JAR_PATH="/usr/local/${project.artifactId}/${project.artifactId}-${project.version}.jar"
-CMD ["sh", "-c", "java $CACHE_DIR $CONFIG_FILE -Xmx2g -jar $JAR_PATH $LOGBACK_PATH"]
+CMD ["sh", "-c", "java $CACHE_DIR $CONFIG_FILE $CONTENT_TYPES -Xmx2g -jar $JAR_PATH $LOGBACK_PATH"]
 
 EXPOSE ${fester.http.port}

--- a/src/main/docker/configs/content-types.properties
+++ b/src/main/docker/configs/content-types.properties
@@ -1,0 +1,302 @@
+application/dash+xml: \
+    description=MPEG DASH; \
+    file_extensions=.mpd
+
+application/octet-stream: \
+    description=Generic Binary Stream; \
+    file_extensions=.saveme,.dump,.hqx,.arc,.o,.a,.bin,.exe,.z,.gz
+
+application/oda: \
+    description=ODA Document; \
+    file_extensions=.oda
+
+application/pdf: \
+    description=Adobe PDF Format; \
+    file_extensions=.pdf
+
+application/postscript: \
+    description=Postscript File; \
+    file_extensions=.eps,.ai,.ps; \
+    icon=ps; \
+    action=application; \
+    application=imagetool %s
+
+application/x-bcpio: \
+    description=Old Binary CPIO Archive; \
+    file_extensions=.bcpio; \
+     action=save
+
+application/x-cpio: \
+    description=Unix CPIO Archive; \
+    file_extensions=.cpio; \
+     action=save
+
+application/x-dvi: \
+    description=TeX DVI File; \
+    file_extensions=.dvi; \
+    action=application; \
+    application=xdvi %s
+
+application/x-gtar: \
+    description=Gnu Tar Archive; \
+    file_extensions=.gtar; \
+    icon=tar; \
+    action=save
+
+application/x-hdf: \
+    description=Hierarchical Data Format; \
+    file_extensions=.hdf; \
+    action=save
+
+application/x-latex: \
+    description=LaTeX Source; \
+    file_extensions=.latex
+
+application/xml: \
+    description=XML document; \
+    file_extensions=.xml
+
+application/x-netcdf: \
+    description=Unidata netCDF Data Format; \
+    file_extensions=.nc,.cdf; \
+    action=save
+
+application/x-shar: \
+    description=Shell Archive; \
+    file_extensions=.sh,.shar; \
+    action=save
+
+application/x-sv4cpio: \
+    description=SVR4 CPIO Archive; \
+    file_extensions=.sv4cpio; \
+     action=save
+
+application/x-sv4crc: \
+    description=SVR4 CPIO with CRC; \
+    file_extensions=.sv4crc; \
+     action=save
+
+application/x-tar: \
+    description=Tar Archive; \
+    file_extensions=.tar; \
+    icon=tar; \
+    action=save
+
+application/x-tex: \
+    description=TeX Source; \
+    file_extensions=.tex
+
+application/x-texinfo: \
+    description=Gnu Texinfo; \
+    file_extensions=.texinfo,.texi
+
+application/x-troff: \
+    description=Troff Source; \
+    file_extensions=.t,.tr,.roff; \
+    action=application; \
+    application=xterm -title troff -e sh -c "nroff %s | col | more -w"
+
+application/x-troff-man: \
+    description=Troff Manpage Source; \
+    file_extensions=.man; \
+    action=application; \
+    application=xterm -title troff -e sh -c "nroff -man %s | col | more -w"
+
+application/x-troff-me: \
+    description=Troff ME Macros; \
+    file_extensions=.me; \
+    action=application; \
+    application=xterm -title troff -e sh -c "nroff -me %s | col | more -w"
+
+application/x-troff-ms: \
+    description=Troff MS Macros; \
+    file_extensions=.ms; \
+    action=application; \
+    application=xterm -title troff -e sh -c "nroff -ms %s | col | more -w"
+
+application/x-troff-msvideo: \
+    description=AVI Video; \
+    file_extensions=.avi; \
+    icon=avi
+
+application/x-ustar: \
+    description=US Tar Archive; \
+    file_extensions=.ustar; \
+    action=save
+
+application/x-wais-source: \
+    description=Wais Source; \
+    file_extensions=.src,.wsrc
+
+application/zip: \
+    description=Zip File; \
+    file_extensions=.zip; \
+    icon=zip; \
+    action=save
+
+audio/aac: \
+    description=Advanced Audio Coding Audio; \
+    file_extensions=.aac
+
+audio/basic: \
+    description=Basic Audio; \
+    file_extensions=.snd,.au; \
+    icon=audio; \
+    action=application; \
+    application=audiotool %s
+
+audio/flac: \
+    description=Free Lossless Audio Codec Audio; \
+    file_extensions=.flac
+
+audio/mp4: \
+    description=MPEG-4 Audio; \
+    file_extensions=.m4a
+
+audio/mpeg: \
+    description=MPEG Audio; \
+    file_extensions=.mp2,.mp3
+
+audio/ogg: \
+    description=Ogg Audio; \
+    file_extensions=.oga,.ogg,.opus,.spx
+
+audio/x-aiff: \
+    description=Audio Interchange Format File; \
+    file_extensions=.aifc,.aif,.aiff; \
+    icon=aiff
+
+audio/x-wav: \
+    description=Wav Audio; \
+    file_extensions=.wav; \
+    icon=wav
+
+content/unknown: \
+    description=Unknown Content
+
+image/bmp: \
+    description=Bitmap Image; \
+    file_extensions=.bmp; \
+
+image/gif: \
+    description=GIF Image; \
+    file_extensions=.gif; \
+    icon=gif; \
+    action=browser
+
+image/ief: \
+    description=Image Exchange Format; \
+    file_extensions=.ief
+
+image/jpeg: \
+    description=JPEG Image; \
+    file_extensions=.jfif,.jfif-tbnl,.jpe,.jpg,.jpeg; \
+    icon=jpeg; \
+    action=browser; \
+    application=imagetool %s
+
+image/png: \
+    description=PNG Image; \
+    file_extensions=.png; \
+    icon=png; \
+    action=browser
+
+image/svg+xml: \
+    description=Scalable Vector Graphics; \
+    file_extensions=.svg,.svgz
+
+image/tiff: \
+    description=TIFF Image; \
+    file_extensions=.tif,.tiff; \
+    icon=tiff
+
+image/vnd.fpx: \
+    description=FlashPix Image; \
+    file_extensions=.fpx,.fpix
+
+image/x-cmu-rast: \
+    description=CMU Raster Image; \
+    file_extensions=.ras
+
+image/x-portable-anymap: \
+    description=PBM Anymap Format; \
+    file_extensions=.pnm
+
+image/x-portable-bitmap: \
+    description=PBM Bitmap Format; \
+    file_extensions=.pbm
+
+image/x-portable-graymap: \
+    description=PBM Graymap Format; \
+    file_extensions=.pgm
+
+image/x-portable-pixmap: \
+    description=PBM Pixmap Format; \
+    file_extensions=.ppm
+
+image/x-rgb: \
+    description=RGB Image; \
+    file_extensions=.rgb
+
+image/x-xbitmap: \
+    description=X Bitmap Image; \
+    file_extensions=.xbm,.xpm
+
+image/x-xwindowdump: \
+    description=X Window Dump Image; \
+    file_extensions=.xwd
+
+message/rfc822: \
+    description=Internet Email Message; \
+    file_extensions=.mime
+
+temp.file.template: /tmp/%s
+
+text/html: \
+    description=HTML Document; \
+    file_extensions=.htm,.html; \
+    icon=html
+
+text/plain: \
+    description=Plain Text; \
+    file_extensions=.text,.c,.cc,.c++,.h,.pl,.txt,.java,.el; \
+    icon=text; \
+    action=browser
+
+text/tab-separated-values: \
+    description=Tab Separated Values Text; \
+    file_extensions=.tsv
+
+text/x-setext: \
+    description=Structure Enhanced Text; \
+    file_extensions=.etx
+
+unknown/unknown: \
+    description=Unknown Data Type
+
+video/mp4: \
+    description=MPEG-4 Video; \
+    file_extensions=.m4v,.mp4
+
+video/mpeg: \
+    description=MPEG Video Clip; \
+    file_extensions=.mpg,.mpe,.mpeg; \
+    icon=mpeg; \
+    action=application; \
+    application=mpeg_play %s
+
+video/ogg: \
+    description=Ogg Video; \
+    file_extensions=.ogv
+
+video/quicktime: \
+    description=QuickTime Video Clip; \
+    file_extensions=.mov,.qt
+
+video/webm: \
+    description=WebM Video; \
+    file_extensions=.webm
+
+video/x-sgi-movie: \
+    description=SGI Movie; \
+    file_extensions=.movie,.mv

--- a/src/test/java/edu/ucla/library/iiif/fester/utils/TestUtils.java
+++ b/src/test/java/edu/ucla/library/iiif/fester/utils/TestUtils.java
@@ -44,6 +44,11 @@ public final class TestUtils {
     /**
      * Determines if the given manifests are effectively equal.
      *
+     * Note that this method does not consider integers and their corresponding floating point representations to be
+     * equal (e.g., 60 != 60.0), so any JSON test fixtures with integral duration values should be modified so that they
+     * all have a ".0" appended to the end of the value. For example, <code>"duration": 60</code> should be changed to
+     * <code>"duration": 60.0</code>.
+     *
      * @param aManifestArray An array of IIIF manifests
      * @return true if they are all equal after "de-randomizing" IIIF resource IDs, false otherwise
      */

--- a/src/test/resources/csv/video/video_mpd.csv
+++ b/src/test/resources/csv/video/video_mpd.csv
@@ -1,0 +1,3 @@
+Project Name,Item ARK,Parent ARK,Object Type,File Name,Item Sequence,Title,media.width,media.height,media.duration,media.format,Bucketeer State,IIIF Access URL,AV Access URL
+Test Video,ark:/21198/zz00000000,,Collection,,,Test Video,,,,,succeeded,,
+Test Video,ark:/21198/zz00000001,ark:/21198/zz00000000,Work,,1,Texas Chainsaw Massacre,720,540,5021,video/mp4,,,https://test-wowza.library.ucla.edu/iiif_av_public/mp4:woolseytexaschainsawmassacre.mp4/manifest.mpd

--- a/src/test/resources/json/v3/video_mpd.json
+++ b/src/test/resources/json/v3/video_mpd.json
@@ -1,0 +1,43 @@
+{
+  "@context": "http://iiif.io/api/presentation/3/context.json",
+  "type": "Manifest",
+  "id": "http://b1dbe4a0-443c-479f-bf0a-25c352df0d8f.iiif.library.ucla.edu/ark%3A%2F21198%2Fzz00000001/manifest",
+  "label": {
+    "none": [
+      "Texas Chainsaw Massacre"
+    ]
+  },
+  "items": [
+    {
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Texas Chainsaw Massacre"
+        ]
+      },
+      "id": "http://b1dbe4a0-443c-479f-bf0a-25c352df0d8f.iiif.library.ucla.edu/ark%3A%2F21198%2Fzz00000001/manifest/canvas-s39o",
+      "width": 720,
+      "height": 540,
+      "duration": 5021.0,
+      "items": [
+        {
+          "type": "AnnotationPage",
+          "id": "http://b1dbe4a0-443c-479f-bf0a-25c352df0d8f.iiif.library.ucla.edu/ark%3A%2F21198%2Fzz00000001/manifest/canvas-s39o/anno-page-u590",
+          "items": [
+            {
+              "type": "Annotation",
+              "id": "http://b1dbe4a0-443c-479f-bf0a-25c352df0d8f.iiif.library.ucla.edu/ark%3A%2F21198%2Fzz00000001/manifest/annotations/anno-g334",
+              "motivation": "painting",
+              "body": {
+                "type": "Video",
+                "id": "https://test-wowza.library.ucla.edu/iiif_av_public/mp4:woolseytexaschainsawmassacre.mp4/manifest.mpd",
+                "format": "application/dash+xml"
+              },
+              "target": "http://b1dbe4a0-443c-479f-bf0a-25c352df0d8f.iiif.library.ucla.edu/ark%3A%2F21198%2Fzz00000001/manifest/canvas-s39o"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Changes:
- add a custom `content-types.properties` file that adds the MPEG DASH (`application/dash+xml`) type to the OpenJDK 11 MIME type database
  - the existing database was retrieved with the Eclipse debugger; I set a breakpoint in the `sun.net.www.MimeTable` class where it loads the database into a Properties object, which I then serialized, and put into the aforementioned file along with a new entry for the MPEG DASH type
- add a test to confirm that Fester recognizes `.mpd` URLs as MPEG DASH

One thing I'm not sure about is if `src/main/docker/configs` is the right place for this file.