### PR TITLE
[IIIF-1059] Update status handler with " MB"

### DIFF
--- a/src/main/java/edu/ucla/library/iiif/fester/Constants.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/Constants.java
@@ -7,6 +7,11 @@ package edu.ucla.library.iiif.fester;
 public final class Constants {
 
     /**
+     * The name of a data type
+     */
+    public static final String MB_STR = "MB";
+
+    /**
      * ResourceBundle file name for I18n messages.
      */
     public static final String MESSAGES = "fester_messages";
@@ -96,6 +101,11 @@ public final class Constants {
      * Just a empty string, useful.
      */
     public static final String EMPTY = "";
+
+    /**
+     * Just a space, useful.
+     */
+    public static final String SPACE = " ";
 
     /**
      * A delimiter for use in string parsing.

--- a/src/main/java/edu/ucla/library/iiif/fester/handlers/GetStatusHandler.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/handlers/GetStatusHandler.java
@@ -38,6 +38,10 @@ public class GetStatusHandler implements Handler<RoutingContext> {
             final long usedMem = totalMem - freeMem;
             final double percentMem = (double) usedMem / (double) totalMem * 100D;
             final JsonObject memory = new JsonObject();
+            final String totalMemStr = totalMem + Constants.SPACE + Constants.MB_STR;
+            final String freeMemStr = freeMem + Constants.SPACE + Constants.MB_STR;
+            final String usedMemStr = usedMem + Constants.SPACE + Constants.MB_STR;
+
 
             if (percentMem >= WARN_PERCENT && percentMem < ERROR_PERCENT) {
                 status.put(Status.STATUS, Status.WARN);
@@ -47,8 +51,8 @@ public class GetStatusHandler implements Handler<RoutingContext> {
                 status.put(Status.STATUS, Status.OK);
             }
             status.put(Status.MEMORY, memory);
-            memory.put(Status.TOTAL_MEMORY, totalMem).put(Status.FREE_MEMORY, freeMem).put(Status.USED_MEMORY, usedMem)
-                    .put(Status.PERCENT_MEMORY, percentMem);
+            memory.put(Status.TOTAL_MEMORY, totalMemStr).put(Status.FREE_MEMORY, freeMemStr)
+                .put(Status.USED_MEMORY, usedMemStr).put(Status.PERCENT_MEMORY, percentMem);
 
             response.setStatusCode(200);
             response.putHeader(Constants.CONTENT_TYPE, Constants.JSON_MEDIA_TYPE).end(status.encodePrettily());

--- a/src/test/java/edu/ucla/library/iiif/fester/fit/GetStatusFT.java
+++ b/src/test/java/edu/ucla/library/iiif/fester/fit/GetStatusFT.java
@@ -34,11 +34,13 @@ public class GetStatusFT extends BaseFesterFT {
                 final JsonObject response = request.result().bodyAsJsonObject();
                 final String status = response.getString(Status.STATUS);
                 final JsonObject memory = response.getJsonObject(Status.MEMORY);
-                final long freeMemory = memory.getLong(Status.FREE_MEMORY);
-                final long totalMemory = memory.getLong(Status.TOTAL_MEMORY);
+                final String freeMemory = memory.getString(Status.FREE_MEMORY);
+                final String totalMemory = memory.getString(Status.TOTAL_MEMORY);
+                final String usedMemory = memory.getString(Status.USED_MEMORY);
 
                 aContext.assertEquals(Status.OK, status);
-                aContext.assertTrue(totalMemory > freeMemory);
+                aContext.assertTrue(freeMemory.contains(Constants.MB_STR) &&
+                    totalMemory.contains(Constants.MB_STR) && usedMemory.contains(Constants.MB_STR));
 
                 complete(asyncTask);
             } else {
@@ -46,5 +48,4 @@ public class GetStatusFT extends BaseFesterFT {
             }
         });
     }
-
 }


### PR DESCRIPTION
GetStatusHandler
converted long memory values into strings with " MB" attached to string
changed memory.put to send new string values
GetStatusFT
retrieved string values and used lambda function to split string values where there is a space
Check if second word after space in string is "MB"
*Note
Ultimately did not use SizeFromBytes in FileUtils because whenever I would use it, GetStatusFT would fail (sometimes it would be GB instead of MB and there isn't a way, at least to my knowledge, to specify MB)