### PR TITLE
Store our A/V thumbnail URLs in Docker env instead of hard-coding

### DIFF
--- a/src/main/docker/configs/fester.properties.default
+++ b/src/main/docker/configs/fester.properties.default
@@ -32,10 +32,10 @@ AV_URL_STRING=https://wowza.library.ucla.edu/iiif_av_public/
 AV_EXTS=/manifest.mpd,/playlist.m3u8
 
 # The URL of the default thumbnail image for Canvases with Sound content
-AV_DEFAULT_AUDIO_THUMBNAIL_URL=https://prod-uclalibrary-resources.s3-us-west-2.amazonaws.com/audio_icon.svg
+AV_DEFAULT_AUDIO_THUMBNAIL_URL=
 
 # The URL of the default thumbnail image for Canvases with Video content
-AV_DEFAULT_VIDEO_THUMBNAIL_URL=https://prod-uclalibrary-resources.s3-us-west-2.amazonaws.com/video_icon.svg
+AV_DEFAULT_VIDEO_THUMBNAIL_URL=
 
 # The version of Festerize that is compatible with this version of Fester
 FESTERIZE_VERSION=

--- a/src/main/docker/configs/fester.properties.default
+++ b/src/main/docker/configs/fester.properties.default
@@ -32,10 +32,10 @@ AV_URL_STRING=https://wowza.library.ucla.edu/iiif_av_public/
 AV_EXTS=/manifest.mpd,/playlist.m3u8
 
 # The URL of the default thumbnail image for Canvases with Sound content
-AV_DEFAULT_AUDIO_THUMBNAIL_URL=
+AV_DEFAULT_AUDIO_THUMBNAIL_URL=https://prod-uclalibrary-resources.s3-us-west-2.amazonaws.com/audio_icon.svg
 
 # The URL of the default thumbnail image for Canvases with Video content
-AV_DEFAULT_VIDEO_THUMBNAIL_URL=
+AV_DEFAULT_VIDEO_THUMBNAIL_URL=https://prod-uclalibrary-resources.s3-us-west-2.amazonaws.com/video_icon.svg
 
 # The version of Festerize that is compatible with this version of Fester
 FESTERIZE_VERSION=

--- a/src/main/java/edu/ucla/library/iiif/fester/Constants.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/Constants.java
@@ -295,18 +295,6 @@ public final class Constants {
     public static final String DEFAULT_AV_STRING = "mp4";
 
     /**
-     * The default thumbnail for audio content.
-     */
-    public static final String UCLA_AUDIO_THUMBNAIL =
-            "https://prod-uclalibrary-resources.s3-us-west-2.amazonaws.com/audio_icon.svg";
-
-    /**
-     * The default thumbnail for video content.
-     */
-    public static final String UCLA_VIDEO_THUMBNAIL =
-            "https://prod-uclalibrary-resources.s3-us-west-2.amazonaws.com/video_icon.svg";
-
-    /**
      * Private constructor for Constants class.
      */
     private Constants() {

--- a/src/main/java/edu/ucla/library/iiif/fester/verticles/V3ManifestVerticle.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/verticles/V3ManifestVerticle.java
@@ -435,7 +435,7 @@ public class V3ManifestVerticle extends AbstractFesterVerticle {
             final String encodedPageID = URLEncoder.encode(pageID, StandardCharsets.UTF_8);
             final Canvas canvas = new Canvas(aMinter, pageLabel);
             final String pageURI;
-            final String thumbnail;
+            final String thumbnailURI;
             final int width;
             final int height;
             final float duration;
@@ -445,28 +445,30 @@ public class V3ManifestVerticle extends AbstractFesterVerticle {
                 final String resourceURI = CsvParser.getMetadata(columns, aCsvHeaders.getContentAccessUrlIndex()).get();
                 final VideoContent[] videos = getVideoContent(resourceURI);
 
-                thumbnail = StringUtils.trimTo(config().getString(Config.DEFAULT_VIDEO_THUMBNAIL),
-                        Constants.UCLA_VIDEO_THUMBNAIL);
+                thumbnailURI = config().getString(Config.DEFAULT_VIDEO_THUMBNAIL);
 
                 // We've already validated these numeric values in CsvParser
                 width = Integer.parseInt(CsvParser.getMetadata(columns, aCsvHeaders.getMediaWidthIndex()).get());
                 height = Integer.parseInt(CsvParser.getMetadata(columns, aCsvHeaders.getMediaHeightIndex()).get());
                 duration = Float.parseFloat(CsvParser.getMetadata(columns, aCsvHeaders.getMediaDurationIndex()).get());
 
-                canvas.setWidthHeight(width, height).setDuration(duration).setThumbnails(new ImageContent(thumbnail));
-                canvas.paintWith(aMinter, videos);
+                if (thumbnailURI != null) {
+                    canvas.setThumbnails(new ImageContent(thumbnailURI));
+                }
+                canvas.setWidthHeight(width, height).setDuration(duration).paintWith(aMinter, videos);
             } else if (format.isPresent() && format.get().contains("audio/")) {
                 final String resourceURI = CsvParser.getMetadata(columns, aCsvHeaders.getContentAccessUrlIndex()).get();
                 final SoundContent[] audios = getSoundContent(resourceURI);
 
-                thumbnail = StringUtils.trimTo(config().getString(Config.DEFAULT_AUDIO_THUMBNAIL),
-                        Constants.UCLA_AUDIO_THUMBNAIL);
+                thumbnailURI = config().getString(Config.DEFAULT_AUDIO_THUMBNAIL);
 
                 // We've already validated this numeric value in CsvParser
                 duration = Float.parseFloat(CsvParser.getMetadata(columns, aCsvHeaders.getMediaDurationIndex()).get());
 
-                canvas.setDuration(duration).setThumbnails(new ImageContent(thumbnail));
-                canvas.paintWith(aMinter, audios);
+                if (thumbnailURI != null) {
+                    canvas.setThumbnails(new ImageContent(thumbnailURI));
+                }
+                canvas.setDuration(duration).paintWith(aMinter, audios);
             } else {
                 String resourceURI;
                 ImageContent image;


### PR DESCRIPTION
I figured I'd make these changes we've discussed today while I was thinking about it. The behavior is the same as before, except these changes would allow someone using this app to omit thumbnails from A/V canvases, if desired, by removing the URLs from the Docker config.