### PR TITLE
[SERV-414] Update dependencies for security

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,8 @@
     <alphanumeric.comparator.version>1.4.1</alphanumeric.comparator.version>
 
     <!-- Dependencies pulled out for security reasons -->
-    <jackson.version></jackson.version>
+    <jackson.databind.version>2.12.6.1</jackson.databind.version>
+    <commons.io.version>2.7</commons.io.version>
 
     <!-- Exclusions/Replacements -->
     <snakeyaml.version>1.26</snakeyaml.version>
@@ -257,6 +258,16 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-ext</artifactId>
       <version>${slf4j.ext.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>${jackson.databind.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>${commons.io.version}</version>
     </dependency>
 
     <!-- A Vert.x plug-in for more flexible configuration control -->
@@ -1066,7 +1077,7 @@
               <systemPropertyVariables>
                 <vertx.logger-delegate-factory-class-name>io.vertx.core.logging.SLF4JLogDelegateFactory</vertx.logger-delegate-factory-class-name>
                 <fester.url>${fester.url}</fester.url>
-                <fester.http.port>${http.port}</fester.http.port>
+                <fester.http.port>${http.test.port}</fester.http.port>
                 <vertx-config-path>${project.basedir}/target/test-classes/test-config.properties</vertx-config-path>
               </systemPropertyVariables>
               <argLine>${jacoco.agent.arg}</argLine>
@@ -1251,6 +1262,6 @@
   <parent>
     <artifactId>freelib-parent</artifactId>
     <groupId>info.freelibrary</groupId>
-    <version>6.6.3</version>
+    <version>7.2.2</version>
   </parent>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
     <curl.version>7.68.0-1ubuntu2.7</curl.version>
 
     <!-- Application dependencies -->
-    <vertx.version>3.9.12</vertx.version>
+    <vertx.version>4.2.6</vertx.version>
     <opencsv.version>5.0</opencsv.version>
     <moirai.version>2.0.0</moirai.version>
     <slf4j.ext.version>1.7.32</slf4j.ext.version>
@@ -84,10 +84,14 @@
     <commons.lang.version>3.9</commons.lang.version>
     <freelib.utils.version>3.0.1</freelib.utils.version>
     <freelib.maven.version>0.3.0</freelib.maven.version>
-    <vertx.super.s3.version>1.3.3</vertx.super.s3.version>
+    <vertx.s3.service.version>0.0.0-SNAPSHOT</vertx.s3.service.version>
+    <netty.epoll.version>4.1.59.Final</netty.epoll.version>
     <jiiify.presentation.v2.version>0.5.6</jiiify.presentation.v2.version>
     <jiiify.presentation.v3.version>0.12.0</jiiify.presentation.v3.version>
     <alphanumeric.comparator.version>1.4.1</alphanumeric.comparator.version>
+
+    <!-- Dependencies pulled out for security reasons -->
+    <jackson.version></jackson.version>
 
     <!-- Exclusions/Replacements -->
     <snakeyaml.version>1.26</snakeyaml.version>
@@ -95,19 +99,18 @@
 
     <!-- Versions of tools used for testing -->
     <jsoup.version>1.14.2</jsoup.version>
-    <aws.sdk.version>1.12.172</aws.sdk.version>
-    <testcontainers.version>1.15.1</testcontainers.version>
+    <aws.sdk.version>1.12.192</aws.sdk.version>
+    <testcontainers.version>1.16.3</testcontainers.version>
     <jcip.annotations.version>1.0-1</jcip.annotations.version>
 
     <!-- Build plug-in versions -->
     <exec.plugin.version>3.0.0</exec.plugin.version>
     <shade.plugin.version>2.4.3</shade.plugin.version>
     <deploy.plugin.version>2.8.2</deploy.plugin.version>
-    <netty.epoll.version>4.1.37.Final</netty.epoll.version>
-    <vertx.plugin.version>1.0.18</vertx.plugin.version>
+    <vertx.plugin.version>1.0.27</vertx.plugin.version>
     <codacy.plugin.version>1.2.0</codacy.plugin.version>
     <xml.maven.plugin.version>1.0.2</xml.maven.plugin.version>
-    <docker.maven.plugin.version>0.33.0</docker.maven.plugin.version>
+    <docker.maven.plugin.version>0.39.1</docker.maven.plugin.version>
 
     <!-- Name of the main Vert.x verticle -->
     <main.verticle>edu.ucla.library.iiif.fester.verticles.MainVerticle</main.verticle>
@@ -274,8 +277,8 @@
     </dependency>
     <dependency>
       <groupId>info.freelibrary</groupId>
-      <artifactId>vertx-super-s3</artifactId>
-      <version>${vertx.super.s3.version}</version>
+      <artifactId>vertx-s3-service</artifactId>
+      <version>${vertx.s3.service.version}</version>
     </dependency>
     <dependency>
       <groupId>com.opencsv</groupId>
@@ -618,7 +621,7 @@
                   <exclude>info.freelibrary:jiiify-presentation-v2</exclude>
                   <exclude>info.freelibrary:jiiify-presentation-v3</exclude>
                   <exclude>info.freelibrary:vertx-pairtree</exclude>
-                  <exclude>info.freelibrary:vertx-super-s3</exclude>
+                  <exclude>info.freelibrary:vertx-s3-service</exclude>
                   <exclude>io.netty:netty-buffer</exclude>
                   <exclude>io.netty:netty-codec-dns</exclude>
                   <exclude>io.netty:netty-codec-http2</exclude>
@@ -648,8 +651,10 @@
                   <exclude>io.swagger:swagger-parser</exclude>
                   <exclude>io.vertx:vertx-auth-common</exclude>
                   <exclude>io.vertx:vertx-bridge-common</exclude>
+                  <exclude>io.vertx:vertx-codegen</exclude>
                   <exclude>io.vertx:vertx-config</exclude>
                   <exclude>io.vertx:vertx-core</exclude>
+                  <exclude>io.vertx:vertx-service-proxy</exclude>
                   <exclude>io.vertx:vertx-web-api-contract</exclude>
                   <exclude>io.vertx:vertx-web-client</exclude>
                   <exclude>io.vertx:vertx-web-common</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -79,19 +79,16 @@
     <vertx.version>4.2.6</vertx.version>
     <opencsv.version>5.0</opencsv.version>
     <moirai.version>2.0.0</moirai.version>
-    <slf4j.ext.version>1.7.32</slf4j.ext.version>
     <jcl.over.slf4j.version>1.7.32</jcl.over.slf4j.version>
     <commons.lang.version>3.9</commons.lang.version>
     <freelib.utils.version>3.0.1</freelib.utils.version>
-    <freelib.maven.version>0.3.0</freelib.maven.version>
-    <vertx.s3.service.version>0.0.0-SNAPSHOT</vertx.s3.service.version>
+    <vertx.s3.service.version>2.0.0-alpha-1</vertx.s3.service.version>
     <netty.epoll.version>4.1.59.Final</netty.epoll.version>
-    <jiiify.presentation.v2.version>0.5.6</jiiify.presentation.v2.version>
+    <jiiify.presentation.v2.version> 0.5.7</jiiify.presentation.v2.version>
     <jiiify.presentation.v3.version>0.12.0</jiiify.presentation.v3.version>
     <alphanumeric.comparator.version>1.4.1</alphanumeric.comparator.version>
 
     <!-- Dependencies pulled out for security reasons -->
-    <jackson.databind.version>2.12.6.1</jackson.databind.version>
     <commons.io.version>2.7</commons.io.version>
 
     <!-- Exclusions/Replacements -->
@@ -255,16 +252,6 @@
 
     <!-- Below is a dependency that needs updating due to security issue (may be able to remove in future) -->
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-ext</artifactId>
-      <version>${slf4j.ext.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-databind</artifactId>
-      <version>${jackson.databind.version}</version>
-    </dependency>
-    <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
       <version>${commons.io.version}</version>
@@ -424,7 +411,6 @@
       <plugin>
         <groupId>info.freelibrary</groupId>
         <artifactId>freelib-maven-plugins</artifactId>
-        <version>${freelib.maven.version}</version>
         <executions>
           <execution>
             <phase>process-resources</phase>

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -24,16 +24,16 @@ COPY configs/${project.artifactId}.properties.tmpl /etc/${project.artifactId}/${
 COPY configs/${project.artifactId}.properties.default \
     /etc/${project.artifactId}/${project.artifactId}.properties.default
 
-RUN mkdir -p /var/log/${project.artifactId} /var/cache/${project.artifactId} \
+RUN mkdir -p /var/log/${project.artifactId} /var/cache/${project.artifactId} /tmp/vertx-cache \
     /usr/local/${project.artifactId}/file-uploads /etc/${project.artifactId} \
  && touch /etc/${project.artifactId}/${project.artifactId}.properties \
  && chown -R ${project.artifactId} /var/log/${project.artifactId} /var/cache/${project.artifactId} \
-    /usr/local/${project.artifactId}/file-uploads /etc/${project.artifactId} \
+    /usr/local/${project.artifactId}/file-uploads /etc/${project.artifactId} /tmp/vertx-cache \
     /etc/${project.artifactId}/${project.artifactId}.properties /usr/local/bin/docker-entrypoint.sh
 
 USER ${project.artifactId}
 ENTRYPOINT ["docker-entrypoint.sh"]
-ENV CACHE_DIR="-Dvertx.cacheDirBase=/tmp"
+ENV CACHE_DIR="-Dvertx.cacheDirBase=/tmp/vertx-cache"
 ENV CONFIG_FILE="-Dvertx-config-path=/etc/${project.artifactId}/${project.artifactId}.properties"
 ENV JAVA_TOOL_OPTIONS="${jdwp.client.config}"
 ENV JAR_PATH="/usr/local/${project.artifactId}/${project.artifactId}-${project.version}.jar"

--- a/src/main/java/edu/ucla/library/iiif/fester/Config.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/Config.java
@@ -6,61 +6,61 @@ package edu.ucla.library.iiif.fester;
  */
 public final class Config {
 
-    /* Configuration parameter for the URL Fester is available at */
+    /** Configuration parameter for the URL Fester is available at */
     public static final String FESTER_URL = "fester.url";
 
-    /* The HTTP port configuration parameter */
+    /** The HTTP port configuration parameter */
     public static final String HTTP_PORT = "fester.http.port";
 
-    /* The OpenAPI specification configuration parameter */
+    /** The OpenAPI specification configuration parameter */
     public static final String OPENAPI_SPEC_PATH = "openapi.spec.path";
 
-    /* The AWS S3 access key */
+    /** The AWS S3 access key */
     public static final String S3_ACCESS_KEY = "fester.s3.access_key";
 
-    /* The AWS S3 secret key */
+    /** The AWS S3 secret key */
     public static final String S3_SECRET_KEY = "fester.s3.secret_key";
 
-    /* The AWS S3 region used for signing communications */
+    /** The AWS S3 region used for signing communications */
     public static final String S3_REGION = "fester.s3.region";
 
-    /* The AWS S3 bucket into which manifests and collection docs are put */
+    /** The AWS S3 bucket into which manifests and collection docs are put */
     public static final String S3_BUCKET = "fester.s3.bucket";
 
-    /* The base IIIF server URL that is used to get width and height for canvases */
+    /** The base IIIF server URL that is used to get width and height for canvases */
     public static final String IIIF_BASE_URL = "iiif.base.url";
 
-    /* The placeholder image URL, used for images that are missing */
+    /** The placeholder image URL, used for images that are missing */
     public static final String PLACEHOLDER_IMAGE = "fester.placeholder.url";
 
-    /* The S3 endpoint that's used when storing and retrieving manifests */
+    /** The S3 endpoint that's used when storing and retrieving manifests */
     public static final String S3_ENDPOINT = "fester.s3.endpoint";
 
-    /* Config property for turning logs on while running in test mode */
+    /** Config property for turning logs on while running in test mode */
     public static final String LOGS_ON = "fester.logs.output";
 
-    /* A feature flags configuration for the Docker container */
+    /** A feature flags configuration for the Docker container */
     public static final String FEATURE_FLAGS = "feature.flags";
 
-    /* The port a debugger may listen on to debug a containerized Fester instance */
+    /** The port a debugger may listen on to debug a containerized Fester instance */
     public static final String JDWP_HOST_PORT = "jdwp.host.port";
 
-    /* The version of Festerize that is compatible with this version of Fester */
+    /** The version of Festerize that is compatible with this version of Fester */
     public static final String FESTERIZE_VERSION = "festerize.version";
 
-    /* A string to distinguish A/V access URLs from generic IIF access URLs */
+    /** A string to distinguish A/V access URLs from generic IIF access URLs */
     public static final String AV_URL_STRING = "fester.av.string";
 
-    /* The URL of the default thumbnail image for Canvases with Sound content */
+    /** The URL of the default thumbnail image for Canvases with Sound content */
     public static final String DEFAULT_AUDIO_THUMBNAIL = "fester.av.default_audio_thumbnail.url";
 
-    /* The URL of the default thumbnail image for Canvases with Video content */
+    /** The URL of the default thumbnail image for Canvases with Video content */
     public static final String DEFAULT_VIDEO_THUMBNAIL = "fester.av.default_video_thumbnail.url";
 
-    /* A string for different manifest versions which will be appended onto the generic AV_URL_STRING */
+    /** A string for different manifest versions which will be appended onto the generic AV_URL_STRING */
     public static final String AV_URL_EXTENSIONS = "fester.av.string.exts";
 
-    /* A string specifying the default IIIF Image API 2 size parameter to use for thumbnail IDs */
+    /** A string specifying the default IIIF Image API 2 size parameter to use for thumbnail IDs */
     @SuppressWarnings({ "PMD.LongVariable" })
     public static final String DEFAULT_IMAGE_THUMBNAIL_SIZE = "fester.default_image_thumbnail.size";
 

--- a/src/main/java/edu/ucla/library/iiif/fester/Constants.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/Constants.java
@@ -19,6 +19,7 @@ public final class Constants {
     /**
      * The IP for an unspecified host.
      */
+    @SuppressWarnings("PMD.AvoidUsingHardCodedIP")
     public static final String UNSPECIFIED_HOST = "0.0.0.0";
 
     /**

--- a/src/main/java/edu/ucla/library/iiif/fester/CsvHeaders.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/CsvHeaders.java
@@ -1,5 +1,5 @@
 
-package edu.ucla.library.iiif.fester;
+package edu.ucla.library.iiif.fester; // NOPMD - ExcessivePublicCount
 
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -11,6 +11,7 @@ import io.vertx.core.json.JsonObject;
 /**
  * The CSV file's headers.
  */
+@SuppressWarnings({ "PMD.TooManyMethods", "PMD.TooManyFields" })
 public class CsvHeaders {
 
     /**
@@ -103,7 +104,8 @@ public class CsvHeaders {
      *
      * @param aRow CSV header data
      */
-    public CsvHeaders(final String[] aRow) {
+    @SuppressWarnings("PMD.CyclomaticComplexity")
+    public CsvHeaders(final String... aRow) {
         for (int index = 0; index < aRow.length; index++) {
 
             // Trim whitespace before attempting to match

--- a/src/main/java/edu/ucla/library/iiif/fester/CsvMetadata.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/CsvMetadata.java
@@ -12,10 +12,13 @@ import java.util.Optional;
  */
 public class CsvMetadata {
 
+    /** A map of CSV works. */
     private final Map<String, List<String[]>> myWorksMap;
 
+    /** A map of CSV pages. */
     private final Map<String, List<String[]>> myPagesMap;
 
+    /** A list of works from the CSV. */
     private final List<String[]> myWorksList;
 
     /**
@@ -56,7 +59,7 @@ public class CsvMetadata {
      * @return True if our metadata has works; else, false
      */
     public boolean hasWorks() {
-        return myWorksList.size() > 0;
+        return !myWorksList.isEmpty();
     }
 
     /**
@@ -68,9 +71,9 @@ public class CsvMetadata {
     public Optional<String> getFirstCollectionID(final int aIndex) {
         if (hasWorks()) {
             return Optional.ofNullable(myWorksList.get(0)[aIndex]);
-        } else {
-            return Optional.empty();
         }
+
+        return Optional.empty();
     }
 
     /**
@@ -88,7 +91,7 @@ public class CsvMetadata {
      * @return True if pages are found; else, false
      */
     public boolean hasPages() {
-        return myPagesMap.size() > 0;
+        return !myPagesMap.isEmpty();
     }
 
     /**

--- a/src/main/java/edu/ucla/library/iiif/fester/CsvParsingException.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/CsvParsingException.java
@@ -40,4 +40,15 @@ public class CsvParsingException extends I18nException {
     public CsvParsingException(final String aMessageCode, final Object... aDetails) {
         super(Constants.MESSAGES, aMessageCode, aDetails);
     }
+
+    /**
+     * Creates a new CSV parsing exception.
+     *
+     * @param aThrowable A parent exception
+     * @param aMessageCode A message code
+     * @param aDetailsArray Additional details about the exception
+     */
+    public CsvParsingException(final Throwable aThrowable, final String aMessageCode, final Object... aDetailsArray) {
+        super(aThrowable, Constants.MESSAGES, aMessageCode, aDetailsArray);
+    }
 }

--- a/src/main/java/edu/ucla/library/iiif/fester/Features.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/Features.java
@@ -11,14 +11,23 @@ import info.freelibrary.util.LoggerFactory;
  */
 public final class Features {
 
+    /** A constant for the batch ingest feature. */
     public static final String BATCH_INGEST = "fester.batch.ingest";
 
+    /** Features' logger. */
     private static final Logger LOGGER = LoggerFactory.getLogger(Features.class, Constants.MESSAGES);
 
+    /**
+     * A map of feature names.
+     */
     private static final Map<String, String> FEATURE_NAMES =
             Map.of(BATCH_INGEST, LOGGER.getMessage(MessageCodes.MFS_084));
 
+    /**
+     * Creates a new features instance.
+     */
     private Features() {
+        // This is intentionally left empty.
     }
 
     /**

--- a/src/main/java/edu/ucla/library/iiif/fester/ImageInfoLookup.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/ImageInfoLookup.java
@@ -20,14 +20,23 @@ import io.vertx.core.json.JsonObject;
  */
 public class ImageInfoLookup {
 
+    /** A fake IIIF server URL. */
     public static final String FAKE_IIIF_SERVER = "https://test.example.com/iiif";
 
+    /** The ImageInfoLookup's logger. */
     private static final Logger LOGGER = LoggerFactory.getLogger(ImageInfoLookup.class, Constants.MESSAGES);
 
-    private static final int CANTALOUPE_TIMEOUT = 300000; // Five minutes
+    /** A lookup timeout. */
+    private static final int CANTALOUPE_TIMEOUT = 300_000; // Five minutes
 
+    /**
+     * An image width.
+     */
     private final int myWidth;
 
+    /**
+     * An image height.
+     */
     private final int myHeight;
 
     /**
@@ -38,6 +47,7 @@ public class ImageInfoLookup {
      * @throws MalformedURLException If the supplied URL isn't well-formed
      * @throws ImageNotFoundException If the requested image cannot be found
      */
+    @SuppressWarnings({ "PMD.CognitiveComplexity", "PMD.CyclomaticComplexity" })
     public ImageInfoLookup(final String aURL) throws MalformedURLException, IOException, ImageNotFoundException {
         LOGGER.debug(MessageCodes.MFS_072, aURL);
 

--- a/src/main/java/edu/ucla/library/iiif/fester/LockedIiifResource.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/LockedIiifResource.java
@@ -9,10 +9,13 @@ import io.vertx.core.shareddata.Lock;
  */
 public class LockedIiifResource {
 
+    /** A resource lock. */
     private final Lock myLock;
 
+    /** A resource. */
     private final JsonObject myResource;
 
+    /** Whether a resource is a collection or work. */
     private final boolean myResourceIsCollection;
 
     /**

--- a/src/main/java/edu/ucla/library/iiif/fester/MalformedPathException.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/MalformedPathException.java
@@ -19,6 +19,7 @@ public class MalformedPathException extends I18nRuntimeException {
      * Creates a new path structure exception.
      */
     public MalformedPathException() {
+        // This is intentionally left empty
     }
 
     /**

--- a/src/main/java/edu/ucla/library/iiif/fester/ObjectType.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/ObjectType.java
@@ -1,13 +1,36 @@
 
 package edu.ucla.library.iiif.fester;
 
+import static edu.ucla.library.iiif.fester.Constants.EMPTY;
+
 /**
  * An enumeration of the expected object types.
  */
 public enum ObjectType {
 
-    COLLECTION("Collection"), WORK("Work"), PAGE("Page"), MISSING("");
+    /**
+     * A collection type.
+     */
+    COLLECTION("Collection"),
 
+    /**
+     * A work type.
+     */
+    WORK("Work"),
+
+    /**
+     * A page type.
+     */
+    PAGE("Page"),
+
+    /**
+     * A page missing.
+     */
+    MISSING(EMPTY);
+
+    /**
+     * An object type.
+     */
     private String myValue;
 
     /**
@@ -39,6 +62,7 @@ public enum ObjectType {
      * @param aString A string to compare to the string value of this object type
      * @return True if the two strings are equal; else, false
      */
+    @SuppressWarnings("PMD.SuspiciousEqualsMethodName") // Cannot override enum's equals
     public boolean equals(final String aString) {
         return getValue().equalsIgnoreCase(aString);
     }

--- a/src/main/java/edu/ucla/library/iiif/fester/Status.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/Status.java
@@ -6,46 +6,51 @@ package edu.ucla.library.iiif.fester;
  */
 public final class Status {
 
-    /* Free memory property */
+    /** Free memory property. */
     public static final String FREE_MEMORY = "free_mem";
 
-    /* Total memory property */
+    /** Total memory property. */
     public static final String TOTAL_MEMORY = "total_mem";
 
-    /* Used memory property */
+    /** Used memory property. */
     public static final String USED_MEMORY = "used_mem";
 
-    /* Percentage memory ((used/total)*100) property */
+    /** Percentage memory ((used/total)*100) property. */
     public static final String PERCENT_MEMORY = "%_used_mem";
 
-    /* Memory category for property values */
+    /** Memory category for property values. */
     public static final String MEMORY = "memory";
 
-    /* The main status property */
+    /** The main status property. */
+    @SuppressWarnings("PMD.AvoidFieldNameMatchingTypeName")
     public static final String STATUS = "status";
 
-    /* The main endpoints status property */
+    /** The main endpoints status property. */
     public static final String ENDPOINTS = "endpoints";
 
-    /* The okay status response */
+    /** The okay status response. */
     public static final String OK = "ok";
 
-    /* The warn status response */
+    /** The warn status response. */
     public static final String WARN = "warn";
 
-    /* The error status response */
+    /** The error status response. */
     public static final String ERROR = "error";
 
-    /* The PUT response HTTP code */
+    /** The PUT response HTTP code. */
     public static final String PUT_RESPONSE = "put.response";
 
-    /* The GET response HTTP code */
+    /** The GET response HTTP code. */
     public static final String GET_RESPONSE = "get.response";
 
-    /* The DELETE response HTTP code */
+    /** The DELETE response HTTP code. */
     public static final String DELETE_RESPONSE = "delete.response";
 
+    /**
+     * Creates a new status object.
+     */
     private Status() {
+        // This is intentionally left empty
     }
 
 }

--- a/src/main/java/edu/ucla/library/iiif/fester/handlers/AbstractFesterHandler.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/handlers/AbstractFesterHandler.java
@@ -1,18 +1,20 @@
 
 package edu.ucla.library.iiif.fester.handlers;
 
-import java.net.MalformedURLException;
-
-import com.amazonaws.regions.Region;
 import com.amazonaws.regions.RegionUtils;
 
 import info.freelibrary.util.Logger;
 import info.freelibrary.util.LoggerFactory;
+
+import info.freelibrary.vertx.s3.LocalStackEndpoint;
 import info.freelibrary.vertx.s3.S3Client;
+import info.freelibrary.vertx.s3.S3ClientOptions;
+import info.freelibrary.vertx.s3.S3Endpoint;
 
 import edu.ucla.library.iiif.fester.Config;
 import edu.ucla.library.iiif.fester.Constants;
 import edu.ucla.library.iiif.fester.MessageCodes;
+
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
@@ -45,33 +47,26 @@ abstract class AbstractFesterHandler implements Handler<RoutingContext> {
             final String s3AccessKey = aConfig.getString(Config.S3_ACCESS_KEY);
             final String s3SecretKey = aConfig.getString(Config.S3_SECRET_KEY);
             final String s3RegionName = aConfig.getString(Config.S3_REGION);
-            final Region s3Region = RegionUtils.getRegion(s3RegionName);
+            final S3ClientOptions config = new S3ClientOptions().setCredentials(s3AccessKey, s3SecretKey);
 
             LOGGER.debug(MessageCodes.MFS_003, s3RegionName);
 
-            if (s3Region != null) {
+            if (RegionUtils.getRegion(s3RegionName) != null) {
                 final String endpoint = aConfig.getString(Config.S3_ENDPOINT);
 
-                try {
-                    // Check to see that we're not overriding the default S3 endpoint
-                    if (endpoint == null || Constants.S3_ENDPOINT.equals(endpoint)) {
-                        final String regionEndpoint = RegionUtils.getRegion(s3RegionName).getServiceEndpoint("s3");
-
-                        LOGGER.debug(MessageCodes.MFS_034, regionEndpoint, "default");
-                        myS3Client = new S3Client(aVertx, s3AccessKey, s3SecretKey, "https://" + regionEndpoint);
-                    } else {
-                        LOGGER.debug(MessageCodes.MFS_034, endpoint, "supplied");
-                        myS3Client = new S3Client(aVertx, s3AccessKey, s3SecretKey, endpoint);
-                    }
-
-                    myS3Client.useV2Signature(true);
-                } catch (final MalformedURLException details) {
-                    throw new IllegalArgumentException(details);
+                if (endpoint == null) {
+                    config.setEndpoint(S3Endpoint.fromRegion(s3RegionName));
+                    LOGGER.debug(MessageCodes.MFS_034, config.getEndpoint().getRegion(), "region");
+                } else if (Constants.S3_ENDPOINT.equals(endpoint)) {
+                    config.setEndpoint(S3Endpoint.US_EAST_1);
+                    LOGGER.debug(MessageCodes.MFS_034, S3Endpoint.US_EAST_1.getRegion(), "default");
+                } else {
+                    config.setEndpoint(new LocalStackEndpoint(endpoint));
+                    LOGGER.debug(MessageCodes.MFS_034, endpoint, "supplied");
                 }
-            } else {
-                myS3Client = new S3Client(aVertx, s3AccessKey, s3SecretKey);
             }
 
+            myS3Client = new S3Client(aVertx, config);
             myS3Bucket = aConfig.getString(Config.S3_BUCKET);
         }
 

--- a/src/main/java/edu/ucla/library/iiif/fester/handlers/AbstractFesterHandler.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/handlers/AbstractFesterHandler.java
@@ -28,12 +28,16 @@ import io.vertx.ext.web.RoutingContext;
  */
 abstract class AbstractFesterHandler implements Handler<RoutingContext> {
 
+    /** The abstract handler's logger. */
     private static final Logger LOGGER = LoggerFactory.getLogger(AbstractFesterHandler.class, Constants.MESSAGES);
 
+    /** Local reference to the Vert.x instance. */
     protected final Vertx myVertx;
 
+    /** An S3 client that can be used by handlers. */
     protected S3Client myS3Client;
 
+    /** An S3 bucket that handlers may use. */
     protected String myS3Bucket;
 
     /**

--- a/src/main/java/edu/ucla/library/iiif/fester/handlers/CheckEndpointsHandler.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/handlers/CheckEndpointsHandler.java
@@ -86,7 +86,7 @@ public class CheckEndpointsHandler extends AbstractFesterHandler {
                         final int statusCode = error.getStatusCode();
                         final String message = error.getMessage();
 
-                        determineEndpointStatus(Status.GET_RESPONSE, statusCode, message, endpoints, delete);
+                        determineEndpointStatus(Status.DELETE_RESPONSE, statusCode, message, endpoints, delete);
                     } else {
                         determineEndpointStatus(Status.DELETE_RESPONSE, HTTP.OK, Status.OK, endpoints, delete);
                     }

--- a/src/main/java/edu/ucla/library/iiif/fester/handlers/CheckEndpointsHandler.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/handlers/CheckEndpointsHandler.java
@@ -1,14 +1,17 @@
 
 package edu.ucla.library.iiif.fester.handlers;
 
+import info.freelibrary.util.Logger;
+import info.freelibrary.util.LoggerFactory;
+
+import info.freelibrary.iiif.presentation.v2.Manifest;
+
+import info.freelibrary.vertx.s3.UnexpectedStatusException;
+
 import edu.ucla.library.iiif.fester.Constants;
 import edu.ucla.library.iiif.fester.HTTP;
 import edu.ucla.library.iiif.fester.MessageCodes;
 import edu.ucla.library.iiif.fester.Status;
-
-import info.freelibrary.iiif.presentation.v2.Manifest;
-import info.freelibrary.util.Logger;
-import info.freelibrary.util.LoggerFactory;
 
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
@@ -30,47 +33,62 @@ public class CheckEndpointsHandler extends AbstractFesterHandler {
     private static final String APPEND = " : ";
 
     /**
-     *  Creates a handler that checks S3 endpoint statuses.
+     * Creates a handler that checks S3 endpoint statuses.
      *
      * @param aVertx A Vert.x instance
      * @param aConfig A JSON configuration
      */
-    public CheckEndpointsHandler( final Vertx aVertx, final JsonObject aConfig ) {
-        super( aVertx, aConfig );
+    public CheckEndpointsHandler(final Vertx aVertx, final JsonObject aConfig) {
+        super(aVertx, aConfig);
     }
 
     @Override
-    public void handle( final RoutingContext aContext ) {
+    public void handle(final RoutingContext aContext) {
         final HttpServerResponse response = aContext.response();
-        final Manifest upload = new Manifest("id","label");
+        final Manifest upload = new Manifest("id", "label");
         final JsonObject endpoints = new JsonObject();
         final JsonObject status = new JsonObject();
 
         Future.future(put -> {
             myS3Client.put(myS3Bucket, UPLOAD_KEY, Buffer.buffer(upload.toJSON().encodePrettily()), putResponse -> {
-                final int statusCode = putResponse.statusCode();
-                final String statusMessage = putResponse.statusMessage();
-                endpoints.put(Status.PUT_RESPONSE, statusCode);
-                determineEndpointStatus(statusCode, statusMessage, endpoints, put);
+                if (putResponse.failed()) {
+                    final UnexpectedStatusException error = (UnexpectedStatusException) putResponse.cause();
+                    final int statusCode = error.getStatusCode();
+                    final String message = error.getMessage();
+
+                    determineEndpointStatus(Status.PUT_RESPONSE, statusCode, message, endpoints, put);
+                } else {
+                    determineEndpointStatus(Status.PUT_RESPONSE, HTTP.OK, Status.OK, endpoints, put);
+                }
             });
         }).compose(addGet -> {
             return Future.future(get -> {
                 myS3Client.get(myS3Bucket, UPLOAD_KEY, getResponse -> {
-                    final int statusCode = getResponse.statusCode();
-                    final String statusMessage = getResponse.statusMessage();
-                    endpoints.put(Status.GET_RESPONSE, statusCode);
-                    determineEndpointStatus(statusCode, statusMessage, endpoints, get);
+                    if (getResponse.failed()) {
+                        final UnexpectedStatusException error = (UnexpectedStatusException) getResponse.cause();
+                        final int statusCode = error.getStatusCode();
+                        final String message = error.getMessage();
+
+                        determineEndpointStatus(Status.GET_RESPONSE, statusCode, message, endpoints, get);
+                    } else {
+                        determineEndpointStatus(Status.GET_RESPONSE, HTTP.OK, Status.OK, endpoints, get);
+                    }
                 });
-            } );
+            });
         }).compose(addDel -> {
             return Future.future(delete -> {
                 myS3Client.delete(myS3Bucket, UPLOAD_KEY, deleteResponse -> {
-                    final int statusCode = deleteResponse.statusCode();
-                    final String statusMessage = deleteResponse.statusMessage();
-                    endpoints.put(Status.DELETE_RESPONSE, statusCode);
-                    determineEndpointStatus(statusCode, statusMessage, endpoints, delete);
+                    if (deleteResponse.failed()) {
+                        final UnexpectedStatusException error = (UnexpectedStatusException) deleteResponse.cause();
+                        final int statusCode = error.getStatusCode();
+                        final String message = error.getMessage();
+
+                        determineEndpointStatus(Status.GET_RESPONSE, statusCode, message, endpoints, delete);
+                    } else {
+                        determineEndpointStatus(Status.DELETE_RESPONSE, HTTP.OK, Status.OK, endpoints, delete);
+                    }
                 });
-            } );
+            });
         }).onSuccess(success -> {
             status.put(Status.STATUS, determineOverallStatus(endpoints)).put(Status.ENDPOINTS, endpoints);
 
@@ -81,6 +99,7 @@ public class CheckEndpointsHandler extends AbstractFesterHandler {
             final String errorMessage = LOGGER.getMessage(MessageCodes.MFS_155, statusMessage);
 
             LOGGER.error(errorMessage);
+
             response.setStatusCode(HTTP.INTERNAL_SERVER_ERROR);
             response.putHeader(Constants.CONTENT_TYPE, Constants.PLAIN_TEXT_TYPE);
             response.end(errorMessage);
@@ -88,29 +107,45 @@ public class CheckEndpointsHandler extends AbstractFesterHandler {
 
     }
 
-    private void determineEndpointStatus(final int aCode, final String aStatus,
+    /**
+     * Determines the endpoint's status.
+     *
+     * @param aCode A status code
+     * @param aStatus A status message
+     * @param aMessage Additional details in the form of a JsonObject
+     * @param aPromise A promise of completion
+     */
+    private void determineEndpointStatus(final String aEndpoint, final int aCode, final String aStatus,
             final JsonObject aMessage, final Promise<Object> aPromise) {
+        aMessage.put(aEndpoint, aCode);
+
         if (aCode >= HTTP.BAD_REQUEST && aCode < HTTP.INTERNAL_SERVER_ERROR) {
-            final String failMessage = LOGGER.getMessage(MessageCodes.MFS_156, aStatus);
             aMessage.put(Status.STATUS, Status.WARN + APPEND + aStatus);
-            aPromise.fail("4XX error: " + failMessage);
+            aPromise.fail("4XX error: " + LOGGER.getMessage(MessageCodes.MFS_156, aStatus));
         } else if (aCode >= HTTP.INTERNAL_SERVER_ERROR) {
-            final String failMessage = LOGGER.getMessage(MessageCodes.MFS_156, aStatus);
             aMessage.put(Status.STATUS, Status.ERROR + APPEND + aStatus);
-            aPromise.fail("5XX error: " + failMessage);
+            aPromise.fail("5XX error: " + LOGGER.getMessage(MessageCodes.MFS_156, aStatus));
         } else {
             aPromise.complete();
         }
     }
 
+    /**
+     * Determines the overall status from the details in the supplied JsonObject.
+     *
+     * @param aMessage Additional details in the form of a JsonObject
+     * @return The overall status
+     */
     private String determineOverallStatus(final JsonObject aMessage) {
-        if (aMessage.encode().contains( Status.WARN )) {
+        if (aMessage.encode().contains(Status.WARN)) {
             return Status.WARN;
-        } else if (aMessage.encode().contains( Status.ERROR )) {
-            return Status.ERROR;
-        } else {
-            return Status.OK;
         }
+
+        if (aMessage.encode().contains(Status.ERROR)) {
+            return Status.ERROR;
+        }
+
+        return Status.OK;
     }
 
 }

--- a/src/main/java/edu/ucla/library/iiif/fester/handlers/CheckEndpointsHandler.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/handlers/CheckEndpointsHandler.java
@@ -26,10 +26,13 @@ import io.vertx.ext.web.RoutingContext;
  */
 public class CheckEndpointsHandler extends AbstractFesterHandler {
 
+    /** The logger for this handler. */
     private static final Logger LOGGER = LoggerFactory.getLogger(CheckEndpointsHandler.class, Constants.MESSAGES);
 
+    /** A key for a test of the S3 endpoints. */
     private static final String UPLOAD_KEY = "test_load.json";
 
+    /** A delimiter used in appending. */
     private static final String APPEND = " : ";
 
     /**
@@ -110,6 +113,7 @@ public class CheckEndpointsHandler extends AbstractFesterHandler {
     /**
      * Determines the endpoint's status.
      *
+     * @param aEndpoint A service endpoint
      * @param aCode A status code
      * @param aStatus A status message
      * @param aMessage Additional details in the form of a JsonObject

--- a/src/main/java/edu/ucla/library/iiif/fester/handlers/DeleteManifestHandler.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/handlers/DeleteManifestHandler.java
@@ -4,10 +4,13 @@ package edu.ucla.library.iiif.fester.handlers;
 import info.freelibrary.util.Logger;
 import info.freelibrary.util.LoggerFactory;
 
+import info.freelibrary.vertx.s3.UnexpectedStatusException;
+
 import edu.ucla.library.iiif.fester.Constants;
 import edu.ucla.library.iiif.fester.HTTP;
 import edu.ucla.library.iiif.fester.MessageCodes;
 import edu.ucla.library.iiif.fester.utils.IDUtils;
+
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
@@ -39,39 +42,40 @@ public class DeleteManifestHandler extends AbstractFesterHandler {
         final String manifestS3Key = IDUtils.getWorkS3Key(manifestID);
 
         myS3Client.delete(myS3Bucket, manifestS3Key, deleteResponse -> {
-            final int statusCode = deleteResponse.statusCode();
+            if (deleteResponse.failed()) {
+                final UnexpectedStatusException error = (UnexpectedStatusException) deleteResponse.cause();
+                final int statusCode = error.getStatusCode();
 
-            switch (statusCode) {
-                case HTTP.SUCCESS_NO_CONTENT:
-                    response.setStatusCode(HTTP.SUCCESS_NO_CONTENT);
-                    response.putHeader(Constants.CONTENT_TYPE, Constants.PLAIN_TEXT_TYPE);
-                    response.end(LOGGER.getMessage(MessageCodes.MFS_088, manifestID));
+                switch (statusCode) {
+                    case HTTP.FORBIDDEN:
+                        response.setStatusCode(HTTP.FORBIDDEN);
+                        response.putHeader(Constants.CONTENT_TYPE, Constants.PLAIN_TEXT_TYPE);
+                        response.end(LOGGER.getMessage(MessageCodes.MFS_089, manifestID));
 
-                    break;
-                case HTTP.FORBIDDEN:
-                    response.setStatusCode(HTTP.FORBIDDEN);
-                    response.putHeader(Constants.CONTENT_TYPE, Constants.PLAIN_TEXT_TYPE);
-                    response.end(LOGGER.getMessage(MessageCodes.MFS_089, manifestID));
+                        break;
+                    case HTTP.INTERNAL_SERVER_ERROR:
+                        final String serverErrorMessage = LOGGER.getMessage(MessageCodes.MFS_014, manifestID);
 
-                    break;
-                case HTTP.INTERNAL_SERVER_ERROR:
-                    final String serverErrorMessage = LOGGER.getMessage(MessageCodes.MFS_014, manifestID);
+                        LOGGER.error(serverErrorMessage);
 
-                    LOGGER.error(serverErrorMessage);
+                        response.setStatusCode(HTTP.INTERNAL_SERVER_ERROR);
+                        response.putHeader(Constants.CONTENT_TYPE, Constants.PLAIN_TEXT_TYPE);
+                        response.end(serverErrorMessage);
 
-                    response.setStatusCode(HTTP.INTERNAL_SERVER_ERROR);
-                    response.putHeader(Constants.CONTENT_TYPE, Constants.PLAIN_TEXT_TYPE);
-                    response.end(serverErrorMessage);
+                        break;
+                    default:
+                        final String errorMessage = LOGGER.getMessage(MessageCodes.MFS_013, statusCode, manifestID);
 
-                    break;
-                default:
-                    final String errorMessage = LOGGER.getMessage(MessageCodes.MFS_013, statusCode, manifestID);
+                        LOGGER.warn(errorMessage);
 
-                    LOGGER.warn(errorMessage);
-
-                    response.setStatusCode(statusCode);
-                    response.putHeader(Constants.CONTENT_TYPE, Constants.PLAIN_TEXT_TYPE);
-                    response.end(errorMessage);
+                        response.setStatusCode(statusCode);
+                        response.putHeader(Constants.CONTENT_TYPE, Constants.PLAIN_TEXT_TYPE);
+                        response.end(errorMessage);
+                }
+            } else {
+                response.setStatusCode(HTTP.SUCCESS_NO_CONTENT);
+                response.putHeader(Constants.CONTENT_TYPE, Constants.PLAIN_TEXT_TYPE);
+                response.end(LOGGER.getMessage(MessageCodes.MFS_088, manifestID));
             }
         });
     }

--- a/src/main/java/edu/ucla/library/iiif/fester/handlers/DeleteManifestHandler.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/handlers/DeleteManifestHandler.java
@@ -22,6 +22,9 @@ import io.vertx.ext.web.RoutingContext;
  */
 public class DeleteManifestHandler extends AbstractFesterHandler {
 
+    /**
+     * The logger for this handler.
+     */
     private static final Logger LOGGER = LoggerFactory.getLogger(DeleteManifestHandler.class, Constants.MESSAGES);
 
     /**
@@ -71,6 +74,8 @@ public class DeleteManifestHandler extends AbstractFesterHandler {
                         response.setStatusCode(statusCode);
                         response.putHeader(Constants.CONTENT_TYPE, Constants.PLAIN_TEXT_TYPE);
                         response.end(errorMessage);
+
+                        break;
                 }
             } else {
                 response.setStatusCode(HTTP.SUCCESS_NO_CONTENT);

--- a/src/main/java/edu/ucla/library/iiif/fester/handlers/EndpointConfigHandler.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/handlers/EndpointConfigHandler.java
@@ -20,6 +20,7 @@ import edu.ucla.library.iiif.fester.Features;
 import edu.ucla.library.iiif.fester.HTTP;
 import edu.ucla.library.iiif.fester.MessageCodes;
 import edu.ucla.library.iiif.fester.Op;
+
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 import io.vertx.core.Promise;
@@ -33,18 +34,37 @@ import io.vertx.ext.web.handler.StaticHandler;
 /**
  * An OpenAPI endpoint configuration handler.
  */
+@SuppressWarnings("deprecation")
 public class EndpointConfigHandler implements Handler<AsyncResult<OpenAPI3RouterFactory>> {
 
+    /**
+     * The config handler's logger.
+     */
     private static final Logger LOGGER = LoggerFactory.getLogger(EndpointConfigHandler.class, Constants.MESSAGES);
 
+    /**
+     * A feature-flags configuration file.
+     */
     private static final String FEATURE_FLAGS_FILE = "/etc/fester/fester-features.conf";
 
+    /**
+     * The batch upload form's URL path.
+     */
     private static final String BATCH_UPLOAD_FORM = "/fester/upload/csv";
 
+    /**
+     * A promise of completion.
+     */
     private final Promise<Router> myPromise;
 
+    /**
+     * A configuration object.
+     */
     private final JsonObject myConfig;
 
+    /**
+     * A reference to the Vert.x instance.
+     */
     private final Vertx myVertx;
 
     /**
@@ -195,8 +215,7 @@ public class EndpointConfigHandler implements Handler<AsyncResult<OpenAPI3Router
             return Optional.of(ConfigFeatureFlagChecker.forConfigSupplier(Suppliers.supplierAndThen(
                     FileResourceLoaders.forFile(new File(FEATURE_FLAGS_FILE)), TypesafeConfigReader.FROM_STRING),
                     TypesafeConfigDecider.FEATURE_ENABLED));
-        } else {
-            return Optional.empty();
         }
+        return Optional.empty();
     }
 }

--- a/src/main/java/edu/ucla/library/iiif/fester/handlers/FeatureOffHandler.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/handlers/FeatureOffHandler.java
@@ -13,6 +13,7 @@ import edu.ucla.library.iiif.fester.Constants;
 import edu.ucla.library.iiif.fester.Features;
 import edu.ucla.library.iiif.fester.HTTP;
 import edu.ucla.library.iiif.fester.MessageCodes;
+
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.core.json.JsonObject;
@@ -23,6 +24,7 @@ import io.vertx.ext.web.RoutingContext;
  */
 public class FeatureOffHandler extends AbstractFesterHandler {
 
+    /** The logger for this handler. */
     private static final Logger LOGGER = LoggerFactory.getLogger(FeatureOffHandler.class, Constants.MESSAGES);
 
     /** A template HTML page for the feature off notification */

--- a/src/main/java/edu/ucla/library/iiif/fester/handlers/GetCollectionHandler.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/handlers/GetCollectionHandler.java
@@ -23,6 +23,9 @@ import io.vertx.ext.web.RoutingContext;
  */
 public class GetCollectionHandler extends AbstractFesterHandler implements Handler<RoutingContext> {
 
+    /**
+     * The logger for this handler.
+     */
     private static final Logger LOGGER = LoggerFactory.getLogger(GetCollectionHandler.class, Constants.MESSAGES);
 
     /**

--- a/src/main/java/edu/ucla/library/iiif/fester/handlers/GetManifestHandler.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/handlers/GetManifestHandler.java
@@ -9,6 +9,7 @@ import edu.ucla.library.iiif.fester.HTTP;
 import edu.ucla.library.iiif.fester.MessageCodes;
 import edu.ucla.library.iiif.fester.Op;
 import edu.ucla.library.iiif.fester.verticles.S3BucketVerticle;
+
 import io.vertx.core.Vertx;
 import io.vertx.core.eventbus.DeliveryOptions;
 import io.vertx.core.eventbus.ReplyException;
@@ -21,6 +22,7 @@ import io.vertx.ext.web.RoutingContext;
  */
 public class GetManifestHandler extends AbstractFesterHandler {
 
+    /** The logger for this handler. */
     private static final Logger LOGGER = LoggerFactory.getLogger(GetManifestHandler.class, Constants.MESSAGES);
 
     /**

--- a/src/main/java/edu/ucla/library/iiif/fester/handlers/GetStatusHandler.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/handlers/GetStatusHandler.java
@@ -18,15 +18,28 @@ import io.vertx.ext.web.RoutingContext;
  */
 public class GetStatusHandler implements Handler<RoutingContext> {
 
+    /**
+     * The logger for this handler.
+     */
     private static final Logger LOGGER = LoggerFactory.getLogger(GetStatusHandler.class, Constants.MESSAGES);
 
+    /**
+     * The number of megabytes used to calculate memory usage.
+     */
     private static final int MB = 1024 * 1024;
 
+    /**
+     * A hard-coded level of usage to warn about.
+     */
     private static final double WARN_PERCENT = 85.0D;
 
+    /**
+     * A hard-coded level of usage to report as an error.
+     */
     private static final double ERROR_PERCENT = 95.0D;
 
     @Override
+    @SuppressWarnings("PMD.AvoidCatchingThrowable")
     public void handle(final RoutingContext aContext) {
         final HttpServerResponse response = aContext.response();
         final JsonObject status = new JsonObject();
@@ -50,6 +63,7 @@ public class GetStatusHandler implements Handler<RoutingContext> {
             } else {
                 status.put(Status.STATUS, Status.OK);
             }
+
             status.put(Status.MEMORY, memory);
             memory.put(Status.TOTAL_MEMORY, totalMemStr).put(Status.FREE_MEMORY, freeMemStr)
                 .put(Status.USED_MEMORY, usedMemStr).put(Status.PERCENT_MEMORY, percentMem);

--- a/src/main/java/edu/ucla/library/iiif/fester/handlers/MatchingOpNotFoundHandler.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/handlers/MatchingOpNotFoundHandler.java
@@ -7,6 +7,7 @@ import info.freelibrary.util.LoggerFactory;
 import edu.ucla.library.iiif.fester.Constants;
 import edu.ucla.library.iiif.fester.HTTP;
 import edu.ucla.library.iiif.fester.MessageCodes;
+
 import io.vertx.core.Handler;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerRequest;
@@ -22,6 +23,7 @@ import io.vertx.ext.web.RoutingContext;
  */
 public class MatchingOpNotFoundHandler implements Handler<RoutingContext> {
 
+    /** The logger for this handler. */
     private static final Logger LOGGER = LoggerFactory.getLogger(MatchingOpNotFoundHandler.class, Constants.MESSAGES);
 
     @Override

--- a/src/main/java/edu/ucla/library/iiif/fester/handlers/PostCsvHandler.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/handlers/PostCsvHandler.java
@@ -1,5 +1,5 @@
 
-package edu.ucla.library.iiif.fester.handlers;
+package edu.ucla.library.iiif.fester.handlers; // NOPMD - ExcessiveImports
 
 import java.io.IOException;
 import java.io.StringReader;
@@ -42,18 +42,27 @@ import io.vertx.ext.web.RoutingContext;
  */
 public class PostCsvHandler extends AbstractFesterHandler {
 
+    /** The logger for this handler. */
     private static final Logger LOGGER = LoggerFactory.getLogger(PostCsvHandler.class, Constants.MESSAGES);
 
+    /** The template for attachments. */
     private static final String ATTACHMENT = "attachment; filename=\"{}\"";
 
+    /** A break tag constants. */
     private static final String BR_TAG = "<br>";
 
+    /** The exception page used by this handler. */
     private final String myExceptionPage;
 
+    /** The Fester URL. */
     private final String myUrl;
 
+    /** The festerize version. */
     private final String myFesterizeVersion;
 
+    /**
+     * The festerize user agent pattern.
+     */
     private final Pattern myFesterizeUserAgentPattern;
 
     /**
@@ -75,6 +84,7 @@ public class PostCsvHandler extends AbstractFesterHandler {
     }
 
     @Override
+    @SuppressWarnings("PMD.CognitiveComplexity")
     public void handle(final RoutingContext aContext) {
         final HttpServerRequest request = aContext.request();
         final HttpServerResponse response = aContext.response();
@@ -84,7 +94,7 @@ public class PostCsvHandler extends AbstractFesterHandler {
         final String errorMessage;
 
         // An uploaded CSV is required
-        if (csvUploads.size() == 0) {
+        if (csvUploads.isEmpty()) {
             errorMessage = LOGGER.getMessage(MessageCodes.MFS_037);
 
             response.setStatusCode(HTTP.BAD_REQUEST);
@@ -172,6 +182,7 @@ public class PostCsvHandler extends AbstractFesterHandler {
      * Return an error page (and response code) to the requester.
      *
      * @param aResponse A HTTP response
+     * @param aStatusCode A status code
      * @param aThrowable A throwable exception
      */
     private void returnError(final HttpServerResponse aResponse, final int aStatusCode, final Throwable aThrowable) {

--- a/src/main/java/edu/ucla/library/iiif/fester/handlers/PutCollectionHandler.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/handlers/PutCollectionHandler.java
@@ -21,6 +21,7 @@ import io.vertx.ext.web.RoutingContext;
  */
 public class PutCollectionHandler extends AbstractFesterHandler {
 
+    /** This handler's logger. */
     private static final Logger LOGGER = LoggerFactory.getLogger(PutCollectionHandler.class, Constants.MESSAGES);
 
     /**

--- a/src/main/java/edu/ucla/library/iiif/fester/handlers/PutManifestHandler.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/handlers/PutManifestHandler.java
@@ -4,10 +4,13 @@ package edu.ucla.library.iiif.fester.handlers;
 import info.freelibrary.util.Logger;
 import info.freelibrary.util.LoggerFactory;
 
+import info.freelibrary.vertx.s3.UnexpectedStatusException;
+
 import edu.ucla.library.iiif.fester.Constants;
 import edu.ucla.library.iiif.fester.HTTP;
 import edu.ucla.library.iiif.fester.MessageCodes;
 import edu.ucla.library.iiif.fester.utils.IDUtils;
+
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
@@ -41,41 +44,42 @@ public class PutManifestHandler extends AbstractFesterHandler {
 
         // For now we're not going to check if it exists before we overwrite it
         myS3Client.put(myS3Bucket, manifestS3Key, body.toBuffer(), put -> {
-            final int statusCode = put.statusCode();
+            if (put.failed()) {
+                final UnexpectedStatusException error = (UnexpectedStatusException) put.cause();
+                final int statusCode = error.getStatusCode();
 
-            switch (statusCode) {
-                case HTTP.OK:
-                    response.setStatusCode(HTTP.OK);
-                    response.putHeader(Constants.CONTENT_TYPE, Constants.PLAIN_TEXT_TYPE);
-                    response.end(LOGGER.getMessage(MessageCodes.MFS_092, manifestID));
+                switch (statusCode) {
+                    case HTTP.FORBIDDEN:
+                        LOGGER.debug(MessageCodes.MFS_023, manifestID);
 
-                    break;
-                case HTTP.FORBIDDEN:
-                    LOGGER.debug(MessageCodes.MFS_023, manifestID);
+                        response.setStatusCode(HTTP.FORBIDDEN);
+                        response.putHeader(Constants.CONTENT_TYPE, Constants.PLAIN_TEXT_TYPE);
+                        response.end(LOGGER.getMessage(MessageCodes.MFS_089, manifestID));
 
-                    response.setStatusCode(HTTP.FORBIDDEN);
-                    response.putHeader(Constants.CONTENT_TYPE, Constants.PLAIN_TEXT_TYPE);
-                    response.end(LOGGER.getMessage(MessageCodes.MFS_089, manifestID));
+                        break;
+                    case HTTP.INTERNAL_SERVER_ERROR:
+                        final String serverErrorMessage = LOGGER.getMessage(MessageCodes.MFS_015, manifestID);
 
-                    break;
-                case HTTP.INTERNAL_SERVER_ERROR:
-                    final String serverErrorMessage = LOGGER.getMessage(MessageCodes.MFS_015, manifestID);
+                        LOGGER.error(serverErrorMessage);
 
-                    LOGGER.error(serverErrorMessage);
+                        response.setStatusCode(HTTP.INTERNAL_SERVER_ERROR);
+                        response.putHeader(Constants.CONTENT_TYPE, Constants.PLAIN_TEXT_TYPE);
+                        response.end(serverErrorMessage);
 
-                    response.setStatusCode(HTTP.INTERNAL_SERVER_ERROR);
-                    response.putHeader(Constants.CONTENT_TYPE, Constants.PLAIN_TEXT_TYPE);
-                    response.end(serverErrorMessage);
+                        break;
+                    default:
+                        final String errorMessage = LOGGER.getMessage(MessageCodes.MFS_013, statusCode, manifestID);
 
-                    break;
-                default:
-                    final String errorMessage = LOGGER.getMessage(MessageCodes.MFS_013, statusCode, manifestID);
+                        LOGGER.warn(errorMessage);
 
-                    LOGGER.warn(errorMessage);
-
-                    response.setStatusCode(statusCode);
-                    response.putHeader(Constants.CONTENT_TYPE, Constants.PLAIN_TEXT_TYPE);
-                    response.end(errorMessage);
+                        response.setStatusCode(statusCode);
+                        response.putHeader(Constants.CONTENT_TYPE, Constants.PLAIN_TEXT_TYPE);
+                        response.end(errorMessage);
+                }
+            } else {
+                response.setStatusCode(HTTP.OK);
+                response.putHeader(Constants.CONTENT_TYPE, Constants.PLAIN_TEXT_TYPE);
+                response.end(LOGGER.getMessage(MessageCodes.MFS_092, manifestID));
             }
         });
     }

--- a/src/main/java/edu/ucla/library/iiif/fester/handlers/PutManifestHandler.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/handlers/PutManifestHandler.java
@@ -22,6 +22,7 @@ import io.vertx.ext.web.RoutingContext;
  */
 public class PutManifestHandler extends AbstractFesterHandler {
 
+    /** This handler's logger. */
     private static final Logger LOGGER = LoggerFactory.getLogger(PutManifestHandler.class, Constants.MESSAGES);
 
     /**
@@ -75,6 +76,8 @@ public class PutManifestHandler extends AbstractFesterHandler {
                         response.setStatusCode(statusCode);
                         response.putHeader(Constants.CONTENT_TYPE, Constants.PLAIN_TEXT_TYPE);
                         response.end(errorMessage);
+
+                        break;
                 }
             } else {
                 response.setStatusCode(HTTP.OK);

--- a/src/main/java/edu/ucla/library/iiif/fester/utils/CodeUtils.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/utils/CodeUtils.java
@@ -12,8 +12,12 @@ import edu.ucla.library.iiif.fester.MessageCodes;
  */
 public final class CodeUtils {
 
+    /** The logger used by the code utilities. */
     private static final Logger LOGGER = LoggerFactory.getLogger(CodeUtils.class, Constants.MESSAGES);
 
+    /**
+     * Creates a new utilities class.
+     */
     private CodeUtils() {
         // This is a utility class
     }
@@ -25,7 +29,7 @@ public final class CodeUtils {
      * @return A message code in integer form
      * @throws IllegalArgumentException If the supplied string isn't a message code
      */
-    public static int getInt(final String aMessageCode) throws IllegalArgumentException {
+    public static int getInt(final String aMessageCode) {
         try {
             return Integer.parseInt(aMessageCode.substring(aMessageCode.lastIndexOf('-') + 1));
         } catch (final NumberFormatException details) {

--- a/src/main/java/edu/ucla/library/iiif/fester/utils/IDUtils.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/utils/IDUtils.java
@@ -23,11 +23,21 @@ import edu.ucla.library.iiif.fester.MessageCodes;
  */
 public final class IDUtils {
 
+    /**
+     * A maximum number of IDs count.
+     */
     private static final int MAX_ID_COUNT = 1000;
 
+    /**
+     * The default ID length.
+     */
     private static final int DEFAULT_ID_LENGTH = 6;
 
+    /**
+     * Creates a new ID utilities instance.
+     */
     private IDUtils() {
+        // This is intentionally left empty
     }
 
     /**
@@ -46,6 +56,7 @@ public final class IDUtils {
      * @param aIDLength The length of an ID to generate
      * @return A list of unique IDs
      */
+    @SuppressWarnings("PMD.AvoidReassigningLoopVariables")
     public static List<String> getIDs(final int aCount, final int aIDLength) {
         final Set<String> idSet = new HashSet<>(aCount);
 
@@ -91,7 +102,7 @@ public final class IDUtils {
      * @throws MalformedPathException If the supplied S3 key doesn't start with {@link Constants#WORK_S3_KEY_PREFIX} or
      *         {@link Constants#COLLECTION_S3_KEY_PREFIX}
      */
-    public static String getResourceURIPath(final String aS3Key) throws MalformedPathException {
+    public static String getResourceURIPath(final String aS3Key) {
         final String encodedID = URLEncoder.encode(getResourceID(aS3Key), StandardCharsets.UTF_8);
         final String path;
 
@@ -114,7 +125,7 @@ public final class IDUtils {
      * @throws MalformedPathException If the supplied S3 key doesn't start with {@link Constants#WORK_S3_KEY_PREFIX} or
      *         {@link Constants#COLLECTION_S3_KEY_PREFIX}
      */
-    public static String getResourceID(final String aS3Key) throws MalformedPathException {
+    public static String getResourceID(final String aS3Key) {
         final String s3KeyPrefix;
 
         checkPrefixValidity(aS3Key);
@@ -146,7 +157,7 @@ public final class IDUtils {
      * @throws MalformedPathException If the supplied URI doesn't contain {@link Constants#MANIFEST_URI_PATH_SUFFIX} or
      *         {@link Constants#COLLECTION_URI_PATH_PREFIX}
      */
-    public static String getResourceS3Key(final URI aURI) throws MalformedPathException {
+    public static String getResourceS3Key(final URI aURI) {
         final String path = aURI.getPath();
         final String encodedID;
         final String uriPathPrefix;

--- a/src/main/java/edu/ucla/library/iiif/fester/utils/ItemSequenceComparator.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/utils/ItemSequenceComparator.java
@@ -11,6 +11,7 @@ import java.util.Comparator;
  */
 public class ItemSequenceComparator implements Comparator<String[]> {
 
+    /** The comparator's index. */
     private final int myIndex;
 
     /**

--- a/src/main/java/edu/ucla/library/iiif/fester/utils/V2ManifestLabelComparator.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/utils/V2ManifestLabelComparator.java
@@ -13,6 +13,7 @@ import se.sawano.java.text.AlphanumericComparator;
  */
 public class V2ManifestLabelComparator implements Comparator<Collection.Manifest> {
 
+    /** An alphanumeric comparator. */
     private final AlphanumericComparator myComparator = new AlphanumericComparator();
 
     @Override

--- a/src/main/java/edu/ucla/library/iiif/fester/utils/V3CollectionItemLabelComparator.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/utils/V3CollectionItemLabelComparator.java
@@ -13,6 +13,9 @@ import se.sawano.java.text.AlphanumericComparator;
  */
 public class V3CollectionItemLabelComparator implements Comparator<Collection.Item> {
 
+    /**
+     * An alphanumeric comparator.
+     */
     private final AlphanumericComparator myComparator = new AlphanumericComparator();
 
     @Override
@@ -28,13 +31,11 @@ public class V3CollectionItemLabelComparator implements Comparator<Collection.It
             secondLabel = aSecondCollectionItem.getLabel().getString();
 
             return myComparator.compare(firstLabel, secondLabel);
+        }
+        if (firstType.equals(Collection.Item.Type.COLLECTION) && secondType.equals(Collection.Item.Type.MANIFEST)) {
+            return -1;
         } else {
-            // Sort Collections before Manifests
-            if (firstType.equals(Collection.Item.Type.COLLECTION) && secondType.equals(Collection.Item.Type.MANIFEST)) {
-                return -1;
-            } else {
-                return 1;
-            }
+            return 1;
         }
     }
 }

--- a/src/main/java/edu/ucla/library/iiif/fester/verticles/AbstractFesterVerticle.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/verticles/AbstractFesterVerticle.java
@@ -23,6 +23,7 @@ import io.vertx.core.shareddata.LocalMap;
  */
 public abstract class AbstractFesterVerticle extends AbstractVerticle {
 
+    /** The logger for this verticle. */
     private static final Logger LOGGER = LoggerFactory.getLogger(AbstractFesterVerticle.class, Constants.MESSAGES);
 
     @Override

--- a/src/main/java/edu/ucla/library/iiif/fester/verticles/MainVerticle.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/verticles/MainVerticle.java
@@ -30,18 +30,29 @@ import io.vertx.ext.web.api.contract.openapi3.OpenAPI3RouterFactory;
 /**
  * The verticle that starts the Fester service.
  */
+@SuppressWarnings("deprecation")
 public class MainVerticle extends AbstractVerticle {
 
+    /**
+     * The main verticle's logger.
+     */
     private static final Logger LOGGER = LoggerFactory.getLogger(MainVerticle.class, MESSAGES);
 
+    /**
+     * The OpenAPI specification used by the application.
+     */
     private static final String DEFAULT_SPEC = "fester.yaml";
 
+    /**
+     * The default port the application runs on (can be overridden).
+     */
     private static final int DEFAULT_PORT = 8888;
 
     /**
      * Starts the Fester service.
      */
     @Override
+    @SuppressWarnings({ "PMD.CognitiveComplexity" })
     public void start(final Promise<Void> aPromise) {
         getConfigRetriever().getConfig(configuration -> {
             if (configuration.failed()) {
@@ -142,6 +153,7 @@ public class MainVerticle extends AbstractVerticle {
      * @param aVerticleName The name of the verticle to deploy
      * @param aOptions Any deployment options that should be considered
      * @param aPromise A promise to deploy the requested verticle
+     * @return A future completion
      */
     private Future<Void> deployVerticle(final String aVerticleName, final DeploymentOptions aOptions,
             final Promise<Void> aPromise) {

--- a/src/main/java/edu/ucla/library/iiif/fester/verticles/ManifestVerticle.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/verticles/ManifestVerticle.java
@@ -1,5 +1,5 @@
 
-package edu.ucla.library.iiif.fester.verticles;
+package edu.ucla.library.iiif.fester.verticles; // NOPMD - ExcessiveImports
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -76,18 +76,31 @@ public class ManifestVerticle extends AbstractFesterVerticle {
      */
     public static final String CREATE_WORK = "create-work";
 
+    /**
+     * This verticle's logger.
+     */
     private static final Logger LOGGER = LoggerFactory.getLogger(ManifestVerticle.class, Constants.MESSAGES);
 
+    /**
+     * A kludge for long image lookups. Image lookups will one day be removed from Fester and h/w pulled from the CSV.
+     */
     private static final long TIMEOUT = Long.MAX_VALUE; // A temporary over the top setting for image lookups
 
+    /**
+     * A placeholder image.
+     */
     private String myPlaceholderImage;
 
+    /**
+     * An image host (e.g. Cantaloupe).
+     */
     private String myImageHost;
 
     /**
      * Starts a verticle to handle manifest creation requests.
      */
     @Override
+    @SuppressWarnings({ "PMD.CognitiveComplexity", "PMD.ExcessiveMethodLength" })
     public void start(final Promise<Void> aPromise) {
         if (myImageHost == null) {
             myImageHost = StringUtils.trimToNull(config().getString(Config.IIIF_BASE_URL));
@@ -244,7 +257,7 @@ public class ManifestVerticle extends AbstractFesterVerticle {
             }
         });
 
-        getLockedIiifResource(id, false, promise);
+        lockResource(id, false, promise);
     }
 
     /**
@@ -341,7 +354,7 @@ public class ManifestVerticle extends AbstractFesterVerticle {
             }
         });
 
-        getLockedIiifResource(aWorkID, false, promise);
+        lockResource(aWorkID, false, promise);
     }
 
     /**
@@ -390,7 +403,7 @@ public class ManifestVerticle extends AbstractFesterVerticle {
             }
         });
 
-        getLockedIiifResource(collectionID, true, promise);
+        lockResource(collectionID, true, promise);
     }
 
     /**
@@ -456,7 +469,8 @@ public class ManifestVerticle extends AbstractFesterVerticle {
      * @param aCollDoc Whether the resource is a collection or a manifest ("work")
      * @param aPromise A promise that we'll get a lock
      */
-    private void getLockedIiifResource(final String aID, final boolean aCollDoc,
+    @SuppressWarnings({ "PMD.CognitiveComplexity", "PMD.AvoidCatchingNPE", "PMD.AvoidCatchingGenericException" })
+    private void lockResource(final String aID, final boolean aCollDoc,
             final Promise<LockedIiifResource> aPromise) {
         final SharedData sharedData = vertx.sharedData();
 
@@ -498,7 +512,7 @@ public class ManifestVerticle extends AbstractFesterVerticle {
             } else {
                 // If we can't get a lock, keep trying (forever, really?)
                 vertx.setTimer(1000, timer -> {
-                    getLockedIiifResource(aID, aCollDoc, aPromise);
+                    lockResource(aID, aCollDoc, aPromise);
                 });
             }
         });
@@ -513,8 +527,7 @@ public class ManifestVerticle extends AbstractFesterVerticle {
     private String getManifestVerticleName(final String aApiVersion) {
         if (Constants.IIIF_API_V3.equals(aApiVersion)) {
             return V3ManifestVerticle.class.getName();
-        } else {
-            return V2ManifestVerticle.class.getName();
         }
+        return V2ManifestVerticle.class.getName();
     }
 }

--- a/src/main/java/edu/ucla/library/iiif/fester/verticles/S3BucketVerticle.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/verticles/S3BucketVerticle.java
@@ -39,16 +39,34 @@ import io.vertx.core.shareddata.Counter;
  */
 public class S3BucketVerticle extends AbstractFesterVerticle {
 
+    /**
+     * The logger used by this verticle.
+     */
     private static final Logger LOGGER = LoggerFactory.getLogger(S3BucketVerticle.class, Constants.MESSAGES);
 
+    /**
+     * The default maximum number of retries this verticle will attempt.
+     */
     private static final long MAX_RETRIES = 10;
 
+    /**
+     * An S3 client used by this verticle.
+     */
     private S3Client myS3Client;
 
+    /**
+     * The S3 bucket this verticle uses.
+     */
     private String myS3Bucket;
 
+    /**
+     * The verticle's URL.
+     */
     private String myUrl;
 
+    /**
+     * A placeholder URL pattern.
+     */
     private final String myUrlPlaceholderPattern = Pattern.quote(Constants.URL_PLACEHOLDER);
 
     /**
@@ -121,6 +139,7 @@ public class S3BucketVerticle extends AbstractFesterVerticle {
                 default:
                     message.fail(CodeUtils.getInt(MessageCodes.MFS_139), StringUtils.format(MessageCodes.MFS_139,
                             getClass().toString(), message.toString(), action));
+                    break;
             }
         });
 
@@ -133,7 +152,7 @@ public class S3BucketVerticle extends AbstractFesterVerticle {
      * @param aS3Key The S3 key to use for the manifest
      * @param aMessage A event queue message
      */
-    @SuppressWarnings("checkstyle:indentation")
+    @SuppressWarnings({ "checkstyle:indentation", "PMD.CognitiveComplexity" })
     private void get(final String aS3Key, final Message<JsonObject> aMessage) {
         myS3Client.get(myS3Bucket, aS3Key, get -> {
             if (get.failed()) {
@@ -190,7 +209,7 @@ public class S3BucketVerticle extends AbstractFesterVerticle {
         final String derivedManifestS3Key;
         final String idKey;
 
-        if (context.equals(Constants.CONTEXT_V2)) {
+        if (Constants.CONTEXT_V2.equals(context)) {
             idKey = Constants.ID_V2;
         } else { // Constants.CONTEXT_V3
             idKey = Constants.ID_V3;
@@ -262,6 +281,7 @@ public class S3BucketVerticle extends AbstractFesterVerticle {
      * @param aManifestID A Manifest ID
      * @param aHandler A retry handler
      */
+    @SuppressWarnings("PMD.CognitiveComplexity")
     private void shouldRetry(final String aManifestID, final Handler<AsyncResult<Boolean>> aHandler) {
         final Promise<Boolean> promise = Promise.promise();
 
@@ -300,8 +320,10 @@ public class S3BucketVerticle extends AbstractFesterVerticle {
      * incremented).
      *
      * @param aMessage A message requesting an S3 upload
+     * @param aCode A status code for the reply message
      * @param aDetails The result of the S3 upload
      */
+    @SuppressWarnings("PMD.CognitiveComplexity")
     private void sendReply(final Message<JsonObject> aMessage, final int aCode, final String aDetails) {
         getVertx().sharedData().getLocalCounter(Constants.S3_REQUEST_COUNT, getCounter -> {
             if (getCounter.succeeded()) {

--- a/src/main/java/edu/ucla/library/iiif/fester/verticles/S3BucketVerticle.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/verticles/S3BucketVerticle.java
@@ -10,7 +10,12 @@ import com.amazonaws.regions.RegionUtils;
 import info.freelibrary.util.Logger;
 import info.freelibrary.util.LoggerFactory;
 import info.freelibrary.util.StringUtils;
+
+import info.freelibrary.vertx.s3.LocalStackEndpoint;
 import info.freelibrary.vertx.s3.S3Client;
+import info.freelibrary.vertx.s3.S3ClientOptions;
+import info.freelibrary.vertx.s3.S3Endpoint;
+import info.freelibrary.vertx.s3.UnexpectedStatusException;
 
 import edu.ucla.library.iiif.fester.Config;
 import edu.ucla.library.iiif.fester.Constants;
@@ -19,6 +24,7 @@ import edu.ucla.library.iiif.fester.MessageCodes;
 import edu.ucla.library.iiif.fester.Op;
 import edu.ucla.library.iiif.fester.utils.CodeUtils;
 import edu.ucla.library.iiif.fester.utils.IDUtils;
+
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 import io.vertx.core.Promise;
@@ -59,20 +65,24 @@ public class S3BucketVerticle extends AbstractFesterVerticle {
             final String s3AccessKey = config.getString(Config.S3_ACCESS_KEY);
             final String s3SecretKey = config.getString(Config.S3_SECRET_KEY);
             final String s3RegionName = config.getString(Config.S3_REGION, "us-east-1");
-            final String endpoint = config.getString(Config.S3_ENDPOINT);
+            final S3ClientOptions opts = new S3ClientOptions().setCredentials(s3AccessKey, s3SecretKey);
 
-            // Check to see that we're not overriding the default S3 endpoint
-            if (endpoint == null || Constants.S3_ENDPOINT.equals(endpoint)) {
-                final String regionEndpoint = RegionUtils.getRegion(s3RegionName).getServiceEndpoint("s3");
+            if (RegionUtils.getRegion(s3RegionName) != null) {
+                final String endpoint = config.getString(Config.S3_ENDPOINT);
 
-                LOGGER.debug(MessageCodes.MFS_034, regionEndpoint, "default");
-                myS3Client = new S3Client(getVertx(), s3AccessKey, s3SecretKey, "https://" + regionEndpoint);
-            } else {
-                LOGGER.debug(MessageCodes.MFS_034, endpoint, "supplied");
-                myS3Client = new S3Client(getVertx(), s3AccessKey, s3SecretKey, endpoint);
+                if (endpoint == null) {
+                    opts.setEndpoint(S3Endpoint.fromRegion(s3RegionName));
+                    LOGGER.debug(MessageCodes.MFS_034, opts.getEndpoint().getRegion(), "region");
+                } else if (Constants.S3_ENDPOINT.equals(endpoint)) {
+                    opts.setEndpoint(S3Endpoint.US_EAST_1);
+                    LOGGER.debug(MessageCodes.MFS_034, S3Endpoint.US_EAST_1.getRegion(), "default");
+                } else {
+                    opts.setEndpoint(new LocalStackEndpoint(endpoint));
+                    LOGGER.debug(MessageCodes.MFS_034, endpoint, "supplied");
+                }
             }
 
-            myS3Client.useV2Signature(true);
+            myS3Client = new S3Client(getVertx(), opts);
             myS3Bucket = config.getString(Config.S3_BUCKET);
 
             // Trace is only for developer use; don't turn on when running on a server
@@ -126,15 +136,31 @@ public class S3BucketVerticle extends AbstractFesterVerticle {
     @SuppressWarnings("checkstyle:indentation")
     private void get(final String aS3Key, final Message<JsonObject> aMessage) {
         myS3Client.get(myS3Bucket, aS3Key, get -> {
-            final int statusCode = get.statusCode();
-            final String statusMessage = get.statusMessage();
+            if (get.failed()) {
+                final UnexpectedStatusException error = (UnexpectedStatusException) get.cause();
+                final int statusCode = error.getStatusCode();
+                final String statusMessage = error.getMessage();
 
-            // This lets us know at what time we received a response, in addition to the code
-            LOGGER.debug(MessageCodes.MFS_096, aS3Key, statusCode);
+                LOGGER.debug(MessageCodes.MFS_096, aS3Key, statusCode);
 
-            if (statusCode == HTTP.OK) {
-                get.bodyHandler(body -> {
-                    final String serializedJson = body.toString(StandardCharsets.UTF_8);
+                if (statusCode == HTTP.NOT_FOUND) {
+                    aMessage.fail(statusCode, statusMessage);
+                } else {
+                    get.result().body(body -> {
+                        final Buffer buffer = body.result();
+
+                        if (buffer != null) {
+                            LOGGER.error(error, MessageCodes.MFS_097, aS3Key, buffer.toString(StandardCharsets.UTF_8));
+                        }
+                    });
+
+                    aMessage.fail(HTTP.INTERNAL_SERVER_ERROR, statusMessage);
+                }
+            } else {
+                LOGGER.debug(MessageCodes.MFS_096, aS3Key, HTTP.OK);
+
+                get.result().body(body -> {
+                    final String serializedJson = body.result().toString(StandardCharsets.UTF_8);
                     final String manifest;
 
                     if (aMessage.headers().get(Constants.NO_REWRITE_URLS) != null) {
@@ -145,18 +171,7 @@ public class S3BucketVerticle extends AbstractFesterVerticle {
 
                     aMessage.reply(new JsonObject(manifest));
                 });
-            } else if (statusCode == HTTP.NOT_FOUND) {
-                aMessage.fail(HTTP.NOT_FOUND, statusMessage);
-            } else {
-                get.bodyHandler(body -> {
-                    LOGGER.error(body.toString(StandardCharsets.UTF_8));
-                });
-
-                aMessage.fail(HTTP.INTERNAL_SERVER_ERROR, statusMessage);
             }
-        }, exception -> {
-            LOGGER.error(exception, MessageCodes.MFS_097, aS3Key, exception.getMessage());
-            aMessage.fail(HTTP.INTERNAL_SERVER_ERROR, exception.getMessage());
         });
     }
 
@@ -172,14 +187,15 @@ public class S3BucketVerticle extends AbstractFesterVerticle {
         final Buffer manifestContent = aManifest.toBuffer();
         final String manifestID = IDUtils.getResourceID(aS3Key);
         final String context = aManifest.getString("@context");
-        final String idKey;
         final String derivedManifestS3Key;
+        final String idKey;
 
         if (context.equals(Constants.CONTEXT_V2)) {
             idKey = Constants.ID_V2;
         } else { // Constants.CONTEXT_V3
             idKey = Constants.ID_V3;
         }
+
         derivedManifestS3Key = IDUtils.getResourceS3Key(URI.create(aManifest.getString(idKey)));
 
         LOGGER.debug(MessageCodes.MFS_051, aManifest, myS3Bucket);
@@ -190,39 +206,23 @@ public class S3BucketVerticle extends AbstractFesterVerticle {
         }
 
         try {
-            myS3Client.put(myS3Bucket, aS3Key, manifestContent, response -> {
-                final int statusCode = response.statusCode();
-
-                response.exceptionHandler(exception -> {
-                    LOGGER.error(exception, exception.getMessage());
-                    sendReply(aMessage, CodeUtils.getInt(MessageCodes.MFS_052), exception.getMessage());
-                });
-
-                // If we get a successful upload response code, send a reply to indicate so
-                if (statusCode == HTTP.OK) {
-                    LOGGER.info(MessageCodes.MFS_053, manifestID);
-
-                    // Send the success result and decrement the S3 request counter
-                    sendReply(aMessage, 0, Op.SUCCESS);
-                } else {
-                    LOGGER.error(MessageCodes.MFS_054, statusCode, response.statusMessage());
-
-                    // Log the detailed reason we failed so we can track down the issue
-                    response.bodyHandler(body -> {
-                        LOGGER.error(MessageCodes.MFS_052, body.getString(0, body.length()));
-                    });
+            myS3Client.put(myS3Bucket, aS3Key, manifestContent, put -> {
+                if (put.failed()) {
+                    final UnexpectedStatusException error = (UnexpectedStatusException) put.cause();
+                    final int statusCode = error.getStatusCode();
+                    final String message = error.getMessage();
 
                     // If there is some internal S3 server error, let's try again
                     if (statusCode == HTTP.INTERNAL_SERVER_ERROR) {
                         sendReply(aMessage, 0, Op.RETRY);
                     } else {
-                        LOGGER.warn(MessageCodes.MFS_055, statusCode + " - " + response.statusMessage());
+                        LOGGER.warn(MessageCodes.MFS_055, statusCode + " -> " + message);
                         retryUpload(manifestID, aMessage);
                     }
+                } else {
+                    LOGGER.info(MessageCodes.MFS_053, manifestID);
+                    sendReply(aMessage, 0, Op.SUCCESS); // Decrements the request counter
                 }
-            }, exception -> {
-                LOGGER.warn(MessageCodes.MFS_055, exception.getMessage());
-                retryUpload(manifestID, aMessage);
             });
         } catch (final ConnectionPoolTooBusyException details) {
             LOGGER.debug(MessageCodes.MFS_056, manifestID);

--- a/src/main/java/edu/ucla/library/iiif/fester/verticles/V2ManifestVerticle.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/verticles/V2ManifestVerticle.java
@@ -1,5 +1,5 @@
 
-package edu.ucla.library.iiif.fester.verticles;
+package edu.ucla.library.iiif.fester.verticles; // NOPMD - ExcessiveImports
 
 import java.io.IOException;
 import java.net.URI;
@@ -63,16 +63,22 @@ import io.vertx.core.json.JsonObject;
  */
 public class V2ManifestVerticle extends AbstractFesterVerticle {
 
+    /** The verticle's logger. */
     private static final Logger LOGGER = LoggerFactory.getLogger(V2ManifestVerticle.class, MessageCodes.BUNDLE);
 
+    /** A sequence URI template. */
     private static final String SEQUENCE_URI = "{}/{}/manifest/sequence/normal";
 
+    /** A manifest URI template. */
     private static final String MANIFEST_URI = "{}/{}/manifest";
 
+    /** A canvas URI template. */
     private static final String CANVAS_URI = "{}/{}/manifest/canvas/{}";
 
+    /** An annotation URI template. */
     private static final String ANNOTATION_URI = "{}/{}/annotation/{}";
 
+    /** A simple URI template. */
     private static final String SIMPLE_URI = "{}/{}";
 
     /**
@@ -432,11 +438,13 @@ public class V2ManifestVerticle extends AbstractFesterVerticle {
      *
      * @param aCsvHeaders A CSV headers
      * @param aPageList A list of pages to add
-     * @param aSequence A sequence to add pages to
      * @param aImageHost An image host for image links
+     * @param aPlaceholderImage A placeholder image link
      * @param aWorkID A URL encoded work ID
      * @throws IOException If there is trouble adding a page
+     * @return An array of canvases
      */
+    @SuppressWarnings("PMD.CognitiveComplexity")
     private Canvas[] createCanvases(final CsvHeaders aCsvHeaders, final List<String[]> aPageList,
             final String aImageHost, final String aPlaceholderImage, final String aWorkID) {
         final Iterator<String[]> iterator = aPageList.iterator();

--- a/src/main/java/edu/ucla/library/iiif/fester/verticles/V3ManifestVerticle.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/verticles/V3ManifestVerticle.java
@@ -1,5 +1,5 @@
 
-package edu.ucla.library.iiif.fester.verticles;
+package edu.ucla.library.iiif.fester.verticles; // NOPMD - ExcessiveImports
 
 import java.io.IOException;
 import java.net.URI;
@@ -75,12 +75,18 @@ import io.vertx.core.json.JsonObject;
  */
 public class V3ManifestVerticle extends AbstractFesterVerticle {
 
+    /**
+     * The logger for this verticle.
+     */
     private static final Logger LOGGER = LoggerFactory.getLogger(V3ManifestVerticle.class, MessageCodes.BUNDLE);
 
+    /** A substitution pattern. */
     private static final String SUBSTITUTION_PATTERN = "{}";
 
+    /** A manifest URI template. */
     private static final String MANIFEST_URI = "{}/{}/manifest";
 
+    /** A simple URI template. */
     private static final String SIMPLE_URI = "{}/{}";
 
     /**
@@ -438,10 +444,13 @@ public class V3ManifestVerticle extends AbstractFesterVerticle {
      *
      * @param aCsvHeaders A CSV headers
      * @param aPageList A list of pages to add
-     * @param aSequence A sequence to add pages to
      * @param aImageHost An image host for image links
+     * @param aPlaceholderImage A placeholder image link
      * @param aMinter An ID minter
+     * @return An array of canvases
      */
+    @SuppressWarnings({ "PMD.ExcessiveMethodLength", "PMD.NcssCount", "PMD.CognitiveComplexity",
+        "PMD.CyclomaticComplexity" })
     private Canvas[] createCanvases(final CsvHeaders aCsvHeaders, final List<String[]> aPageList,
             final String aImageHost, final String aPlaceholderImage, final Minter aMinter) {
         final Iterator<String[]> iterator = aPageList.iterator();
@@ -579,6 +588,7 @@ public class V3ManifestVerticle extends AbstractFesterVerticle {
         return canvases.toArray(new Canvas[] {});
     }
 
+    @SuppressWarnings("PMD.AvoidLiteralsInIfCondition")
     private VideoContent[] getVideoContent(final String aResourceURI) {
         final int substitutionCount = countSubstitutionPatterns(aResourceURI);
         final VideoContent[] videos;
@@ -601,6 +611,7 @@ public class V3ManifestVerticle extends AbstractFesterVerticle {
         return videos;
     }
 
+    @SuppressWarnings("PMD.AvoidLiteralsInIfCondition")
     private SoundContent[] getSoundContent(final String aResourceURI) {
         final int substitutionCount = countSubstitutionPatterns(aResourceURI);
         final SoundContent[] audios;
@@ -647,10 +658,11 @@ public class V3ManifestVerticle extends AbstractFesterVerticle {
     /**
      * Updates existing metadata.
      *
-     * @param aMetadata A metadata property
+     * @param aMetadataList A list of metadata properties
      * @param aStringArray A metadata label and, optionally, its value
      * @return Metadata about the work
      */
+    @SuppressWarnings("PMD.AvoidLiteralsInIfCondition")
     private List<Metadata> updateMetadata(final List<Metadata> aMetadataList, final String... aStringArray) {
         final List<Metadata> metadataList = new ArrayList<>();
 

--- a/src/main/tools/checkstyle/checkstyle.xml
+++ b/src/main/tools/checkstyle/checkstyle.xml
@@ -7,7 +7,7 @@
 <module name="Checker">
   <property name="severity" value="warning" />
   <module name="LineLength">
-    <property name="id" value="lineLengthChecker"/>
+    <property name="id" value="lineLengthChecker" />
     <property name="max" value="120" />
     <property name="fileExtensions" value="java, py, sh, txt" />
   </module>
@@ -16,7 +16,7 @@
     <module name="RedundantModifier" />
     <module name="UnusedImports" />
     <module name="AvoidStarImport">
-      <property name="excludes" value="j2html.TagCreator,org.junit.Assert,com.google.common.base.Preconditions"/>
+      <property name="excludes" value="j2html.TagCreator,org.junit.Assert,info.freelibrary.util.Constants" />
     </module>
     <module name="ConstantName" />
     <module name="EqualsHashCode" />
@@ -44,17 +44,14 @@
     <module name="BooleanExpressionComplexity">
       <property name="max" value="4" />
     </module>
-    <module name="MissingJavadocMethod"/>
+    <module name="MissingJavadocMethod" />
     <module name="JavadocType">
       <property name="excludeScope" value="anoninner" />
-      <property name="scope" value="public" />
       <property name="allowUnknownTags" value="true" />
     </module>
-    <module name="MissingJavadocType"/>
-    <module name="MissingJavadocPackage"/>
-    <module name="JavadocMethod">
-      <property name="scope" value="public" />
-    </module>
+    <module name="MissingJavadocType" />
+    <module name="MissingJavadocPackage" />
+    <module name="JavadocMethod" />
     <module name="NeedBraces" />
     <module name="LeftCurly" />
     <module name="RightCurly" />
@@ -88,19 +85,19 @@
     </module>
   </module>
   <module name="FileTabCharacter">
-    <property name="id" value="fileTabCharacterChecker"/>
+    <property name="id" value="fileTabCharacterChecker" />
     <property name="eachLine" value="true" />
     <property name="fileExtensions" value="java,css,js,xml,xq,default,tmpl,properties" />
   </module>
   <module name="RegexpSingleline">
-    <property name="id" value="regexpSingleLineChecker"/>
+    <property name="id" value="regexpSingleLineChecker" />
     <property name="format" value="(?&lt;!\*)\s+$|\*\s\s+$" />
     <property name="message" value="Trailing whitespace" />
     <property name="fileExtensions" value="java,css,js,xml,html,default,tmpl,properties" />
   </module>
   <module name="SuppressWarningsFilter" />
   <module name="NewlineAtEndOfFile">
-    <property name="id" value="newLineAtEndOfFileChecker"/>
+    <property name="id" value="newLineAtEndOfFileChecker" />
     <property name="fileExtensions" value="java,css,js,xml,html,default,tmpl,properties" />
   </module>
 </module>

--- a/src/main/tools/pmd/ruleset.xml
+++ b/src/main/tools/pmd/ruleset.xml
@@ -1,75 +1,107 @@
 <?xml version="1.0"?>
-<ruleset name="Custom ruleset" xmlns="http://pmd.sourceforge.net/ruleset/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<ruleset name="Custom ruleset" xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 https://pmd.sourceforge.io/ruleset_2_0_0.xsd">
 
   <description>FreeLibrary PMD Rules</description>
 
   <exclude-pattern>.*/test/.*</exclude-pattern>
   <exclude-pattern>.*/generated/.*</exclude-pattern>
-  <rule ref="rulesets/java/android.xml" />
-  <rule ref="rulesets/java/basic.xml">
-    <exclude name="AvoidUsingOctalValues" />
+
+  <!-- For details about the Java rules, cf. https://pmd.github.io/pmd/pmd_rules_java -->
+
+  <rule ref="category/java/bestpractices.xml">
+    <exclude name="GuardLogStatement" />
   </rule>
-  <rule ref="rulesets/java/braces.xml" />
-  <rule ref="rulesets/java/clone.xml" />
-  <rule ref="rulesets/java/codesize.xml">
-    <exclude name="NPathComplexity" />
-    <exclude name="CyclomaticComplexity" />
-    <exclude name="StdCyclomaticComplexity" />
-    <exclude name="ModifiedCyclomaticComplexity" />
-  </rule>
-  <rule ref="rulesets/java/codesize.xml/TooManyMethods">
+  <rule ref="category/java/bestpractices.xml/UnusedPrivateMethod">
     <properties>
-      <property name="maxmethods" value="15" />
+      <property name="ignoredAnnotations"
+        value="com.fasterxml.jackson.annotation.JsonSetter|com.fasterxml.jackson.annotation.JsonGetter" />
     </properties>
   </rule>
-  <rule ref="rulesets/java/design.xml">
-    <exclude name="GodClass" />
-    <exclude name="AccessorMethodGeneration" />
-    <exclude name="AccessorClassGeneration" />
-    <exclude name="ConfusingTernary" />
-  </rule>
-  <rule ref="rulesets/java/design.xml/AvoidDeeplyNestedIfStmts">
+  <rule ref="category/java/bestpractices.xml/ForLoopVariableCount">
     <properties>
-      <property name="problemDepth" value="5" />
+      <property name="maximumVariables" value="2" />
     </properties>
   </rule>
-  <rule ref="rulesets/java/empty.xml" />
-  <rule ref="rulesets/java/finalizers.xml" />
-  <rule ref="rulesets/java/imports.xml">
-    <exclude name="TooManyStaticImports" />
-  </rule>
-  <rule ref="rulesets/java/junit.xml" />
-  <rule ref="rulesets/java/migrating.xml" />
-  <rule ref="rulesets/java/naming.xml">
-    <exclude name="ShortVariable" />
-  </rule>
-  <rule ref="rulesets/java/naming.xml/ShortClassName">
-    <properties>
-      <property name="minimum" value="3" />
-    </properties>
-  </rule>
-  <rule ref="rulesets/java/naming.xml/LongVariable">
-    <properties>
-      <property name="minimum" value="25" />
-    </properties>
-  </rule>
-  <rule ref="rulesets/java/optimizations.xml">
-    <exclude name="AvoidInstantiatingObjectsInLoops" />
-  </rule>
-  <rule ref="rulesets/java/strictexception.xml" />
-  <rule ref="rulesets/java/strings.xml" />
-  <rule ref="rulesets/java/sunsecure.xml" />
-  <rule ref="rulesets/java/typeresolution.xml" />
-  <rule ref="rulesets/java/unnecessary.xml">
-    <exclude name="UselessParentheses" />
-  </rule>
-  <rule ref="rulesets/java/unusedcode.xml">
-    <exclude name="UnusedPrivateMethod" />
+
+  <rule ref="category/java/codestyle.xml">
+    <exclude name="OnlyOneReturn" />
+    <exclude name="DefaultPackage" />
+    <exclude name="CallSuperInConstructor" /> <!-- Default super is handled by default -->
+    <exclude name="ConfusingTernary" /> <!-- It makes more sense to ask if something isn't null, IMHO -->
+    <exclude name="PrematureDeclaration" /> <!-- Sometimes useful, but more often than not a false positive -->
+    <exclude name="AtLeastOneConstructor" />
+    <exclude name="CommentDefaultAccessModifier" />
   </rule>
   <rule ref="category/java/codestyle.xml/ClassNamingConventions">
     <properties>
-      <property name="utilityClassPattern" value="[A-Z][a-zA-Z0-9]+"/>
+      <property name="classPattern" value="[A-Z][a-zA-Z0-9]*" />
+      <property name="abstractClassPattern" value="Abstract[A-Z][a-zA-Z0-9]*" />
+      <property name="interfacePattern" value="[A-Z][a-zA-Z0-9]*" />
+      <property name="enumPattern" value="[A-Z][a-zA-Z0-9]*" />
+      <property name="annotationPattern" value="[A-Z][a-zA-Z0-9]*" />
+      <property name="utilityClassPattern" value="[A-Z][a-zA-Z0-9]*" />
     </properties>
   </rule>
+  <rule ref="category/java/codestyle.xml/LinguisticNaming">
+    <properties>
+      <property name="ignoredAnnotations" value="java.lang.Override" />
+      <property name="checkBooleanMethod" value="true" />
+      <property name="checkGetters" value="true" />
+      <property name="checkSetters" value="false" />
+      <property name="booleanMethodPrefixes" value="is|has|should" />
+      <property name="transformMethodNames" value="to|as|from" />
+      <property name="checkFields" value="true" />
+      <property name="checkVariables" value="true" />
+      <property name="booleanFieldPrefixes" value="is|has|should" />
+    </properties>
+  </rule>
+  <rule ref="category/java/codestyle.xml/LongVariable">
+    <properties>
+      <property name="minimum" value="35" />
+    </properties>
+  </rule>
+  <rule ref="category/java/codestyle.xml/ShortVariable">
+    <properties>
+      <property name="minimum" value="1" />
+    </properties>
+  </rule>
+  <rule ref="category/java/codestyle.xml/ShortClassName">
+    <properties>
+      <property name="minimum" value="2" />
+    </properties>
+  </rule>
+
+  <rule ref="category/java/design.xml">
+    <exclude name="LawOfDemeter" />
+    <exclude name="LoosePackageCoupling" />
+    <exclude name="UselessOverridingMethod" />
+  </rule>
+  <rule ref="category/java/design.xml/TooManyMethods">
+    <properties>
+      <property name="maxmethods" value="20" />
+    </properties>
+  </rule>
+
+  <rule ref="category/java/documentation.xml" />
+  <rule ref="category/java/documentation.xml/CommentSize">
+    <properties>
+      <property name="maxLines" value="30" />
+      <property name="maxLineLength" value="120" />
+    </properties>
+  </rule>
+
+  <rule ref="category/java/errorprone.xml">
+    <exclude name="AssignmentInOperand" />
+    <exclude name="DataflowAnomalyAnalysis" />
+    <exclude name="BeanMembersShouldSerialize" />
+  </rule>
+
+  <rule ref="category/java/performance.xml">
+    <exclude name="AvoidInstantiatingObjectsInLoops" />
+  </rule>
+
+  <rule ref="category/java/security.xml" />
+
 </ruleset>

--- a/src/test/java/edu/ucla/library/iiif/fester/fit/MissingImageFT.java
+++ b/src/test/java/edu/ucla/library/iiif/fester/fit/MissingImageFT.java
@@ -164,6 +164,7 @@ public class MissingImageFT extends BaseFesterFT {
      * Check the results of our test.
      *
      * @param aAsyncTask An asynchronous task
+     * @param aContext A testing context
      */
     private void checkResults(final Async aAsyncTask, final TestContext aContext) {
         final Manifest manifest = Manifest.fromString(myS3Client.getObjectAsString(BUCKET, MANIFEST_S3_KEY));

--- a/src/test/java/edu/ucla/library/iiif/fester/fit/PagesManifestFT.java
+++ b/src/test/java/edu/ucla/library/iiif/fester/fit/PagesManifestFT.java
@@ -169,6 +169,7 @@ public class PagesManifestFT extends BaseFesterFT {
      * Check the results of our test.
      *
      * @param aAsyncTask An asynchronous task
+     * @param aContext A testing context
      */
     private void checkResults(final Async aAsyncTask, final TestContext aContext) {
         for (int index = 0; index < MANIFESTS.length; index++) {

--- a/src/test/java/edu/ucla/library/iiif/fester/fit/WorkUpdateFT.java
+++ b/src/test/java/edu/ucla/library/iiif/fester/fit/WorkUpdateFT.java
@@ -21,9 +21,9 @@ import edu.ucla.library.iiif.fester.HTTP;
 import edu.ucla.library.iiif.fester.MessageCodes;
 import edu.ucla.library.iiif.fester.MetadataLabels;
 import edu.ucla.library.iiif.fester.utils.ManifestTestUtils;
+import edu.ucla.library.iiif.fester.utils.TestUtils;
 import edu.ucla.library.iiif.fester.utils.V2ManifestTestUtils;
 import edu.ucla.library.iiif.fester.utils.V3ManifestTestUtils;
-import edu.ucla.library.iiif.fester.utils.TestUtils;
 
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
@@ -139,7 +139,6 @@ public class WorkUpdateFT extends BaseFesterFT {
     /**
      * Checks a manifest to make sure it's been updated.
      *
-     * @param aContext A test context
      * @param aManifestUtils A utilities class for a particular version of IIIF manifests
      * @return A future result of the check
      */
@@ -203,6 +202,7 @@ public class WorkUpdateFT extends BaseFesterFT {
      * A method to upload a CSV file.
      *
      * @param aForm A form with the CSV file's information
+     * @param aCsvFile A CSV file to upload
      * @param aPromise A promise that the upload happens
      */
     private void uploadCSV(final MultipartForm aForm, final File aCsvFile, final Promise<Void> aPromise) {

--- a/src/test/java/edu/ucla/library/iiif/fester/handlers/DeleteManifestHandlerTest.java
+++ b/src/test/java/edu/ucla/library/iiif/fester/handlers/DeleteManifestHandlerTest.java
@@ -15,6 +15,8 @@ import edu.ucla.library.iiif.fester.MessageCodes;
 import edu.ucla.library.iiif.fester.utils.IDUtils;
 import edu.ucla.library.iiif.fester.utils.TestUtils;
 
+import io.vertx.core.http.HttpClient;
+import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 
@@ -32,24 +34,26 @@ public class DeleteManifestHandlerTest extends AbstractFesterHandlerTest {
      * @throws IOException If there is trouble reading a manifest
      */
     @Test
-    @SuppressWarnings("deprecation")
     public void testDeleteManifestHandler(final TestContext aContext) throws IOException {
         final Async asyncTask = aContext.async();
         final int port = aContext.get(Config.HTTP_PORT);
         final String requestPath = IDUtils.getResourceURIPath(myManifestS3Key);
+        final HttpClient client = myVertx.createHttpClient();
 
         LOGGER.debug(MessageCodes.MFS_012, myManifestS3Key);
 
-        myVertx.createHttpClient().delete(port, Constants.UNSPECIFIED_HOST, requestPath, response -> {
-            final int statusCode = response.statusCode();
+        client.request(HttpMethod.DELETE, port, Constants.UNSPECIFIED_HOST, requestPath).onSuccess(handler -> {
+            handler.response(response -> {
+                final int statusCode = response.result().statusCode();
 
-            if (response.statusCode() == HTTP.SUCCESS_NO_CONTENT) {
-                aContext.assertFalse(myS3Client.doesObjectExist(myS3Bucket, myManifestS3Key));
-                TestUtils.complete(asyncTask);
-            } else {
-                aContext.fail(LOGGER.getMessage(MessageCodes.MFS_004, HTTP.SUCCESS_NO_CONTENT, statusCode));
-            }
-        }).end();
+                if (statusCode == HTTP.SUCCESS_NO_CONTENT) {
+                    aContext.assertFalse(myS3Client.doesObjectExist(myS3Bucket, myManifestS3Key));
+                    TestUtils.complete(asyncTask);
+                } else {
+                    aContext.fail(LOGGER.getMessage(MessageCodes.MFS_004, HTTP.SUCCESS_NO_CONTENT, statusCode));
+                }
+            }).end();
+        }).onFailure(aContext::fail);
     }
 
     /**
@@ -58,21 +62,23 @@ public class DeleteManifestHandlerTest extends AbstractFesterHandlerTest {
      * @param aContext A testing context
      */
     @Test
-    @SuppressWarnings("deprecation")
     public void testDeleteManifestHandler404(final TestContext aContext) {
         final Async asyncTask = aContext.async();
         final int port = aContext.get(Config.HTTP_PORT);
         final String testIDPath = "/testIdentifier"; // path should be: /{id}/manifest
+        final HttpClient client = myVertx.createHttpClient();
 
-        myVertx.createHttpClient().delete(port, Constants.UNSPECIFIED_HOST, testIDPath, response -> {
-            final int statusCode = response.statusCode();
+        client.request(HttpMethod.DELETE, port, Constants.UNSPECIFIED_HOST, testIDPath).onSuccess(handler -> {
+            handler.response(response -> {
+                final int statusCode = response.result().statusCode();
 
-            if (response.statusCode() != HTTP.NOT_FOUND) {
-                aContext.fail(LOGGER.getMessage(MessageCodes.MFS_004, HTTP.NOT_FOUND, statusCode));
-            }
+                if (statusCode != HTTP.NOT_FOUND) {
+                    aContext.fail(LOGGER.getMessage(MessageCodes.MFS_004, HTTP.NOT_FOUND, statusCode));
+                }
 
-            TestUtils.complete(asyncTask);
-        }).end();
+                TestUtils.complete(asyncTask);
+            }).end();
+        }).onFailure(aContext::fail);
     }
 
 }


### PR DESCRIPTION
This PR is broken down into two different commits (to make reviewing easier):

**785e588**: Security updates solved by moving to Vert.x v4
* Update dependencies for security fix (Vert.x v3 -> v4)
* Update vertx-super-s3 to vertx-s3-service (supports Vert.x v4)
  * This involved changes to our S3 code but did not involve updating to the S3 Vert.x Service (saving that for later)
  * This also did not involve taking advantage of the newer caching available with v4 uploading (saving that for later)
  * Involved changes in the way the S3Client is initialized
* Update Vert.x cache location in Docker container (v4 changed the way that's used)

**22e4a7a**: Update parent project, which introduced stricter code requirements
* Lots of Javadoc additions and updates (fixed variables, etc.)
* Simple PMD suggestions applied, but many more SuppressWarnings added as acknowledgments of tech debt
* Added Deprecation warnings for OpenAPI factories (will be replaced when we start using our validation service)
* Eclipse made automatic improvements to program flow in places with lots of nested if/else(s)

This PR intentionally avoids trying to do a large refactor and just focuses on addressing issues that are raised by the v3 -> v4 upgrade and upgrade of parent project's Checkstyle and PMD rules (and it punts on a lot of those by using SuppressWarnings).