### PR TITLE
[IIIF-1145] Handle fails on CheckEndpointsHandlerTest better

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,6 @@ jobs:
           maven_profiles: default
           maven_args: >
             -V -ntp -Dorg.slf4j.simpleLogger.log.net.sourceforge.pmd=error -DlogLevel=DEBUG -DtestLogLevel=DEBUG
-            -Dfester.s3.access_key="${{ secrets.AWS_ACCESS_KEY }}"
-            -Dfester.s3.secret_key="${{ secrets.AWS_SECRET_KEY }}"
+            -Dfester.s3.access_key="${{ secrets.AWS_ACCESS_KEY }}" -Dsurefire.skipAfterFailureCount=1
+            -Dfester.s3.secret_key="${{ secrets.AWS_SECRET_KEY }}" -Dfailsafe.skipAfterFailureCount=1
             -Dfester.s3.bucket="${{ secrets.S3_BUCKET }}"

--- a/src/main/resources/fester_messages.xml
+++ b/src/main/resources/fester_messages.xml
@@ -187,4 +187,5 @@
   <entry key="MFS-174">Found item '{}' with format '{}' in CSV '{}', but is missing either duration or A/V access URL</entry>
   <entry key="MFS-175">Found item '{}' with format '{}' in CSV '{}', but it has either height or width, unnecessary for audio content</entry>
   <entry key="MFS-176">Found item '{}' with format '{}' in CSV '{}', but the access url has not been processed for Wowza</entry>
+  <entry key="MFS-177">Test server was responsive: {}</entry>
 </properties>

--- a/src/test/java/edu/ucla/library/iiif/fester/handlers/AbstractFesterHandlerTest.java
+++ b/src/test/java/edu/ucla/library/iiif/fester/handlers/AbstractFesterHandlerTest.java
@@ -173,16 +173,8 @@ abstract class AbstractFesterHandlerTest {
                                 if (fakeDeployment.succeeded()) {
                                     final int testPort = aOpts.getConfig().getInteger(Config.HTTP_PORT);
 
+                                    // Server checker doesn't close the test task until the server is responding
                                     new ServerChecker(testPort, aAsyncTask).run();
-                                    // Give our server a bit more startup time for GitHub Actions
-                                    // FIXME: this is a workaround for another bug that we haven't fount yet
-                                    // try {
-                                    // Thread.sleep(10000);
-                                    // } catch (final InterruptedException details) {
-                                    // System.err.println(details);
-                                    // }
-                                    //
-                                    // aAsyncTask.complete();
                                 } else {
                                     aContext.fail(fakeDeployment.cause());
                                 }

--- a/src/test/java/edu/ucla/library/iiif/fester/handlers/AbstractFesterHandlerTest.java
+++ b/src/test/java/edu/ucla/library/iiif/fester/handlers/AbstractFesterHandlerTest.java
@@ -9,6 +9,7 @@ import java.util.regex.Pattern;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.runner.RunWith;
 
 import com.amazonaws.SdkClientException;
@@ -40,10 +41,14 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.shareddata.LocalMap;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.Timeout;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 
 @RunWith(VertxUnitRunner.class)
 abstract class AbstractFesterHandlerTest {
+
+    @Rule
+    public Timeout myTestTimeout = Timeout.seconds(300);
 
     protected static final String IIIF_URL = "http://0.0.0.0";
 

--- a/src/test/java/edu/ucla/library/iiif/fester/handlers/AbstractFesterHandlerTest.java
+++ b/src/test/java/edu/ucla/library/iiif/fester/handlers/AbstractFesterHandlerTest.java
@@ -48,7 +48,7 @@ import io.vertx.ext.unit.junit.VertxUnitRunner;
 abstract class AbstractFesterHandlerTest {
 
     @Rule
-    public Timeout myTestTimeout = Timeout.seconds(300);
+    public Timeout myTestTimeout = Timeout.seconds(600);
 
     protected static final String IIIF_URL = "http://0.0.0.0";
 

--- a/src/test/java/edu/ucla/library/iiif/fester/handlers/AbstractFesterHandlerTest.java
+++ b/src/test/java/edu/ucla/library/iiif/fester/handlers/AbstractFesterHandlerTest.java
@@ -47,9 +47,6 @@ import io.vertx.ext.unit.junit.VertxUnitRunner;
 @RunWith(VertxUnitRunner.class)
 abstract class AbstractFesterHandlerTest {
 
-    @Rule
-    public Timeout myTestTimeout = Timeout.seconds(600);
-
     protected static final String IIIF_URL = "http://0.0.0.0";
 
     protected static final File V2_MANIFEST_FILE =
@@ -59,6 +56,9 @@ abstract class AbstractFesterHandlerTest {
         new File("src/test/resources/json/v2/ark%3A%2F21198%2Fzz0009gsq9.json");
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AbstractFesterHandlerTest.class, Constants.MESSAGES);
+
+    @Rule
+    public Timeout myTestTimeout = Timeout.seconds(600);
 
     protected Vertx myVertx;
 

--- a/src/test/java/edu/ucla/library/iiif/fester/utils/ServerChecker.java
+++ b/src/test/java/edu/ucla/library/iiif/fester/utils/ServerChecker.java
@@ -1,0 +1,61 @@
+
+package edu.ucla.library.iiif.fester.utils;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+import info.freelibrary.util.Logger;
+import info.freelibrary.util.LoggerFactory;
+import info.freelibrary.util.StringUtils;
+
+import edu.ucla.library.iiif.fester.MessageCodes;
+
+import io.vertx.ext.unit.Async;
+
+/**
+ * A checker to confirm that our server has been started.
+ */
+public class ServerChecker implements Runnable {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ServerChecker.class, MessageCodes.BUNDLE);
+
+    private static final String URL = "http://0.0.0.0:{}/fester/status";
+
+    private final Async myAsyncTask;
+
+    private final int myPort;
+
+    /**
+     * Creates a new server checker.
+     *
+     * @param aPort A port on which to check for the server
+     * @param aAsyncTask A testing task to complete when the server is up
+     */
+    public ServerChecker(final int aPort, final Async aAsyncTask) {
+        myAsyncTask = aAsyncTask;
+        myPort = aPort;
+    }
+
+    @Override
+    public void run() {
+        while (!myAsyncTask.isCompleted()) { // Without completing the test will eventually time out
+            try {
+                final URL url = new URL(StringUtils.format(URL, myPort));
+                final HttpURLConnection http = (HttpURLConnection) url.openConnection();
+                final int responseCode;
+
+                http.setRequestMethod("GET");
+                http.connect();
+                responseCode = http.getResponseCode();
+
+                LOGGER.debug("Found the server: {}", responseCode);
+                myAsyncTask.complete();
+                http.disconnect();
+            } catch (final IOException details) {
+                LOGGER.error(details.getMessage());
+            }
+        }
+    }
+
+}

--- a/src/test/java/edu/ucla/library/iiif/fester/utils/ServerChecker.java
+++ b/src/test/java/edu/ucla/library/iiif/fester/utils/ServerChecker.java
@@ -11,10 +11,11 @@ import info.freelibrary.util.StringUtils;
 
 import edu.ucla.library.iiif.fester.MessageCodes;
 
+import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.unit.Async;
 
 /**
- * A checker to confirm that our server has been started.
+ * A test utility that confirms our server has been started before completing the set up process.
  */
 public class ServerChecker implements Runnable {
 
@@ -37,23 +38,25 @@ public class ServerChecker implements Runnable {
         myPort = aPort;
     }
 
+    /**
+     * Checks that the server is up and responsive.
+     */
     @Override
     public void run() {
-        while (!myAsyncTask.isCompleted()) { // Without completing the test will eventually time out
+        while (!myAsyncTask.isCompleted()) { // Without completing, the test will eventually time out
             try {
                 final URL url = new URL(StringUtils.format(URL, myPort));
                 final HttpURLConnection http = (HttpURLConnection) url.openConnection();
-                final int responseCode;
 
-                http.setRequestMethod("GET");
+                http.setRequestMethod(HttpMethod.GET.name());
                 http.connect();
-                responseCode = http.getResponseCode();
 
-                LOGGER.debug("Found the server: {}", responseCode);
-                myAsyncTask.complete();
+                LOGGER.debug(MessageCodes.MFS_177, http.getResponseCode());
+
                 http.disconnect();
+                myAsyncTask.complete();
             } catch (final IOException details) {
-                LOGGER.error(details.getMessage());
+                // I don't think we care how many times we tried(?)
             }
         }
     }


### PR DESCRIPTION
Catch test fails on CheckEndpointsHandlerTest. There may be several commits incoming as we try to figure out why Actions is failing (while things run successfully locally).