### PR TITLE
[SERV-1299] Fix manifest PUT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<!--<?xml version="1.0" encoding="UTF-8"?>-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
@@ -70,7 +70,7 @@
   <properties>
     <!-- Docker image dependencies -->
     <ubuntu.tag>22.04</ubuntu.tag>
-    <jdk.version>17.0.14+7-1~22.04.1</jdk.version>
+    <jdk.version>17.0.15+6~us1-0ubuntu1~22.04</jdk.version>
     <python3.version>3.10.6-1~22.04.1</python3.version>
     <curl.version>7.81.0-1ubuntu1.20</curl.version>
 

--- a/src/main/java/edu/ucla/library/iiif/fester/handlers/PutCollectionHandler.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/handlers/PutCollectionHandler.java
@@ -40,7 +40,8 @@ public class PutCollectionHandler extends AbstractFesterHandler {
         final JsonObject message = new JsonObject();
         final DeliveryOptions options = new DeliveryOptions();
 
-        message.put(Constants.COLLECTION_NAME, collectionName).put(Constants.DATA, aContext.getBodyAsJson());
+        message.put(Constants.COLLECTION_NAME, collectionName);
+        message.put(Constants.DATA, aContext.getBodyAsJson());
         options.addHeader(Constants.ACTION, Op.PUT_COLLECTION);
 
         sendMessage(S3BucketVerticle.class.getName(), message, options, send -> {

--- a/src/main/java/edu/ucla/library/iiif/fester/verticles/S3BucketVerticle.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/verticles/S3BucketVerticle.java
@@ -10,6 +10,7 @@ import com.amazonaws.regions.RegionUtils;
 import info.freelibrary.util.Logger;
 import info.freelibrary.util.LoggerFactory;
 import info.freelibrary.util.StringUtils;
+
 import info.freelibrary.vertx.s3.S3Client;
 
 import edu.ucla.library.iiif.fester.Config;
@@ -19,6 +20,7 @@ import edu.ucla.library.iiif.fester.MessageCodes;
 import edu.ucla.library.iiif.fester.Op;
 import edu.ucla.library.iiif.fester.utils.CodeUtils;
 import edu.ucla.library.iiif.fester.utils.IDUtils;
+
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 import io.vertx.core.Promise;
@@ -172,8 +174,8 @@ public class S3BucketVerticle extends AbstractFesterVerticle {
         final Buffer manifestContent = aManifest.toBuffer();
         final String manifestID = IDUtils.getResourceID(aS3Key);
         final String context = aManifest.getString("@context");
-        final String idKey;
         final String derivedManifestS3Key;
+        final String idKey;
 
         if (context.equals(Constants.CONTEXT_V2)) {
             idKey = Constants.ID_V2;

--- a/src/test/java/edu/ucla/library/iiif/fester/verticles/FakeS3BucketVerticle.java
+++ b/src/test/java/edu/ucla/library/iiif/fester/verticles/FakeS3BucketVerticle.java
@@ -23,6 +23,7 @@ import edu.ucla.library.iiif.fester.MessageCodes;
 import edu.ucla.library.iiif.fester.Op;
 import edu.ucla.library.iiif.fester.utils.CodeUtils;
 import edu.ucla.library.iiif.fester.utils.IDUtils;
+
 import io.vertx.core.eventbus.Message;
 import io.vertx.core.json.JsonObject;
 
@@ -60,15 +61,16 @@ public class FakeS3BucketVerticle extends AbstractFesterVerticle {
                 StringUtils.format("src/test/resources/json/{}/ark%3A%2F21198%2Fzz0009gsq9.json", myIiifApiVersion)));
         JSON_FILES.put(IDUtils.getWorkS3Key("ark:/21198/zz0009gv8j"), new File(
                 StringUtils.format("src/test/resources/json/{}/ark%3A%2F21198%2Fzz0009gv8j.json", myIiifApiVersion)));
-        JSON_FILES.put(IDUtils.getWorkS3Key("ark:/21198/z12f8rtw"),
-                new File(StringUtils.format("src/test/resources/json/{}/ark%3A%2F21198%2Fz12f8rtw.json",
-                        myIiifApiVersion)));
+        JSON_FILES.put(IDUtils.getWorkS3Key("ark:/21198/z12f8rtw"), new File(
+                StringUtils.format("src/test/resources/json/{}/ark%3A%2F21198%2Fz12f8rtw.json", myIiifApiVersion)));
 
         vertx.eventBus().<JsonObject>consumer(S3BucketVerticle.class.getName()).handler(message -> {
             final JsonObject body = message.body();
             final String manifestID;
             final JsonObject manifest;
             final String action = message.headers().get(Constants.ACTION);
+
+            LOGGER.debug("action: " + action);
 
             switch (action) {
                 case Op.GET_MANIFEST:

--- a/src/test/java/edu/ucla/library/iiif/fester/verticles/FakeS3BucketVerticle.java
+++ b/src/test/java/edu/ucla/library/iiif/fester/verticles/FakeS3BucketVerticle.java
@@ -70,8 +70,6 @@ public class FakeS3BucketVerticle extends AbstractFesterVerticle {
             final JsonObject manifest;
             final String action = message.headers().get(Constants.ACTION);
 
-            LOGGER.debug("action: " + action);
-
             switch (action) {
                 case Op.GET_MANIFEST:
                     manifestID = body.getString(Constants.MANIFEST_ID);


### PR DESCRIPTION
* Update the manifest PUT endpoint to use the S3BucketVerticle instead of the S3 client
* Eclipse did some auto-formatting
* Update AbstractFesterHandlerTest's S3 configuration so that it uses the more recent method
* Update manifest PUT's tests to also use the more recent method