### PR TITLE
[IIIF-1059]  Added MB to /fester/status return values

### DIFF
--- a/src/main/java/edu/ucla/library/iiif/fester/handlers/GetStatusHandler.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/handlers/GetStatusHandler.java
@@ -26,6 +26,8 @@ public class GetStatusHandler implements Handler<RoutingContext> {
 
     private static final double ERROR_PERCENT = 95.0D;
 
+    private static final String MB_STR = " MB";
+
     @Override
     public void handle(final RoutingContext aContext) {
         final HttpServerResponse response = aContext.response();
@@ -38,6 +40,9 @@ public class GetStatusHandler implements Handler<RoutingContext> {
             final long usedMem = totalMem - freeMem;
             final double percentMem = (double) usedMem / (double) totalMem * 100D;
             final JsonObject memory = new JsonObject();
+            final String totalMemStr = String.valueOf(totalMem) + MB_STR;
+            final String freeMemStr = String.valueOf(freeMem) + MB_STR;
+            final String usedMemStr = String.valueOf(usedMem) + MB_STR;
 
             if (percentMem >= WARN_PERCENT && percentMem < ERROR_PERCENT) {
                 status.put(Status.STATUS, Status.WARN);
@@ -47,8 +52,8 @@ public class GetStatusHandler implements Handler<RoutingContext> {
                 status.put(Status.STATUS, Status.OK);
             }
             status.put(Status.MEMORY, memory);
-            memory.put(Status.TOTAL_MEMORY, totalMem).put(Status.FREE_MEMORY, freeMem).put(Status.USED_MEMORY, usedMem)
-                    .put(Status.PERCENT_MEMORY, percentMem);
+            memory.put(Status.TOTAL_MEMORY, totalMemStr).put(Status.FREE_MEMORY, freeMemStr)
+                .put(Status.USED_MEMORY, usedMemStr).put(Status.PERCENT_MEMORY, percentMem);
 
             response.setStatusCode(200);
             response.putHeader(Constants.CONTENT_TYPE, Constants.JSON_MEDIA_TYPE).end(status.encodePrettily());

--- a/src/test/java/edu/ucla/library/iiif/fester/fit/GetStatusFT.java
+++ b/src/test/java/edu/ucla/library/iiif/fester/fit/GetStatusFT.java
@@ -19,6 +19,7 @@ public class GetStatusFT extends BaseFesterFT {
 
     /* Our status endpoint contains the service name because there are other /status options */
     private static final String API_PATH = "/fester/status";
+    private static final String MB_STR = "MB";
 
     /**
      * Tests the status endpoint.
@@ -34,17 +35,25 @@ public class GetStatusFT extends BaseFesterFT {
                 final JsonObject response = request.result().bodyAsJsonObject();
                 final String status = response.getString(Status.STATUS);
                 final JsonObject memory = response.getJsonObject(Status.MEMORY);
-                final long freeMemory = memory.getLong(Status.FREE_MEMORY);
-                final long totalMemory = memory.getLong(Status.TOTAL_MEMORY);
+                final splitMemInterface x = str -> str.split(" ");
+                final String[] freeMemory = x.splitMem(memory.getString(Status.FREE_MEMORY));
+                final String[] totalMemory = x.splitMem(memory.getString(Status.TOTAL_MEMORY));
+                final String[] usedMemory = x.splitMem(memory.getString(Status.USED_MEMORY));
 
                 aContext.assertEquals(Status.OK, status);
-                aContext.assertTrue(totalMemory > freeMemory);
+                aContext.assertTrue(freeMemory[1].equals(MB_STR) && totalMemory[1].equals(MB_STR)
+                    && usedMemory[1].equals(MB_STR));
 
                 complete(asyncTask);
             } else {
                 aContext.fail(request.cause());
             }
         });
+    }
+
+    @FunctionalInterface
+    interface splitMemInterface{
+        String[] splitMem(String aMemStr);
     }
 
 }


### PR DESCRIPTION
- GetStatusHandler
- converted long memory values into strings with " MB" attached to string 
- changed memory.put to send new string values
-  GetStatusFT
- retrieved string values and used lambda function to split string values where there is a space 
- Check if second word after space in string is "MB" 
*Note 
Ultimately did not use SizeFromBytes in FileUtils because whenever I would use it, GetStatusFT would fail (sometimes it would be GB instead of MB and there isn't a way, at least to my knowledge, to specify MB) 