### PR TITLE
Bump Vert.x version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
     <curl.version>7.81.0-1ubuntu1.6</curl.version>
 
     <!-- Application dependencies -->
-    <vertx.version>3.9.12</vertx.version>
+    <vertx.version>3.9.14</vertx.version>
     <opencsv.version>5.7.1</opencsv.version>
     <moirai.version>2.0.0</moirai.version>
     <slf4j.ext.version>1.7.32</slf4j.ext.version>

--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,8 @@
     <commons.io.version>2.7</commons.io.version>
     <jackson.version>2.13.4</jackson.version>
     <jackson.databind.version>2.14.0-rc1</jackson.databind.version>
-    <netty.version>4.1.77.Final</netty.version>
+    <netty.handler.version>4.1.79.Final</netty.handler.version>
+    <netty.common.version>4.1.84.Final</netty.common.version>
 
     <!-- Exclusions/Replacements -->
     <commons.codec.version>1.14</commons.codec.version>
@@ -278,16 +279,6 @@
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
       <version>${commons.io.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-common</artifactId>
-      <version>${netty.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-handler</artifactId>
-      <version>${netty.version}</version>
     </dependency>
 
     <!-- A Vert.x plug-in for more flexible configuration control -->


### PR DESCRIPTION
Javadocs generation on the release failed because the Vert.x version was behind and they're apparently only leaving the last version of the 3.x's Javadocs online at this point.