### PR TITLE
[SERV-909] Update metadata updating

### DIFF
--- a/src/main/java/edu/ucla/library/iiif/fester/verticles/V2ManifestVerticle.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/verticles/V2ManifestVerticle.java
@@ -610,6 +610,9 @@ public class V2ManifestVerticle extends AbstractFesterVerticle {
                 } // If label matches but we have no updated value, ignore the metadata
             }
         } else {
+            // Our metadata comes in pairs so, when looping through an array of all the values, we
+            // need to skip every other one (move the index to the the start of the pair) and halve
+            // the total array count (since we're counting the pair of values as one thing).
             for (int index = 0; index < aStringArray.length / 2; index += 2) {
                 metadata.add(aStringArray[index], aStringArray[index + 1]);
             }

--- a/src/main/java/edu/ucla/library/iiif/fester/verticles/V2ManifestVerticle.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/verticles/V2ManifestVerticle.java
@@ -609,6 +609,10 @@ public class V2ManifestVerticle extends AbstractFesterVerticle {
                     metadata.add(entry);
                 } // If label matches but we have no updated value, ignore the metadata
             }
+        } else {
+            for (int index = 0; index < aStringArray.length / 2; index += 2) {
+                metadata.add(aStringArray[index], aStringArray[index + 1]);
+            }
         }
 
         return metadata;

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <configuration debug="false">
   <property file="/etc/fester/fester.properties" />
 
@@ -24,6 +24,15 @@
   </logger>
 
   <logger name="info.freelibrary.util.I18nException" level="WARN" additivity="true">
+    <appender-ref ref="STDOUT" />
+    <if condition='property("fluency.enabled").equals("true")'>
+      <then>
+        <appender-ref ref="FLUENCY" />
+      </then>
+    </if>
+  </logger>
+
+  <logger name="info.freelibrary.iiif.presentation.v2.ServiceImage" level="ERROR">
     <appender-ref ref="STDOUT" />
     <if condition='property("fluency.enabled").equals("true")'>
       <then>


### PR DESCRIPTION
Previously, if the manifest didn't have any metadata we didn't update it, but this commit changes that so that new metadata fields are added even if there aren't any pre-existing metadata fields in the record.

I also turned down logging on the presentation library's attempt to derive a media type from the URL since not all URLs have file extensions on them. This is something that should probably be fixed upstream too, fwiw.