### PR TITLE
[DLSR-357] Add ImageLookup URL logging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
     <ubuntu.tag>22.04</ubuntu.tag>
     <jdk.version>21.0.10+7-1~22.04</jdk.version>
     <python3.version>3.10.6-1~22.04.1</python3.version>
-    <curl.version>7.81.0-1ubuntu1.23</curl.version>
+    <curl.version>7.81.0-1ubuntu1.24</curl.version>
 
     <!-- Application dependencies -->
     <vertx.version>3.9.16</vertx.version>

--- a/src/main/java/edu/ucla/library/iiif/fester/ImageInfoLookup.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/ImageInfoLookup.java
@@ -42,12 +42,14 @@ public class ImageInfoLookup {
     public ImageInfoLookup(final String aURL) throws MalformedURLException, IOException, ImageNotFoundException {
         final URL url;
 
+        LOGGER.info(MessageCodes.MFS_191, aURL.isBlank() ? "[MISSING]" : aURL);
+
         // Check to make sure our URL is valid
         try {
             url = URI.create(aURL).toURL();
             LOGGER.debug(MessageCodes.MFS_072, aURL);
         } catch (IllegalArgumentException details) {
-            LOGGER.error(details, MessageCodes.MFS_190, aURL);
+            LOGGER.error(details, MessageCodes.MFS_190, aURL.isBlank() ? "[MISSING]" : aURL);
             throw new ImageNotFoundException(MessageCodes.MFS_190, aURL);
         }
 

--- a/src/main/java/edu/ucla/library/iiif/fester/verticles/V3ManifestVerticle.java
+++ b/src/main/java/edu/ucla/library/iiif/fester/verticles/V3ManifestVerticle.java
@@ -490,13 +490,13 @@ public class V3ManifestVerticle extends AbstractFesterVerticle {
 
         while (iterator.hasNext()) {
             final String[] columns = iterator.next();
-            final String pageID = columns[aCsvHeaders.getItemArkIndex()];
+            final String pageID = columns[aCsvHeaders.getItemArkIndex()]; // Get the Item ARK
             final Label pageLabel = new Label(columns[aCsvHeaders.getTitleIndex()]);
             final Optional<String> format = CsvParser.getMetadata(columns, aCsvHeaders.getMediaFormatIndex());
 
             final String imageThumbnailSize = StringUtils.trimTo(
                     config().getString(Config.DEFAULT_IMAGE_THUMBNAIL_SIZE), Constants.DEFAULT_IMAGE_THUMBNAIL_SIZE);
-            final String encodedPageID = URLEncoder.encode(pageID, StandardCharsets.UTF_8);
+            final String encodedPageID = URLEncoder.encode(pageID, StandardCharsets.UTF_8); // Encode Item ARK
             final Optional<String> thumbnailOpt = CsvParser.getMetadata(columns, aCsvHeaders.getThumbnailIndex());
             final Canvas canvas = new Canvas(aMinter, pageLabel);
 
@@ -558,7 +558,7 @@ public class V3ManifestVerticle extends AbstractFesterVerticle {
                 String resourceURI;
                 ImageContent image;
 
-                pageURI = StringUtils.format(SIMPLE_URI, aImageHost, encodedPageID);
+                pageURI = StringUtils.format(SIMPLE_URI, aImageHost, encodedPageID); // Get page URI from encoded ID
                 resourceURI = StringUtils.format(Constants.SAMPLE_URI_TEMPLATE, pageURI, Constants.DEFAULT_SAMPLE_SIZE);
 
                 if (thumbnailOpt.isPresent()) {
@@ -579,7 +579,7 @@ public class V3ManifestVerticle extends AbstractFesterVerticle {
                         height = Integer.parseInt(mediaHeight.get());
                         image = new ImageContent(accessURI).setWidthHeight(width, height);
                     } else {
-                        final ImageInfoLookup infoLookup = new ImageInfoLookup(pageURI);
+                        final ImageInfoLookup infoLookup = new ImageInfoLookup(pageURI); // Look up w/h for page URI
 
                         width = infoLookup.getWidth();
                         height = infoLookup.getHeight();

--- a/src/main/resources/fester_messages.xml
+++ b/src/main/resources/fester_messages.xml
@@ -201,4 +201,5 @@
   <entry key="MFS-188">Unexpected resource type: {}</entry>
   <entry key="MFS-189">Patched JSON file: {}</entry>
   <entry key="MFS-190">Image info lookup failed because of a malformed URL: {}</entry>
+  <entry key="MFS-191">Bucketeer width/height lookup needed for: {}</entry>
 </properties>


### PR DESCRIPTION
ImageLookup is getting an empty/missing URL for pages on works (when the pages CSV is separate from the work CSV).