### PR TITLE
[SERV-910] Add a catch for duplicate IDs in collection doc

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <curl.version>7.81.0-1ubuntu1.13</curl.version>
 
     <!-- Application dependencies -->
-    <vertx.version>3.9.14</vertx.version>
+    <vertx.version>3.9.16</vertx.version>
     <opencsv.version>5.7.1</opencsv.version>
     <moirai.version>2.0.0</moirai.version>
     <slf4j.ext.version>1.7.32</slf4j.ext.version>

--- a/pom.xml
+++ b/pom.xml
@@ -34,45 +34,19 @@
       <organization>UCLA Library</organization>
       <organizationUrl>http://github.com/uclalibrary</organizationUrl>
       <timezone>America/New_York</timezone>
+      <roles>
+        <role>Lead Developer</role>
+      </roles>
     </developer>
-    <developer>
-      <id>hardyoyo</id>
-      <name>Hardy Pottinger</name>
-      <email>hardy.pottinger@gmail.com</email>
-      <timezone>America/Chicago</timezone>
-    </developer>
-    <developer>
-      <id>cachemeoutside</id>
-      <name>Anthony Vuong</name>
-      <email>avuong@cachemeoutside.io</email>
-      <organization>UCLA Library</organization>
-      <organizationUrl>http://github.com/uclalibrary</organizationUrl>
-      <timezone>America/Los_Angeles</timezone>
-    </developer>
-    <developer>
-      <id>markmatney</id>
-      <name>Mark A. Matney, Jr.</name>
-      <email>mmatney@library.ucla.edu</email>
-      <organization>UCLA Library</organization>
-      <organizationUrl>http://github.com/uclalibrary</organizationUrl>
-      <timezone>America/Los_Angeles</timezone>
-    </developer>
-    <developer>
-      <id>DRickard</id>
-      <name>David Rickard</name>
-      <email>drickard1967@library.ucla.edu</email>
-      <organization>UCLA Library</organization>
-      <organizationUrl>http://github.com/uclalibrary</organizationUrl>
-      <timezone>America/Los_Angeles</timezone>
-    </developer>
+    <!-- Also https://github.com/UCLALibrary/fester/graphs/contributors -->
   </developers>
 
   <properties>
     <!-- Docker image dependencies -->
     <ubuntu.tag>22.04</ubuntu.tag>
-    <jdk.version>17.0.4+8-1~22.04</jdk.version>
+    <jdk.version>17.0.8.1+1~us1-0ubuntu1~22.04</jdk.version>
     <python3.version>3.10.6-1~22.04</python3.version>
-    <curl.version>7.81.0-1ubuntu1.6</curl.version>
+    <curl.version>7.81.0-1ubuntu1.13</curl.version>
 
     <!-- Application dependencies -->
     <vertx.version>3.9.14</vertx.version>

--- a/src/main/docker/scripts/show_versions.sh
+++ b/src/main/docker/scripts/show_versions.sh
@@ -14,7 +14,7 @@ print_line() {
 }
 
 declare -a DEPENDENCIES=(
-  "openjdk-11-jre-headless"
+  "openjdk-17-jre-headless"
   "python3"
   "curl"
 )

--- a/src/main/java/edu/ucla/library/iiif/fester/verticles/V2ManifestVerticle.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/verticles/V2ManifestVerticle.java
@@ -288,7 +288,7 @@ public class V2ManifestVerticle extends AbstractFesterVerticle {
         final Stream<Collection.Manifest> stream = collection.getManifests().stream();
 
         try {
-            // Below can throw a RuntimeException if duplicate IDs are found
+            // Below can throw a IllegalStateException if duplicate IDs are found
             manifestMap.putAll(stream.collect(Collectors.toMap(Collection.Manifest::getID, manifest -> manifest)));
 
             // Next, add the new manifests to the map, replacing any that already exist
@@ -314,7 +314,7 @@ public class V2ManifestVerticle extends AbstractFesterVerticle {
                     error(aMessage, update.cause(), MessageCodes.MFS_152, update.cause().getMessage());
                 }
             });
-        } catch (final RuntimeException details) {
+        } catch (final IllegalStateException details) {
             LOGGER.error(details, details.getMessage());
             aMessage.fail(HTTP.INTERNAL_SERVER_ERROR, details.getMessage());
         }


### PR DESCRIPTION
* Catch unusual duplicate ID runtime exception

And, in addition:
* Switch to our new convention for listing devs
* Update dependencies
* Eclipse did two minor syntactical reformats