### PR TITLE
[DLSR-278] Remove Javadocs creation from release GA

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
           MAVEN_GPG_KEY: ${{ secrets.BUILD_KEY }}
         run: |
           mvn -s .maven/settings.xml -U -ntp clean deploy -Prelease -Drevision=${{ github.event.release.tag_name }} \
-            -DlogLevel=DEBUG -DtestLogLevel=DEBUG -DskipPublishing=true \
+            -DlogLevel=DEBUG -DtestLogLevel=DEBUG -DskipPublishing=true -Dmaven.javadoc.skip=true \
             -Ddocker.registry.username="${{ secrets.DOCKER_USERNAME }}" \
             -Ddocker.registry.account="${{ secrets.DOCKER_REGISTRY_ACCOUNT}}" \
             -Ddocker.registry.password="${{ secrets.DOCKER_PASSWORD }}" \


### PR DESCRIPTION
We don't need Javadocs for this project. The upstream parent project though has introduced stricter Javadoc requirements, so we'll just turn off Javadoc creation.