### PR TITLE
Upgrade logging for bad URLs

### DIFF
--- a/src/main/java/edu/ucla/library/iiif/fester/ImageInfoLookup.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/ImageInfoLookup.java
@@ -39,14 +39,23 @@ public class ImageInfoLookup {
      * @throws ImageNotFoundException If the requested image cannot be found
      */
     public ImageInfoLookup(final String aURL) throws MalformedURLException, IOException, ImageNotFoundException {
-        LOGGER.debug(MessageCodes.MFS_072, aURL);
+        final URI uri;
+
+        // Check to make sure our URL is valid
+        try {
+            uri = URI.create(aURL);
+            LOGGER.debug(MessageCodes.MFS_072, aURL);
+        } catch (IllegalArgumentException details) {
+            LOGGER.error(details, MessageCodes.MFS_190, aURL);
+            throw new MalformedURLException(aURL);
+        }
 
         // If our images are using an unspecified host, we're running in test mode and will use fake values
         if (aURL.contains(Constants.UNSPECIFIED_HOST) || aURL.startsWith(FAKE_IIIF_SERVER)) {
             myHeight = 1000;
             myWidth = 1000;
         } else {
-            final HttpURLConnection connection = (HttpURLConnection) URI.create(aURL).toURL().openConnection();
+            final HttpURLConnection connection = (HttpURLConnection) uri.toURL().openConnection();
             final int responseCode;
 
             connection.setReadTimeout(CANTALOUPE_TIMEOUT);

--- a/src/main/java/edu/ucla/library/iiif/fester/verticles/V3ManifestVerticle.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/verticles/V3ManifestVerticle.java
@@ -5,9 +5,7 @@ import static edu.ucla.library.iiif.fester.Constants.EMPTY;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import java.io.IOException;
-import java.net.MalformedURLException;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
@@ -576,14 +574,12 @@ public class V3ManifestVerticle extends AbstractFesterVerticle {
                         width = Integer.parseInt(mediaWidth.get());
                         height = Integer.parseInt(mediaHeight.get());
                         image = new ImageContent(accessURI).setWidthHeight(width, height);
-                    } else if (isValidURL(pageURI)) {
+                    } else {
                         final ImageInfoLookup infoLookup = new ImageInfoLookup(pageURI);
 
                         width = infoLookup.getWidth();
                         height = infoLookup.getHeight();
                         image = new ImageContent(resourceURI).setServices(new ImageService2(pageURI));
-                    } else {
-                        throw new ImageNotFoundException(pageURI);
                     }
 
                     canvas.setWidthHeight(width, height).setThumbnails(new ImageContent(thumbnail));
@@ -591,7 +587,7 @@ public class V3ManifestVerticle extends AbstractFesterVerticle {
                 } catch (final ImageNotFoundException | IOException details) {
                     LOGGER.info(MessageCodes.MFS_078, pageID);
 
-                    if (aPlaceholderImage != null && isValidURL(aPlaceholderImage)) {
+                    if (aPlaceholderImage != null) {
                         try {
                             final ImageInfoLookup placeholderLookup = new ImageInfoLookup(aPlaceholderImage);
                             final int size;
@@ -645,21 +641,6 @@ public class V3ManifestVerticle extends AbstractFesterVerticle {
         }
 
         return canvases.toArray(new Canvas[] {});
-    }
-
-    /**
-     * Check for a valid URL.
-     *
-     * @param aURL A string which might be a valid URL
-     * @return True if the supplied string is a URL; else, false
-     */
-    private static boolean isValidURL(String aURL) {
-        try {
-            new URI(aURL).toURL();
-            return true;
-        } catch (MalformedURLException | URISyntaxException details) {
-            return false;
-        }
     }
 
     private VideoContent[] getVideoContent(final String aResourceURI) {

--- a/src/main/resources/fester_messages.xml
+++ b/src/main/resources/fester_messages.xml
@@ -200,4 +200,5 @@
   <entry key="MFS-187">Uploaded zips must only contain JSON files</entry>
   <entry key="MFS-188">Unexpected resource type: {}</entry>
   <entry key="MFS-189">Patched JSON file: {}</entry>
+  <entry key="MFS-190">Image info lookup failed because of a malformed URL: {}</entry>
 </properties>

--- a/src/test/java/edu/ucla/library/iiif/fester/fit/BatchIngestFfOffT.java
+++ b/src/test/java/edu/ucla/library/iiif/fester/fit/BatchIngestFfOffT.java
@@ -5,7 +5,6 @@ import static edu.ucla.library.iiif.fester.Constants.POST_CSV_ROUTE;
 import static edu.ucla.library.iiif.fester.Constants.UNSPECIFIED_HOST;
 
 import org.jsoup.Jsoup;
-import org.jsoup.nodes.Element;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -85,5 +84,4 @@ public class BatchIngestFfOffT extends BaseFesterFfT {
             }
         });
     }
-
 }

--- a/src/test/java/edu/ucla/library/iiif/fester/fit/BatchIngestFfOffT.java
+++ b/src/test/java/edu/ucla/library/iiif/fester/fit/BatchIngestFfOffT.java
@@ -5,6 +5,7 @@ import static edu.ucla.library.iiif.fester.Constants.POST_CSV_ROUTE;
 import static edu.ucla.library.iiif.fester.Constants.UNSPECIFIED_HOST;
 
 import org.jsoup.Jsoup;
+import org.jsoup.nodes.Element;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 


### PR DESCRIPTION
URI.create() throws an IllegalArgumentException instead of MalformedURLException (like `new URL("").toURL()`) so that needs to be caught. Uncaught exceptions can cause the program to hang. For now, this just adds some logging (in addition to improving the error handling so we can see what's being supplied as the URL (and why it's malformed)).