### PR TITLE
[DLSR-317] Improve bad URL handling

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,4 +47,4 @@ jobs:
           mvn -U -ntp clean verify \
             -Dfester.s3.access_key="${{ secrets.AWS_ACCESS_KEY }}" -Dsurefire.skipAfterFailureCount=1 \
             -Dfester.s3.secret_key="${{ secrets.AWS_SECRET_KEY }}" -Dfailsafe.skipAfterFailureCount=1 \
-            -Dfester.s3.bucket="${{ secrets.S3_BUCKET }}" -DlogLevel=DEBUG -DtestLogLevel=DEBUG
+            -Dfester.s3.bucket="${{ secrets.S3_BUCKET }}" -DlogLevel=INFO -DtestLogLevel=INFO

--- a/src/main/java/edu/ucla/library/iiif/fester/ImageInfoLookup.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/ImageInfoLookup.java
@@ -9,6 +9,7 @@ import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URI;
+import java.net.URL;
 
 import info.freelibrary.util.Logger;
 import info.freelibrary.util.LoggerFactory;
@@ -39,11 +40,11 @@ public class ImageInfoLookup {
      * @throws ImageNotFoundException If the requested image cannot be found
      */
     public ImageInfoLookup(final String aURL) throws MalformedURLException, IOException, ImageNotFoundException {
-        final URI uri;
+        final URL url;
 
         // Check to make sure our URL is valid
         try {
-            uri = URI.create(aURL);
+            url = URI.create(aURL).toURL();
             LOGGER.debug(MessageCodes.MFS_072, aURL);
         } catch (IllegalArgumentException details) {
             LOGGER.error(details, MessageCodes.MFS_190, aURL);
@@ -55,7 +56,7 @@ public class ImageInfoLookup {
             myHeight = 1000;
             myWidth = 1000;
         } else {
-            final HttpURLConnection connection = (HttpURLConnection) uri.toURL().openConnection();
+            final HttpURLConnection connection = (HttpURLConnection) url.openConnection();
             final int responseCode;
 
             connection.setReadTimeout(CANTALOUPE_TIMEOUT);

--- a/src/main/java/edu/ucla/library/iiif/fester/ImageInfoLookup.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/ImageInfoLookup.java
@@ -48,7 +48,7 @@ public class ImageInfoLookup {
             LOGGER.debug(MessageCodes.MFS_072, aURL);
         } catch (IllegalArgumentException details) {
             LOGGER.error(details, MessageCodes.MFS_190, aURL);
-            throw new MalformedURLException(aURL);
+            throw new ImageNotFoundException(MessageCodes.MFS_190, aURL);
         }
 
         // If our images are using an unspecified host, we're running in test mode and will use fake values

--- a/src/main/java/edu/ucla/library/iiif/fester/utils/ItemSequenceComparator.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/utils/ItemSequenceComparator.java
@@ -1,6 +1,3 @@
-/**
- *
- */
 
 package edu.ucla.library.iiif.fester.utils;
 

--- a/src/main/java/edu/ucla/library/iiif/fester/verticles/V2ManifestVerticle.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/verticles/V2ManifestVerticle.java
@@ -406,6 +406,7 @@ public class V2ManifestVerticle extends AbstractFesterVerticle {
      *
      * @param aMessage A message with information about the page updates
      * @throws JsonProcessingException If there is trouble deserializing message components
+     * @throws ImageNotFoundException If the canvas' image couldn't be found
      */
     private void updatePages(final Message<JsonObject> aMessage)
             throws JsonProcessingException, ImageNotFoundException {

--- a/src/main/java/edu/ucla/library/iiif/fester/verticles/V2ManifestVerticle.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/verticles/V2ManifestVerticle.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import info.freelibrary.util.Logger;
 import info.freelibrary.util.LoggerFactory;
 import info.freelibrary.util.StringUtils;
+import info.freelibrary.util.ThrowingConsumer;
 
 import info.freelibrary.iiif.presentation.v2.Canvas;
 import info.freelibrary.iiif.presentation.v2.Collection;
@@ -107,6 +108,9 @@ public class V2ManifestVerticle extends AbstractFesterVerticle {
                         message.fail(HTTP.INTERNAL_SERVER_ERROR, LOGGER.getMessage(MessageCodes.MFS_153, action));
                         break;
                 }
+            } catch (final ImageNotFoundException details) {
+                LOGGER.error(details, details.getMessage());
+                message.fail(HTTP.BAD_REQUEST, details.getMessage());
             } catch (final JsonProcessingException | DecodeException details) {
                 LOGGER.error(details, details.getMessage());
                 message.fail(HTTP.INTERNAL_SERVER_ERROR, details.getMessage());
@@ -190,8 +194,9 @@ public class V2ManifestVerticle extends AbstractFesterVerticle {
      *
      * @param aMessage Information needed to create a work manifest
      * @throws JsonProcessingException If there is trouble deserializing shared information
+     * @throws ImageNotFoundException If an image URL from the CSV data is bad or an empty URL
      */
-    private void createWork(final Message<JsonObject> aMessage) throws JsonProcessingException {
+    private void createWork(final Message<JsonObject> aMessage) throws JsonProcessingException, ImageNotFoundException {
         final JsonObject body = aMessage.body();
         final ObjectMapper mapper = new ObjectMapper();
         final CsvHeaders csvHeaders = CsvHeaders.fromJSON(body.getJsonObject(Constants.CSV_HEADERS));
@@ -251,13 +256,15 @@ public class V2ManifestVerticle extends AbstractFesterVerticle {
             pageList.sort(new ItemSequenceComparator(csvHeaders.getItemSequenceIndex()));
             sequence.addCanvas(createCanvases(csvHeaders, pageList, imageHost, placeholderImage, encodedWorkID));
         } else {
-            CsvParser.getMetadata(workRow, csvHeaders.getContentAccessUrlIndex()).ifPresent(accessURL -> {
-                final List<String[]> pageList = new ArrayList<>(1);
+            CsvParser.getMetadata(workRow, csvHeaders.getContentAccessUrlIndex())
+                    .ifPresent(ThrowingConsumer.sneaky(accessURL -> {
+                        final List<String[]> pageList = new ArrayList<>(1);
 
-                pageList.add(workRow);
-                manifest.addSequence(sequence);
-                sequence.addCanvas(createCanvases(csvHeaders, pageList, imageHost, placeholderImage, encodedWorkID));
-            });
+                        pageList.add(workRow);
+                        manifest.addSequence(sequence);
+                        sequence.addCanvas(
+                                createCanvases(csvHeaders, pageList, imageHost, placeholderImage, encodedWorkID));
+                    }));
         }
 
         jsonManifest = manifest.toJSON();
@@ -400,7 +407,8 @@ public class V2ManifestVerticle extends AbstractFesterVerticle {
      * @param aMessage A message with information about the page updates
      * @throws JsonProcessingException If there is trouble deserializing message components
      */
-    private void updatePages(final Message<JsonObject> aMessage) throws JsonProcessingException {
+    private void updatePages(final Message<JsonObject> aMessage)
+            throws JsonProcessingException, ImageNotFoundException {
         final JsonObject body = aMessage.body();
         final String workID = body.getString(Constants.MANIFEST_ID);
         final String imageHost = body.getString(Constants.IIIF_HOST);
@@ -460,11 +468,12 @@ public class V2ManifestVerticle extends AbstractFesterVerticle {
      * @param aImageHost An image host for image links
      * @param aWorkID A URL encoded work ID
      * @return An array of canvases
-     * @throws IOException If there is trouble adding a page
+     * @throws ImageNotFoundException If the canvas' image couldn't be found
      */
     @SuppressWarnings({ "PMD.CyclomaticComplexity", "PMD.NcssCount" })
     private Canvas[] createCanvases(final CsvHeaders aCsvHeaders, final List<String[]> aPageList,
-            final String aImageHost, final String aPlaceholderImage, final String aWorkID) {
+            final String aImageHost, final String aPlaceholderImage, final String aWorkID)
+            throws ImageNotFoundException {
         final Iterator<String[]> iterator = aPageList.iterator();
         final List<Canvas> canvases = new ArrayList<>();
 

--- a/src/main/java/edu/ucla/library/iiif/fester/verticles/V3ManifestVerticle.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/verticles/V3ManifestVerticle.java
@@ -73,7 +73,6 @@ import edu.ucla.library.iiif.fester.utils.V3CollectionItemLabelComparator;
 import io.vertx.core.Promise;
 import io.vertx.core.eventbus.DeliveryOptions;
 import io.vertx.core.eventbus.Message;
-import io.vertx.core.json.DecodeException;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
@@ -119,10 +118,10 @@ public class V3ManifestVerticle extends AbstractFesterVerticle {
                         message.fail(HTTP.INTERNAL_SERVER_ERROR, LOGGER.getMessage(MessageCodes.MFS_153, action));
                         break;
                 }
-            } catch (final JsonProcessingException | DecodeException details) {
-                LOGGER.error(details, details.getMessage());
-                message.fail(HTTP.INTERNAL_SERVER_ERROR, details.getMessage());
-            } catch (final RuntimeException details) {
+            } catch (final ImageNotFoundException details) {
+                // We logged this earlier in the ImageInfoLookup class
+                message.fail(HTTP.BAD_REQUEST, details.getMessage());
+            } catch (final JsonProcessingException | RuntimeException details) {
                 LOGGER.error(details, details.getMessage());
                 message.fail(HTTP.INTERNAL_SERVER_ERROR, details.getMessage());
             }
@@ -203,8 +202,9 @@ public class V3ManifestVerticle extends AbstractFesterVerticle {
      *
      * @param aMessage Information needed to create a work manifest
      * @throws JsonProcessingException If there is trouble deserializing shared information
+     * @throws ImageNotFoundException If the image from the CSV data couldn't be found or was bad data
      */
-    private void createWork(final Message<JsonObject> aMessage) throws JsonProcessingException {
+    private void createWork(final Message<JsonObject> aMessage) throws JsonProcessingException, ImageNotFoundException {
         final JsonObject body = aMessage.body();
         final ObjectMapper mapper = new ObjectMapper();
         final CsvHeaders csvHeaders = CsvHeaders.fromJSON(body.getJsonObject(Constants.CSV_HEADERS));
@@ -429,8 +429,10 @@ public class V3ManifestVerticle extends AbstractFesterVerticle {
      *
      * @param aMessage A message with information about the page updates
      * @throws JsonProcessingException If there is trouble deserializing message components
+     * @throws ImageNotFoundException If the image from the CSV data couldn't be found or was bad data
      */
-    private void updatePages(final Message<JsonObject> aMessage) throws JsonProcessingException {
+    private void updatePages(final Message<JsonObject> aMessage)
+            throws JsonProcessingException, ImageNotFoundException {
         final JsonObject body = aMessage.body();
         final String workID = body.getString(Constants.MANIFEST_ID);
         final String imageHost = body.getString(Constants.IIIF_HOST);
@@ -478,9 +480,11 @@ public class V3ManifestVerticle extends AbstractFesterVerticle {
      * @param aSequence A sequence to add pages to
      * @param aImageHost An image host for image links
      * @param aMinter An ID minter
+     * @throws ImageNotFoundException If the image from the CSV data couldn't be found or was bad data
      */
     private Canvas[] createCanvases(final CsvHeaders aCsvHeaders, final List<String[]> aPageList,
-            final String aImageHost, final String aPlaceholderImage, final Minter aMinter) {
+            final String aImageHost, final String aPlaceholderImage, final Minter aMinter)
+            throws ImageNotFoundException {
         final Iterator<String[]> iterator = aPageList.iterator();
         final List<Canvas> canvases = new ArrayList<>();
 
@@ -584,7 +588,7 @@ public class V3ManifestVerticle extends AbstractFesterVerticle {
 
                     canvas.setWidthHeight(width, height).setThumbnails(new ImageContent(thumbnail));
                     canvas.paintWith(image);
-                } catch (final ImageNotFoundException | IOException details) {
+                } catch (final IOException details) {
                     LOGGER.info(MessageCodes.MFS_078, pageID);
 
                     if (aPlaceholderImage != null) {
@@ -608,7 +612,7 @@ public class V3ManifestVerticle extends AbstractFesterVerticle {
                             // Create a canvas using the width and height of the placeholder image
                             canvas.setWidthHeight(width, height).setThumbnails(new ImageContent(thumbnail));
                             canvas.paintWith(image);
-                        } catch (final ImageNotFoundException | IOException lookupDetails) {
+                        } catch (final IOException lookupDetails) {
                             // We couldn't find the placeholder image so we create an empty canvas
                             LOGGER.error(lookupDetails, lookupDetails.getMessage());
 

--- a/src/test/java/edu/ucla/library/iiif/fester/fit/BatchIngestFfOffT.java
+++ b/src/test/java/edu/ucla/library/iiif/fester/fit/BatchIngestFfOffT.java
@@ -5,7 +5,6 @@ import static edu.ucla.library.iiif.fester.Constants.POST_CSV_ROUTE;
 import static edu.ucla.library.iiif.fester.Constants.UNSPECIFIED_HOST;
 
 import org.jsoup.Jsoup;
-import org.jsoup.nodes.Element;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 

--- a/src/test/java/edu/ucla/library/iiif/fester/fit/BatchIngestFfOffT.java
+++ b/src/test/java/edu/ucla/library/iiif/fester/fit/BatchIngestFfOffT.java
@@ -5,6 +5,7 @@ import static edu.ucla.library.iiif.fester.Constants.POST_CSV_ROUTE;
 import static edu.ucla.library.iiif.fester.Constants.UNSPECIFIED_HOST;
 
 import org.jsoup.Jsoup;
+import org.jsoup.nodes.Element;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 


### PR DESCRIPTION
Have the ImageInfoLookup throw an ImageNotFoundException if the image couldn't be found due to a bad/empty URL. Catch this and return a 400 (Bad Request) to fail the job.

* Turn down log levels for easier, everyday log surfing
* Fail job if the job has been submitted with a bad/empty image URL in the CSV data